### PR TITLE
feat(compaction): implement different compaction policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ cmake-*
 build/
 out/
 evaluation/
+
+*default.txt
+log/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ else (WIN32)
   set(LEVELDB_PLATFORM_NAME LEVELDB_PLATFORM_POSIX)
 endif (WIN32)
 
+find_package(gflags REQUIRED)
+include_directories(${GFLAGS_INCLUDE_DIR})
 
 add_subdirectory(mod/ft)
 add_subdirectory(mod/pgm)
@@ -371,6 +373,9 @@ if(LEVELDB_BUILD_TESTS)
         "${test_file}"
     )
     target_link_libraries("${test_target_name}" leveldb)
+    if (${test_file} MATCHES ".*test_compaction.cc$")
+      target_link_libraries("${test_target_name}" gflags)
+    endif()
     target_compile_definitions("${test_target_name}"
       PRIVATE
         ${LEVELDB_PLATFORM_NAME}=1
@@ -428,6 +433,8 @@ if(LEVELDB_BUILD_TESTS)
     leveldb_test("${PROJECT_SOURCE_DIR}/mod/read.cc")
     leveldb_test("${PROJECT_SOURCE_DIR}/mod/read_cold.cc")
     leveldb_test("${PROJECT_SOURCE_DIR}/mod/gen_dbtrace.cpp")
+    leveldb_test("${PROJECT_SOURCE_DIR}/mod/test_compaction.cc")
+    leveldb_test("${PROJECT_SOURCE_DIR}/mod/printdb.cc")
 
     # TODO(costan): This test also uses
     #               "${PROJECT_SOURCE_DIR}/util/env_{posix|windows}_test_helper.h"

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -44,6 +44,12 @@
 
 namespace leveldb {
 
+namespace config {
+  int kL0_CompactionTrigger = 4;
+  int kL0_SlowdownWritesTrigger = 8;
+  int kL0_StopWritesTrigger = 12;
+}
+
 const int kNumNonTableCacheFiles = 10;
 
 // Information kept for every waiting writer
@@ -555,9 +561,10 @@ Status DBImpl::WriteLevel0Table(MemTable* mem, VersionEdit* edit,
   if (s.ok() && meta.file_size > 0) {
     const Slice min_user_key = meta.smallest.user_key();
     const Slice max_user_key = meta.largest.user_key();
-    if (base != nullptr) {
-      level = base->PickLevelForMemTableOutput(min_user_key, max_user_key);
-    }
+    // Put memtable to L0
+    // if (base != nullptr) {
+    //   level = base->PickLevelForMemTableOutput(min_user_key, max_user_key);
+    // }
     edit->AddFile(level, meta.number, meta.file_size, meta.smallest,
                   meta.largest);
 
@@ -1046,9 +1053,26 @@ Status DBImpl::InstallCompactionResults(CompactionState* compact) {
   // Add compaction outputs
   compact->compaction->AddInputDeletions(compact->compaction->edit());
   const int level = compact->compaction->level();
+  int target_level = level + 1;
+  if (options_.compaction_policy != kCompactionStyleLevel) {
+    if (options_.compaction_policy != kCompactionStyleLazyLevel || target_level != options_.max_logical_level - 1) {
+      // need to find an empty level
+      int target_start_physical_level = GetStartPhysicalLevel(target_level, &options_);
+      int target_end_physical_level = GetEndPhysicalLevel(target_level, &options_);
+      for (int j = target_end_physical_level - 1; j >= target_start_physical_level; j--) {
+        if (versions_->NumLevelFiles(j) == 0) {
+          target_level = j;
+          break;
+        }
+      }
+    } else {
+      // lazy level compaction to the last level
+      target_level = GetStartPhysicalLevel(target_level, &options_);
+    }
+  }
   for (size_t i = 0; i < compact->outputs.size(); i++) {
     const CompactionState::Output& out = compact->outputs[i];
-    compact->compaction->edit()->AddFile(level + 1, out.number, out.file_size,
+    compact->compaction->edit()->AddFile(target_level, out.number, out.file_size,
                                          out.smallest, out.largest);
   }
   return versions_->LogAndApply(compact->compaction->edit(), &mutex_);
@@ -1083,7 +1107,6 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
   bool has_current_user_key = false;
   SequenceNumber last_sequence_for_key = kMaxSequenceNumber;
 
-//  vector<string> keys;
 
   for (; input->Valid() && !shutting_down_.load(std::memory_order_acquire);) {
     // Prioritize immutable compaction work
@@ -1100,9 +1123,6 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
     }
 
     Slice key = input->key();
-//    ParsedInternalKey parsed;
-//    ParseInternalKey(key, &parsed);
-//    keys.push_back(parsed.user_key);
 
     if (compact->compaction->ShouldStopBefore(key) &&
         compact->builder != nullptr) {
@@ -1209,6 +1229,8 @@ Status DBImpl::DoCompactionWork(CompactionState* compact) {
 
   mutex_.Lock();
   stats_[compact->compaction->level() + 1].Add(stats);
+  Log(options_.info_log, "compacted from: %d, bytes read: %ld, bytes written: %ld, use time: %ld (%ld secs)",
+      compact->compaction->level(), stats.bytes_read, stats.bytes_written, stats.micros, stats.micros / 1000000);
 
   if (status.ok()) {
     status = InstallCompactionResults(compact);
@@ -1859,6 +1881,14 @@ void DBImpl::PrintFileInfo() {
     ver->PrintAll();
     // std::cout<<"flag4"<<std::endl;
     ver->Unref();
+}
+
+void DBImpl::PrintLevelInfo() {
+  MutexLock l(&mutex_);
+  Version* ver = versions_->current();
+  ver->Ref();
+  ver->PrintLevelSummary();
+  ver->Unref();
 }
 
 Version* DBImpl::GetCurrentVersion() {

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -75,6 +75,7 @@ class DBImpl : public DB {
 
 
   virtual void PrintFileInfo();
+  virtual void PrintLevelInfo();
   Version* GetCurrentVersion();
   void ReturnCurrentVersion(Version* version);
   void WaitForBackground();

--- a/db/dbformat.h
+++ b/db/dbformat.h
@@ -20,16 +20,16 @@ namespace leveldb {
 // Grouping of constants.  We may want to make some of these
 // parameters set via options.
 namespace config {
-static const int kNumLevels = 7;
+static const int kNumLevels = 64;
 
 // Level-0 compaction is started when we hit this many files.
-static const int kL0_CompactionTrigger = 4;
+extern int kL0_CompactionTrigger;
 
 // Soft limit on number of level-0 files.  We slow down writes at this point.
-static const int kL0_SlowdownWritesTrigger = 8;
+extern int kL0_SlowdownWritesTrigger;
 
 // Maximum number of level-0 files.  We stop writes at this point.
-static const int kL0_StopWritesTrigger = 12;
+extern int kL0_StopWritesTrigger;
 
 // Maximum level to which a new compacted memtable is pushed if it
 // does not create overlap.  We try to push to level 2 to avoid the

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -26,6 +26,10 @@
 #include "port/thread_annotations.h"
 
 namespace leveldb {
+int64_t TotalSizeForLevel(const std::vector<FileMetaData*>* files_, int level, const Options *options);
+int RunNumberLevel(const std::vector<FileMetaData*>* files_, int level, const Options *options);
+int GetStartPhysicalLevel(int logical_level, const Options *options);
+int GetEndPhysicalLevel(int logical_level, const Options *options);
 
 namespace log {
 class Writer;
@@ -117,6 +121,7 @@ class Version {
 
   // print level summary
   void PrintAll() const;
+  void PrintLevelSummary() const;
   int GetFileNum() const;
   // Fill file model data
   bool FillData(const ReadOptions& options, FileMetaData* meta, adgMod::LearnedIndexData* data);
@@ -321,6 +326,8 @@ class VersionSet {
 
   void SetupOtherInputs(Compaction* c);
 
+  void SetupInputsForCompaction(Compaction* c);
+
   // Save current contents to *log
   Status WriteSnapshot(log::Writer* log);
 
@@ -402,7 +409,7 @@ class Compaction {
   VersionEdit edit_;
 
   // Each compaction reads inputs from "level_" and "level_+1"
-  std::vector<FileMetaData*> inputs_[2];  // The two sets of inputs
+  std::vector<FileMetaData*> inputs_[config::kNumLevels];  // The two sets of inputs
 
   // State used to check for number of overlapping grandparent files
   // (parent == level_ + 1, grandparent == level_ + 2)

--- a/include/leveldb/db.h
+++ b/include/leveldb/db.h
@@ -150,6 +150,8 @@ class LEVELDB_EXPORT DB {
   virtual void CompactRange(const Slice* begin, const Slice* end) = 0;
 
   virtual void PrintFileInfo() = 0;
+
+  virtual void PrintLevelInfo() {}
 };
 
 // Destroy the contents of the specified database.

--- a/include/leveldb/options.h
+++ b/include/leveldb/options.h
@@ -31,6 +31,12 @@ enum CompressionType {
   kSnappyCompression = 0x1
 };
 
+enum CompactionPolicy {
+  kCompactionStyleLevel = 0x0,
+  kCompactionStyleTier = 0x1,
+  kCompactionStyleLazyLevel = 0x2
+};
+
 // Options to control the behavior of a database (passed to DB::Open)
 struct LEVELDB_EXPORT Options {
   // Create an Options object with default values for all fields.
@@ -142,6 +148,17 @@ struct LEVELDB_EXPORT Options {
   // Many applications will benefit from passing the result of
   // NewBloomFilterPolicy() here.
   const FilterPolicy* filter_policy = NewBloomFilterPolicy(10);
+
+  // const CompactionPolicy compaction_policy = kCompactionStyleLevel;
+  CompactionPolicy compaction_policy = kCompactionStyleLevel;
+
+  uint64_t max_bytes_for_level_base = 10 * 1048576;
+
+  int max_bytes_for_level_multiplier = 10; // T
+
+  int L0_compaction_trigger = 4; // default 4
+
+  int max_logical_level = 4;
 };
 
 // Options that control read operations

--- a/mod/ALEX/src/core/alex.h
+++ b/mod/ALEX/src/core/alex.h
@@ -94,7 +94,8 @@ class Alex {
     // Maximum node size, in bytes. By default, 16MB.
     // Higher values result in better average throughput, but worse tail/max
     // insert latency
-    int max_node_size = 1 << 11;
+    // int max_node_size = 1 << 11;
+    int max_node_size = adgMod::alex_node_size;
     // Approximate model computation: bulk load faster by using sampling to
     // train models
     bool approximate_model_computation = true;
@@ -107,8 +108,8 @@ class Alex {
   /* Setting max node size automatically changes these parameters */
   struct DerivedParams {
     // The defaults here assume the default max node size of 16MB
-    int max_fanout = 1 << 8;  // assumes 8-byte pointers
-    int max_data_node_slots = (1 << 11) / sizeof(V);
+    int max_fanout = adgMod::alex_node_size / sizeof(void*);  // assumes 8-byte pointers
+    int max_data_node_slots = adgMod::alex_node_size / sizeof(V);
 //      int max_data_node_slots = (1 << 15) / sizeof(V);
 
   };

--- a/mod/LearnedIterator.h
+++ b/mod/LearnedIterator.h
@@ -14,7 +14,9 @@ class LearnedIterator : public Iterator {
     last_block_num_entries(file_model->real_num_entries - (num_blocks - 1) * adgMod::block_num_entries),
     block_content(), current_block(-1), current_entry(-1), key_(), value_() { };
 
-  virtual ~LearnedIterator() = default;
+  virtual ~LearnedIterator() {
+    delete[] scratch;
+  }
 
   virtual void Seek(const Slice& target) {
 		adgMod::Stats* instance = adgMod::Stats::GetInstance();
@@ -553,8 +555,8 @@ class LearnedIterator : public Iterator {
 	adgMod::LearnedIndexData* file_model;
   int file_num;
   
-  // char* scratch = nullptr;
-  char scratch[4096];
+  char* scratch = nullptr;
+  // char scratch[4096];
   const uint32_t num_blocks;  
 	const uint32_t last_block_num_entries;
   
@@ -580,6 +582,9 @@ class LearnedIterator : public Iterator {
     // std::cout<<"read_size:"<<read_size<<std::endl;
     read_size *= adgMod::entry_size;
     // std::cout<<"read_size:"<<read_size<<" current block:"<<current_block<<" block_size:"<<adgMod::block_size<<std::endl;
+    if (scratch == nullptr) {
+      scratch = new char[read_size];
+    }
     Status s = file->Read(current_block * adgMod::block_size, read_size, &block_content, scratch);
     assert(s.ok());
   }

--- a/mod/ft/fiting_tree_memory.h
+++ b/mod/ft/fiting_tree_memory.h
@@ -10,7 +10,7 @@
 #define FInnerNodeType 1
 #define FLeafNodeType 0
 #define Disk 1
-#define Binary 0
+#define Binary 1
 #define BufferSize 256
 const long MaxNodeSize = BlockSize;
 

--- a/mod/ft/storage_management.h
+++ b/mod/ft/storage_management.h
@@ -132,7 +132,7 @@ class StorageManager {
             if (first) {
                 fp = fopen(file_name,"wb");
 
-                char empty_block[BlockSize];
+                char empty_block[BlockSize]={0};
                 MetaNode mn;
                 mn.block_count = 1;
                 mn.level = 0;

--- a/mod/learned_index.cpp
+++ b/mod/learned_index.cpp
@@ -567,14 +567,6 @@ bool LearnedIndexData::Learned(Version* version, int v_count, int level) {
     return true;
   }
   return false;
-  //        } else {
-  //            if (level_learning_enabled && ++current_seek >= allowed_seek &&
-  //            !learning.exchange(true)) {
-  //                env->ScheduleLearning(&LearnedIndexData::Learn, new
-  //                VersionAndSelf{version, v_count, this, level}, 0);
-  //            }
-  //            return false;
-  //        }
 }
 
 // file model checker, used to be also learning trigger
@@ -588,15 +580,6 @@ bool LearnedIndexData::Learned(Version* version, int v_count,
     return true;
   } else
     return false;
-        //  } else {
-        //      if (file_learning_enabled && (true || level != 0 && level != 1)
-        //       && !learning.exchange(true)) {
-        //         std::cout<<"Checking file model and schedule: "<<learned_not_atomic<< " "<<learned.load()<<std::endl;
-        //          env->ScheduleLearning(( void(*)(void *) )&LearnedIndexData::FileLearn, new
-        //          MetaAndSelf{version, v_count, meta, this, level}, 0);
-        //      }
-        //      return false;
-        //  }
 }
 
 bool LearnedIndexData::FillData(Version* version, FileMetaData* meta) {
@@ -626,10 +609,6 @@ void LearnedIndexData::WriteModel(const string& filename) {
     output_file << "StartAcc"
                 << " " << min_key << " " << max_key << " " << size << " " << level
                 << " " << cost << "\n";
-    // // testing num entires
-    // for (auto& pair : num_entries_accumulated.array) {
-    //   output_file << pair.first << " " << pair.second << "\n";
-    // }
   }
   else if(adgMod::modelmode == 4){
     if(rmi.layer2_size() != 0){

--- a/mod/learned_index.h
+++ b/mod/learned_index.h
@@ -105,7 +105,7 @@ namespace adgMod {
         StorageManager<lippKeyType, lippValueType> lipp_index;
         //fitting tree
         ft::FITingTree ft;
-        pgm::MappedPGMIndex<long long int, 1024> pgm;
+        pgm::MappedPGMIndex<long long int, PGM_Error, PGM_internal_Error> pgm;
         rmi::RmiLAbs<long long int, rmi::LinearSpline, rmi::LinearRegression> rmi;
         rs::RadixSpline<long long int> rs;
         ts::TrieSpline<long long int> ts;

--- a/mod/lipp/core/storage_management.h
+++ b/mod/lipp/core/storage_management.h
@@ -26,7 +26,8 @@ class StorageManager {
         if (size >= 1000000) return 1;
         if (size >= 100000) return 2;
         if(adgMod::lipp_mode == 0){ //original lipp
-            return 5;
+            return adgMod::lipp_gap;
+            // return 5;
         }
         else{//lipp without gaps
             return 0;

--- a/mod/pgm/include/pgm/pgm_index.hpp
+++ b/mod/pgm/include/pgm/pgm_index.hpp
@@ -27,6 +27,10 @@
 #include <vector>
 #include <cstring>
 #include <iostream>
+
+#define PGM_Error 1024
+#define PGM_internal_Error 100
+
 namespace pgm {
 
 #define PGM_SUB_EPS(x, epsilon) ((x) <= (epsilon) ? 0 : ((x) - (epsilon)))

--- a/mod/pgm/test/catch.hpp
+++ b/mod/pgm/test/catch.hpp
@@ -1,9 +1,9 @@
 /*
- *  Catch v2.13.0
- *  Generated: 2020-07-12 20:07:49.015950
+ *  Catch v2.13.8
+ *  Generated: 2022-01-03 21:20:09.589503
  *  ----------------------------------------------------------
  *  This file has been merged from multiple headers. Please don't edit it directly
- *  Copyright (c) 2020 Two Blue Cubes Ltd. All rights reserved.
+ *  Copyright (c) 2022 Two Blue Cubes Ltd. All rights reserved.
  *
  *  Distributed under the Boost Software License, Version 1.0. (See accompanying
  *  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -15,7 +15,7 @@
 
 #define CATCH_VERSION_MAJOR 2
 #define CATCH_VERSION_MINOR 13
-#define CATCH_VERSION_PATCH 0
+#define CATCH_VERSION_PATCH 8
 
 #ifdef __clang__
 #    pragma clang system_header
@@ -36,9 +36,9 @@
 #       pragma clang diagnostic ignored "-Wcovered-switch-default"
 #    endif
 #elif defined __GNUC__
-// Because REQUIREs trigger GCC's -Wparentheses, and because still
-// supported version of g++ have only buggy support for _Pragmas,
-// Wparentheses have to be suppressed globally.
+     // Because REQUIREs trigger GCC's -Wparentheses, and because still
+     // supported version of g++ have only buggy support for _Pragmas,
+     // Wparentheses have to be suppressed globally.
 #    pragma GCC diagnostic ignored "-Wparentheses" // See #674 for details
 
 #    pragma GCC diagnostic push
@@ -66,13 +66,16 @@
 #if !defined(CATCH_CONFIG_IMPL_ONLY)
 // start catch_platform.h
 
+// See e.g.:
+// https://opensource.apple.com/source/CarbonHeaders/CarbonHeaders-18.1/TargetConditionals.h.auto.html
 #ifdef __APPLE__
-# include <TargetConditionals.h>
-# if TARGET_OS_OSX == 1
-#  define CATCH_PLATFORM_MAC
-# elif TARGET_OS_IPHONE == 1
-#  define CATCH_PLATFORM_IPHONE
-# endif
+#  include <TargetConditionals.h>
+#  if (defined(TARGET_OS_OSX) && TARGET_OS_OSX == 1) || \
+      (defined(TARGET_OS_MAC) && TARGET_OS_MAC == 1)
+#    define CATCH_PLATFORM_MAC
+#  elif (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1)
+#    define CATCH_PLATFORM_IPHONE
+#  endif
 
 #elif defined(linux) || defined(__linux) || defined(__linux__)
 #  define CATCH_PLATFORM_LINUX
@@ -93,7 +96,7 @@
 // start catch_user_interfaces.h
 
 namespace Catch {
-unsigned int rngSeed();
+    unsigned int rngSeed();
 }
 
 // end catch_user_interfaces.h
@@ -132,13 +135,9 @@ unsigned int rngSeed();
 
 #endif
 
-#if defined(__cpp_lib_uncaught_exceptions)
-#  define CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
-#endif
-
-// We have to avoid both ICC and Clang, because they try to mask themselves
-// as gcc, and we want only GCC in this block
-#if defined(__GNUC__) && !defined(__clang__) && !defined(__ICC)
+// Only GCC compiler should be used in this block, so other compilers trying to
+// mask themselves as GCC should be ignored.
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__ICC) && !defined(__CUDACC__) && !defined(__LCC__)
 #    define CATCH_INTERNAL_START_WARNINGS_SUPPRESSION _Pragma( "GCC diagnostic push" )
 #    define CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION  _Pragma( "GCC diagnostic pop" )
 
@@ -162,7 +161,7 @@ unsigned int rngSeed();
 // ```
 //
 // Therefore, `CATCH_INTERNAL_IGNORE_BUT_WARN` is not implemented.
-#  if !defined(__ibmxl__)
+#  if !defined(__ibmxl__) && !defined(__CUDACC__)
 #    define CATCH_INTERNAL_IGNORE_BUT_WARN(...) (void)__builtin_constant_p(__VA_ARGS__) /* NOLINT(cppcoreguidelines-pro-type-vararg, hicpp-vararg) */
 #  endif
 
@@ -241,13 +240,6 @@ unsigned int rngSeed();
 // Visual C++
 #if defined(_MSC_VER)
 
-#  define CATCH_INTERNAL_START_WARNINGS_SUPPRESSION __pragma( warning(push) )
-#  define CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION  __pragma( warning(pop) )
-
-#  if _MSC_VER >= 1900 // Visual Studio 2015 or newer
-#    define CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
-#  endif
-
 // Universal Windows platform does not support SEH
 // Or console colours (or console at all...)
 #  if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
@@ -256,13 +248,18 @@ unsigned int rngSeed();
 #    define CATCH_INTERNAL_CONFIG_WINDOWS_SEH
 #  endif
 
+#  if !defined(__clang__) // Handle Clang masquerading for msvc
+
 // MSVC traditional preprocessor needs some workaround for __VA_ARGS__
 // _MSVC_TRADITIONAL == 0 means new conformant preprocessor
 // _MSVC_TRADITIONAL == 1 means old traditional non-conformant preprocessor
-#  if !defined(__clang__) // Handle Clang masquerading for msvc
 #    if !defined(_MSVC_TRADITIONAL) || (defined(_MSVC_TRADITIONAL) && _MSVC_TRADITIONAL)
 #      define CATCH_INTERNAL_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #    endif // MSVC_TRADITIONAL
+
+// Only do this if we're not using clang on Windows, which uses `diagnostic push` & `diagnostic pop`
+#    define CATCH_INTERNAL_START_WARNINGS_SUPPRESSION __pragma( warning(push) )
+#    define CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION  __pragma( warning(pop) )
 #  endif // __clang__
 
 #endif // _MSC_VER
@@ -307,7 +304,7 @@ unsigned int rngSeed();
 // This means that it is detected as Windows, but does not provide
 // the same set of capabilities as real Windows does.
 #if defined(UNDER_RTSS) || defined(RTX64_BUILD)
-#define CATCH_INTERNAL_CONFIG_NO_WINDOWS_SEH
+    #define CATCH_INTERNAL_CONFIG_NO_WINDOWS_SEH
     #define CATCH_INTERNAL_CONFIG_NO_ASYNC
     #define CATCH_CONFIG_COLOUR_NONE
 #endif
@@ -318,25 +315,28 @@ unsigned int rngSeed();
 
 // Various stdlib support checks that require __has_include
 #if defined(__has_include)
-// Check if string_view is available and usable
-    #if __has_include(<string_view>) && defined(CATCH_CPP17_OR_GREATER)
-        #    define CATCH_INTERNAL_CONFIG_CPP17_STRING_VIEW
-    #endif
+  // Check if string_view is available and usable
+  #if __has_include(<string_view>) && defined(CATCH_CPP17_OR_GREATER)
+  #    define CATCH_INTERNAL_CONFIG_CPP17_STRING_VIEW
+  #endif
 
-// Check if optional is available and usable
-    #  if __has_include(<optional>) && defined(CATCH_CPP17_OR_GREATER)
-        #    define CATCH_INTERNAL_CONFIG_CPP17_OPTIONAL
-    #  endif // __has_include(<optional>) && defined(CATCH_CPP17_OR_GREATER)
+  // Check if optional is available and usable
+  #  if __has_include(<optional>) && defined(CATCH_CPP17_OR_GREATER)
+  #    define CATCH_INTERNAL_CONFIG_CPP17_OPTIONAL
+  #  endif // __has_include(<optional>) && defined(CATCH_CPP17_OR_GREATER)
 
-// Check if byte is available and usable
-    #  if __has_include(<cstddef>) && defined(CATCH_CPP17_OR_GREATER)
-        #    define CATCH_INTERNAL_CONFIG_CPP17_BYTE
-    #  endif // __has_include(<cstddef>) && defined(CATCH_CPP17_OR_GREATER)
+  // Check if byte is available and usable
+  #  if __has_include(<cstddef>) && defined(CATCH_CPP17_OR_GREATER)
+  #    include <cstddef>
+  #    if defined(__cpp_lib_byte) && (__cpp_lib_byte > 0)
+  #      define CATCH_INTERNAL_CONFIG_CPP17_BYTE
+  #    endif
+  #  endif // __has_include(<cstddef>) && defined(CATCH_CPP17_OR_GREATER)
 
-// Check if variant is available and usable
-    #  if __has_include(<variant>) && defined(CATCH_CPP17_OR_GREATER)
-        #    if defined(__clang__) && (__clang_major__ < 8)
-// work around clang bug with libstdc++ https://bugs.llvm.org/show_bug.cgi?id=31852
+  // Check if variant is available and usable
+  #  if __has_include(<variant>) && defined(CATCH_CPP17_OR_GREATER)
+  #    if defined(__clang__) && (__clang_major__ < 8)
+         // work around clang bug with libstdc++ https://bugs.llvm.org/show_bug.cgi?id=31852
          // fix should be in clang 8, workaround in libstdc++ 8.2
   #      include <ciso646>
   #      if defined(__GLIBCXX__) && defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE < 9)
@@ -344,10 +344,10 @@ unsigned int rngSeed();
   #      else
   #        define CATCH_INTERNAL_CONFIG_CPP17_VARIANT
   #      endif // defined(__GLIBCXX__) && defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE < 9)
-        #    else
-            #      define CATCH_INTERNAL_CONFIG_CPP17_VARIANT
-        #    endif // defined(__clang__) && (__clang_major__ < 8)
-    #  endif // __has_include(<variant>) && defined(CATCH_CPP17_OR_GREATER)
+  #    else
+  #      define CATCH_INTERNAL_CONFIG_CPP17_VARIANT
+  #    endif // defined(__clang__) && (__clang_major__ < 8)
+  #  endif // __has_include(<variant>) && defined(CATCH_CPP17_OR_GREATER)
 #endif // defined(__has_include)
 
 #if defined(CATCH_INTERNAL_CONFIG_COUNTER) && !defined(CATCH_CONFIG_NO_COUNTER) && !defined(CATCH_CONFIG_COUNTER)
@@ -371,10 +371,6 @@ unsigned int rngSeed();
 
 #if defined(CATCH_INTERNAL_CONFIG_CPP17_OPTIONAL) && !defined(CATCH_CONFIG_NO_CPP17_OPTIONAL) && !defined(CATCH_CONFIG_CPP17_OPTIONAL)
 #  define CATCH_CONFIG_CPP17_OPTIONAL
-#endif
-
-#if defined(CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS) && !defined(CATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS) && !defined(CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS)
-#  define CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
 #endif
 
 #if defined(CATCH_INTERNAL_CONFIG_CPP17_STRING_VIEW) && !defined(CATCH_CONFIG_NO_CPP17_STRING_VIEW) && !defined(CATCH_CONFIG_CPP17_STRING_VIEW)
@@ -487,61 +483,61 @@ std::ostream& operator<<(std::ostream&, Catch_global_namespace_dummy);
 
 namespace Catch {
 
-struct CaseSensitive { enum Choice {
+    struct CaseSensitive { enum Choice {
         Yes,
         No
     }; };
 
-class NonCopyable {
-    NonCopyable( NonCopyable const& )              = delete;
-    NonCopyable( NonCopyable && )                  = delete;
-    NonCopyable& operator = ( NonCopyable const& ) = delete;
-    NonCopyable& operator = ( NonCopyable && )     = delete;
+    class NonCopyable {
+        NonCopyable( NonCopyable const& )              = delete;
+        NonCopyable( NonCopyable && )                  = delete;
+        NonCopyable& operator = ( NonCopyable const& ) = delete;
+        NonCopyable& operator = ( NonCopyable && )     = delete;
 
-protected:
-    NonCopyable();
-    virtual ~NonCopyable();
-};
+    protected:
+        NonCopyable();
+        virtual ~NonCopyable();
+    };
 
-struct SourceLineInfo {
+    struct SourceLineInfo {
 
-    SourceLineInfo() = delete;
-    SourceLineInfo( char const* _file, std::size_t _line ) noexcept
+        SourceLineInfo() = delete;
+        SourceLineInfo( char const* _file, std::size_t _line ) noexcept
         :   file( _file ),
             line( _line )
-    {}
+        {}
 
-    SourceLineInfo( SourceLineInfo const& other )            = default;
-    SourceLineInfo& operator = ( SourceLineInfo const& )     = default;
-    SourceLineInfo( SourceLineInfo&& )              noexcept = default;
-    SourceLineInfo& operator = ( SourceLineInfo&& ) noexcept = default;
+        SourceLineInfo( SourceLineInfo const& other )            = default;
+        SourceLineInfo& operator = ( SourceLineInfo const& )     = default;
+        SourceLineInfo( SourceLineInfo&& )              noexcept = default;
+        SourceLineInfo& operator = ( SourceLineInfo&& ) noexcept = default;
 
-    bool empty() const noexcept { return file[0] == '\0'; }
-    bool operator == ( SourceLineInfo const& other ) const noexcept;
-    bool operator < ( SourceLineInfo const& other ) const noexcept;
+        bool empty() const noexcept { return file[0] == '\0'; }
+        bool operator == ( SourceLineInfo const& other ) const noexcept;
+        bool operator < ( SourceLineInfo const& other ) const noexcept;
 
-    char const* file;
-    std::size_t line;
-};
+        char const* file;
+        std::size_t line;
+    };
 
-std::ostream& operator << ( std::ostream& os, SourceLineInfo const& info );
+    std::ostream& operator << ( std::ostream& os, SourceLineInfo const& info );
 
-// Bring in operator<< from global namespace into Catch namespace
-// This is necessary because the overload of operator<< above makes
-// lookup stop at namespace Catch
-using ::operator<<;
+    // Bring in operator<< from global namespace into Catch namespace
+    // This is necessary because the overload of operator<< above makes
+    // lookup stop at namespace Catch
+    using ::operator<<;
 
-// Use this in variadic streaming macros to allow
-//    >> +StreamEndStop
-// as well as
-//    >> stuff +StreamEndStop
-struct StreamEndStop {
-    std::string operator+() const;
-};
-template<typename T>
-T const& operator + ( T const& value, StreamEndStop ) {
-    return value;
-}
+    // Use this in variadic streaming macros to allow
+    //    >> +StreamEndStop
+    // as well as
+    //    >> stuff +StreamEndStop
+    struct StreamEndStop {
+        std::string operator+() const;
+    };
+    template<typename T>
+    T const& operator + ( T const& value, StreamEndStop ) {
+        return value;
+    }
 }
 
 #define CATCH_INTERNAL_LINEINFO \
@@ -550,9 +546,9 @@ T const& operator + ( T const& value, StreamEndStop ) {
 // end catch_common.h
 namespace Catch {
 
-struct RegistrarForTagAliases {
-    RegistrarForTagAliases( char const* alias, char const* tag, SourceLineInfo const& lineInfo );
-};
+    struct RegistrarForTagAliases {
+        RegistrarForTagAliases( char const* alias, char const* tag, SourceLineInfo const& lineInfo );
+    };
 
 } // end namespace Catch
 
@@ -571,26 +567,26 @@ struct RegistrarForTagAliases {
 
 namespace Catch {
 
-class TestSpec;
+    class TestSpec;
 
-struct ITestInvoker {
-    virtual void invoke () const = 0;
-    virtual ~ITestInvoker();
-};
+    struct ITestInvoker {
+        virtual void invoke () const = 0;
+        virtual ~ITestInvoker();
+    };
 
-class TestCase;
-struct IConfig;
+    class TestCase;
+    struct IConfig;
 
-struct ITestCaseRegistry {
-    virtual ~ITestCaseRegistry();
-    virtual std::vector<TestCase> const& getAllTests() const = 0;
-    virtual std::vector<TestCase> const& getAllTestsSorted( IConfig const& config ) const = 0;
-};
+    struct ITestCaseRegistry {
+        virtual ~ITestCaseRegistry();
+        virtual std::vector<TestCase> const& getAllTests() const = 0;
+        virtual std::vector<TestCase> const& getAllTestsSorted( IConfig const& config ) const = 0;
+    };
 
-bool isThrowSafe( TestCase const& testCase, IConfig const& config );
-bool matchTest( TestCase const& testCase, TestSpec const& testSpec, IConfig const& config );
-std::vector<TestCase> filterTests( std::vector<TestCase> const& testCases, TestSpec const& testSpec, IConfig const& config );
-std::vector<TestCase> const& getAllTestCasesSorted( IConfig const& config );
+    bool isThrowSafe( TestCase const& testCase, IConfig const& config );
+    bool matchTest( TestCase const& testCase, TestSpec const& testSpec, IConfig const& config );
+    std::vector<TestCase> filterTests( std::vector<TestCase> const& testCases, TestSpec const& testSpec, IConfig const& config );
+    std::vector<TestCase> const& getAllTestCasesSorted( IConfig const& config );
 
 }
 
@@ -604,86 +600,86 @@ std::vector<TestCase> const& getAllTestCasesSorted( IConfig const& config );
 
 namespace Catch {
 
-/// A non-owning string class (similar to the forthcoming std::string_view)
-/// Note that, because a StringRef may be a substring of another string,
-/// it may not be null terminated.
-class StringRef {
-public:
-    using size_type = std::size_t;
-    using const_iterator = const char*;
+    /// A non-owning string class (similar to the forthcoming std::string_view)
+    /// Note that, because a StringRef may be a substring of another string,
+    /// it may not be null terminated.
+    class StringRef {
+    public:
+        using size_type = std::size_t;
+        using const_iterator = const char*;
 
-private:
-    static constexpr char const* const s_empty = "";
+    private:
+        static constexpr char const* const s_empty = "";
 
-    char const* m_start = s_empty;
-    size_type m_size = 0;
+        char const* m_start = s_empty;
+        size_type m_size = 0;
 
-public: // construction
-    constexpr StringRef() noexcept = default;
+    public: // construction
+        constexpr StringRef() noexcept = default;
 
-    StringRef( char const* rawChars ) noexcept;
+        StringRef( char const* rawChars ) noexcept;
 
-    constexpr StringRef( char const* rawChars, size_type size ) noexcept
+        constexpr StringRef( char const* rawChars, size_type size ) noexcept
         :   m_start( rawChars ),
             m_size( size )
-    {}
+        {}
 
-    StringRef( std::string const& stdString ) noexcept
+        StringRef( std::string const& stdString ) noexcept
         :   m_start( stdString.c_str() ),
             m_size( stdString.size() )
-    {}
+        {}
 
-    explicit operator std::string() const {
-        return std::string(m_start, m_size);
+        explicit operator std::string() const {
+            return std::string(m_start, m_size);
+        }
+
+    public: // operators
+        auto operator == ( StringRef const& other ) const noexcept -> bool;
+        auto operator != (StringRef const& other) const noexcept -> bool {
+            return !(*this == other);
+        }
+
+        auto operator[] ( size_type index ) const noexcept -> char {
+            assert(index < m_size);
+            return m_start[index];
+        }
+
+    public: // named queries
+        constexpr auto empty() const noexcept -> bool {
+            return m_size == 0;
+        }
+        constexpr auto size() const noexcept -> size_type {
+            return m_size;
+        }
+
+        // Returns the current start pointer. If the StringRef is not
+        // null-terminated, throws std::domain_exception
+        auto c_str() const -> char const*;
+
+    public: // substrings and searches
+        // Returns a substring of [start, start + length).
+        // If start + length > size(), then the substring is [start, size()).
+        // If start > size(), then the substring is empty.
+        auto substr( size_type start, size_type length ) const noexcept -> StringRef;
+
+        // Returns the current start pointer. May not be null-terminated.
+        auto data() const noexcept -> char const*;
+
+        constexpr auto isNullTerminated() const noexcept -> bool {
+            return m_start[m_size] == '\0';
+        }
+
+    public: // iterators
+        constexpr const_iterator begin() const { return m_start; }
+        constexpr const_iterator end() const { return m_start + m_size; }
+    };
+
+    auto operator += ( std::string& lhs, StringRef const& sr ) -> std::string&;
+    auto operator << ( std::ostream& os, StringRef const& sr ) -> std::ostream&;
+
+    constexpr auto operator "" _sr( char const* rawChars, std::size_t size ) noexcept -> StringRef {
+        return StringRef( rawChars, size );
     }
-
-public: // operators
-    auto operator == ( StringRef const& other ) const noexcept -> bool;
-    auto operator != (StringRef const& other) const noexcept -> bool {
-        return !(*this == other);
-    }
-
-    auto operator[] ( size_type index ) const noexcept -> char {
-        assert(index < m_size);
-        return m_start[index];
-    }
-
-public: // named queries
-    constexpr auto empty() const noexcept -> bool {
-        return m_size == 0;
-    }
-    constexpr auto size() const noexcept -> size_type {
-        return m_size;
-    }
-
-    // Returns the current start pointer. If the StringRef is not
-    // null-terminated, throws std::domain_exception
-    auto c_str() const -> char const*;
-
-public: // substrings and searches
-    // Returns a substring of [start, start + length).
-    // If start + length > size(), then the substring is [start, size()).
-    // If start > size(), then the substring is empty.
-    auto substr( size_type start, size_type length ) const noexcept -> StringRef;
-
-    // Returns the current start pointer. May not be null-terminated.
-    auto data() const noexcept -> char const*;
-
-    constexpr auto isNullTerminated() const noexcept -> bool {
-        return m_start[m_size] == '\0';
-    }
-
-public: // iterators
-    constexpr const_iterator begin() const { return m_start; }
-    constexpr const_iterator end() const { return m_start + m_size; }
-};
-
-auto operator += ( std::string& lhs, StringRef const& sr ) -> std::string&;
-auto operator << ( std::ostream& os, StringRef const& sr ) -> std::ostream&;
-
-constexpr auto operator "" _sr( char const* rawChars, std::size_t size ) noexcept -> StringRef {
-    return StringRef( rawChars, size );
-}
 } // namespace Catch
 
 constexpr auto operator "" _catch_sr( char const* rawChars, std::size_t size ) noexcept -> Catch::StringRef {
@@ -925,30 +921,30 @@ constexpr auto operator "" _catch_sr( char const* rawChars, std::size_t size ) n
 #include <type_traits>
 
 namespace Catch {
-template<typename T>
-struct always_false : std::false_type {};
+    template<typename T>
+    struct always_false : std::false_type {};
 
-template <typename> struct true_given : std::true_type {};
-struct is_callable_tester {
+    template <typename> struct true_given : std::true_type {};
+    struct is_callable_tester {
+        template <typename Fun, typename... Args>
+        true_given<decltype(std::declval<Fun>()(std::declval<Args>()...))> static test(int);
+        template <typename...>
+        std::false_type static test(...);
+    };
+
+    template <typename T>
+    struct is_callable;
+
     template <typename Fun, typename... Args>
-    true_given<decltype(std::declval<Fun>()(std::declval<Args>()...))> static test(int);
-    template <typename...>
-    std::false_type static test(...);
-};
-
-template <typename T>
-struct is_callable;
-
-template <typename Fun, typename... Args>
-struct is_callable<Fun(Args...)> : decltype(is_callable_tester::test<Fun, Args...>(0)) {};
+    struct is_callable<Fun(Args...)> : decltype(is_callable_tester::test<Fun, Args...>(0)) {};
 
 #if defined(__cpp_lib_is_invocable) && __cpp_lib_is_invocable >= 201703
-// std::result_of is deprecated in C++17 and removed in C++20. Hence, it is
-// replaced with std::invoke_result here.
-template <typename Func, typename... U>
-using FunctionReturnType = std::remove_reference_t<std::remove_cv_t<std::invoke_result_t<Func, U...>>>;
+    // std::result_of is deprecated in C++17 and removed in C++20. Hence, it is
+    // replaced with std::invoke_result here.
+    template <typename Func, typename... U>
+    using FunctionReturnType = std::remove_reference_t<std::remove_cv_t<std::invoke_result_t<Func, U...>>>;
 #else
-// Keep ::type here because we still support C++11
+    // Keep ::type here because we still support C++11
     template <typename Func, typename... U>
     using FunctionReturnType = typename std::remove_reference<typename std::remove_cv<typename std::result_of<Func(U...)>::type>::type>::type;
 #endif
@@ -956,7 +952,7 @@ using FunctionReturnType = std::remove_reference_t<std::remove_cv_t<std::invoke_
 } // namespace Catch
 
 namespace mpl_{
-struct na;
+    struct na;
 }
 
 // end catch_meta.hpp
@@ -995,7 +991,7 @@ struct AutoReg : NonCopyable {
 } // end namespace Catch
 
 #if defined(CATCH_CONFIG_DISABLE)
-#define INTERNAL_CATCH_TESTCASE_NO_REGISTRATION( TestName, ... ) \
+    #define INTERNAL_CATCH_TESTCASE_NO_REGISTRATION( TestName, ... ) \
         static void TestName()
     #define INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION( TestName, ClassName, ... ) \
         namespace{                        \
@@ -1016,38 +1012,38 @@ struct AutoReg : NonCopyable {
 
     #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
         #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION(Name, Tags, ...) \
-            INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, typename TestType, __VA_ARGS__ )
+            INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, typename TestType, __VA_ARGS__ )
     #else
         #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION(Name, Tags, ...) \
-            INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, typename TestType, __VA_ARGS__ ) )
+            INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, typename TestType, __VA_ARGS__ ) )
     #endif
 
     #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
         #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_SIG_NO_REGISTRATION(Name, Tags, Signature, ...) \
-            INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, Signature, __VA_ARGS__ )
+            INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, Signature, __VA_ARGS__ )
     #else
         #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_SIG_NO_REGISTRATION(Name, Tags, Signature, ...) \
-            INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, Signature, __VA_ARGS__ ) )
+            INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, Signature, __VA_ARGS__ ) )
     #endif
 
     #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
         #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION( ClassName, Name, Tags,... ) \
-            INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ) , ClassName, Name, Tags, typename T, __VA_ARGS__ )
+            INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ) , ClassName, Name, Tags, typename T, __VA_ARGS__ )
     #else
         #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION( ClassName, Name, Tags,... ) \
-            INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ) , ClassName, Name, Tags, typename T, __VA_ARGS__ ) )
+            INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ) , ClassName, Name, Tags, typename T, __VA_ARGS__ ) )
     #endif
 
     #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
         #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_SIG_NO_REGISTRATION( ClassName, Name, Tags, Signature, ... ) \
-            INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ) , ClassName, Name, Tags, Signature, __VA_ARGS__ )
+            INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ) , ClassName, Name, Tags, Signature, __VA_ARGS__ )
     #else
         #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_SIG_NO_REGISTRATION( ClassName, Name, Tags, Signature, ... ) \
-            INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ) , ClassName, Name, Tags, Signature, __VA_ARGS__ ) )
+            INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_NO_REGISTRATION_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ) , ClassName, Name, Tags, Signature, __VA_ARGS__ ) )
     #endif
 #endif
 
-///////////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////////
     #define INTERNAL_CATCH_TESTCASE2( TestName, ... ) \
         static void TestName(); \
         CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
@@ -1056,16 +1052,16 @@ struct AutoReg : NonCopyable {
         CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION \
         static void TestName()
     #define INTERNAL_CATCH_TESTCASE( ... ) \
-        INTERNAL_CATCH_TESTCASE2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ), __VA_ARGS__ )
+        INTERNAL_CATCH_TESTCASE2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ), __VA_ARGS__ )
 
-///////////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////////
     #define INTERNAL_CATCH_METHOD_AS_TEST_CASE( QualifiedMethod, ... ) \
         CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
         CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
         namespace{ Catch::AutoReg INTERNAL_CATCH_UNIQUE_NAME( autoRegistrar )( Catch::makeTestInvoker( &QualifiedMethod ), CATCH_INTERNAL_LINEINFO, "&" #QualifiedMethod, Catch::NameAndTags{ __VA_ARGS__ } ); } /* NOLINT */ \
         CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
-///////////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////////
     #define INTERNAL_CATCH_TEST_CASE_METHOD2( TestName, ClassName, ... )\
         CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
         CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
@@ -1078,16 +1074,16 @@ struct AutoReg : NonCopyable {
         CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION \
         void TestName::test()
     #define INTERNAL_CATCH_TEST_CASE_METHOD( ClassName, ... ) \
-        INTERNAL_CATCH_TEST_CASE_METHOD2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ), ClassName, __VA_ARGS__ )
+        INTERNAL_CATCH_TEST_CASE_METHOD2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ), ClassName, __VA_ARGS__ )
 
-///////////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////////
     #define INTERNAL_CATCH_REGISTER_TESTCASE( Function, ... ) \
         CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
         CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
         Catch::AutoReg INTERNAL_CATCH_UNIQUE_NAME( autoRegistrar )( Catch::makeTestInvoker( Function ), CATCH_INTERNAL_LINEINFO, Catch::StringRef(), Catch::NameAndTags{ __VA_ARGS__ } ); /* NOLINT */ \
         CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION
 
-///////////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////////
     #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_2(TestName, TestFunc, Name, Tags, Signature, ... )\
         CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
         CATCH_INTERNAL_SUPPRESS_GLOBALS_WARNINGS \
@@ -1105,7 +1101,7 @@ struct AutoReg : NonCopyable {
                     int index = 0;                                    \
                     constexpr char const* tmpl_types[] = {CATCH_REC_LIST(INTERNAL_CATCH_STRINGIZE_WITHOUT_PARENS, __VA_ARGS__)};\
                     using expander = int[];\
-                    (void)expander{(reg_test(Types{}, Catch::NameAndTags{ Name " - " + std::string(tmpl_types[index]), Tags } ), index++, 0)... };/* NOLINT */ \
+                    (void)expander{(reg_test(Types{}, Catch::NameAndTags{ Name " - " + std::string(tmpl_types[index]), Tags } ), index++)... };/* NOLINT */ \
                 }\
             };\
             static int INTERNAL_CATCH_UNIQUE_NAME( globalRegistrar ) = [](){\
@@ -1119,18 +1115,18 @@ struct AutoReg : NonCopyable {
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
     #define INTERNAL_CATCH_TEMPLATE_TEST_CASE(Name, Tags, ...) \
-        INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, typename TestType, __VA_ARGS__ )
+        INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, typename TestType, __VA_ARGS__ )
 #else
-#define INTERNAL_CATCH_TEMPLATE_TEST_CASE(Name, Tags, ...) \
-        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, typename TestType, __VA_ARGS__ ) )
+    #define INTERNAL_CATCH_TEMPLATE_TEST_CASE(Name, Tags, ...) \
+        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, typename TestType, __VA_ARGS__ ) )
 #endif
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
     #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_SIG(Name, Tags, Signature, ...) \
-        INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, Signature, __VA_ARGS__ )
+        INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, Signature, __VA_ARGS__ )
 #else
-#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_SIG(Name, Tags, Signature, ...) \
-        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, Signature, __VA_ARGS__ ) )
+    #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_SIG(Name, Tags, Signature, ...) \
+        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, Signature, __VA_ARGS__ ) )
 #endif
 
     #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2(TestName, TestFuncName, Name, Tags, Signature, TmplTypes, TypesList) \
@@ -1151,7 +1147,7 @@ struct AutoReg : NonCopyable {
                     constexpr char const* tmpl_types[] = {CATCH_REC_LIST(INTERNAL_CATCH_STRINGIZE_WITHOUT_PARENS, INTERNAL_CATCH_REMOVE_PARENS(TmplTypes))};\
                     constexpr char const* types_list[] = {CATCH_REC_LIST(INTERNAL_CATCH_STRINGIZE_WITHOUT_PARENS, INTERNAL_CATCH_REMOVE_PARENS(TypesList))};\
                     constexpr auto num_types = sizeof(types_list) / sizeof(types_list[0]);\
-                    (void)expander{(Catch::AutoReg( Catch::makeTestInvoker( &TestFuncName<Types> ), CATCH_INTERNAL_LINEINFO, Catch::StringRef(), Catch::NameAndTags{ Name " - " + std::string(tmpl_types[index / num_types]) + "<" + std::string(types_list[index % num_types]) + ">", Tags } ), index++, 0)... };/* NOLINT */\
+                    (void)expander{(Catch::AutoReg( Catch::makeTestInvoker( &TestFuncName<Types> ), CATCH_INTERNAL_LINEINFO, Catch::StringRef(), Catch::NameAndTags{ Name " - " + std::string(tmpl_types[index / num_types]) + "<" + std::string(types_list[index % num_types]) + ">", Tags } ), index++)... };/* NOLINT */\
                 }                                                     \
             };                                                        \
             static int INTERNAL_CATCH_UNIQUE_NAME( globalRegistrar ) = [](){ \
@@ -1168,18 +1164,18 @@ struct AutoReg : NonCopyable {
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
     #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE(Name, Tags, ...)\
-        INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, typename T,__VA_ARGS__)
+        INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, typename T,__VA_ARGS__)
 #else
-#define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE(Name, Tags, ...)\
-        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, typename T, __VA_ARGS__ ) )
+    #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE(Name, Tags, ...)\
+        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, typename T, __VA_ARGS__ ) )
 #endif
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
     #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_SIG(Name, Tags, Signature, ...)\
-        INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, Signature, __VA_ARGS__)
+        INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, Signature, __VA_ARGS__)
 #else
-#define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_SIG(Name, Tags, Signature, ...)\
-        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, Signature, __VA_ARGS__ ) )
+    #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_SIG(Name, Tags, Signature, ...)\
+        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, Signature, __VA_ARGS__ ) )
 #endif
 
     #define INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_2(TestName, TestFunc, Name, Tags, TmplList)\
@@ -1195,7 +1191,7 @@ struct AutoReg : NonCopyable {
             void reg_tests() {                                          \
                 int index = 0;                                    \
                 using expander = int[];                           \
-                (void)expander{(Catch::AutoReg( Catch::makeTestInvoker( &TestFunc<Types> ), CATCH_INTERNAL_LINEINFO, Catch::StringRef(), Catch::NameAndTags{ Name " - " + std::string(INTERNAL_CATCH_STRINGIZE(TmplList)) + " - " + std::to_string(index), Tags } ), index++, 0)... };/* NOLINT */\
+                (void)expander{(Catch::AutoReg( Catch::makeTestInvoker( &TestFunc<Types> ), CATCH_INTERNAL_LINEINFO, Catch::StringRef(), Catch::NameAndTags{ Name " - " + std::string(INTERNAL_CATCH_STRINGIZE(TmplList)) + " - " + std::to_string(index), Tags } ), index++)... };/* NOLINT */\
             }                                                     \
         };\
         static int INTERNAL_CATCH_UNIQUE_NAME( globalRegistrar ) = [](){ \
@@ -1210,7 +1206,7 @@ struct AutoReg : NonCopyable {
         static void TestFunc()
 
     #define INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE(Name, Tags, TmplList) \
-        INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), Name, Tags, TmplList )
+        INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), Name, Tags, TmplList )
 
     #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( TestNameClass, TestName, ClassName, Name, Tags, Signature, ... ) \
         CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
@@ -1229,7 +1225,7 @@ struct AutoReg : NonCopyable {
                     int index = 0;                                    \
                     constexpr char const* tmpl_types[] = {CATCH_REC_LIST(INTERNAL_CATCH_STRINGIZE_WITHOUT_PARENS, __VA_ARGS__)};\
                     using expander = int[];\
-                    (void)expander{(reg_test(Types{}, #ClassName, Catch::NameAndTags{ Name " - " + std::string(tmpl_types[index]), Tags } ), index++, 0)... };/* NOLINT */ \
+                    (void)expander{(reg_test(Types{}, #ClassName, Catch::NameAndTags{ Name " - " + std::string(tmpl_types[index]), Tags } ), index++)... };/* NOLINT */ \
                 }\
             };\
             static int INTERNAL_CATCH_UNIQUE_NAME( globalRegistrar ) = [](){\
@@ -1243,18 +1239,18 @@ struct AutoReg : NonCopyable {
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
     #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD( ClassName, Name, Tags,... ) \
-        INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ) , ClassName, Name, Tags, typename T, __VA_ARGS__ )
+        INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ) , ClassName, Name, Tags, typename T, __VA_ARGS__ )
 #else
-#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD( ClassName, Name, Tags,... ) \
-        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ) , ClassName, Name, Tags, typename T, __VA_ARGS__ ) )
+    #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD( ClassName, Name, Tags,... ) \
+        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ) , ClassName, Name, Tags, typename T, __VA_ARGS__ ) )
 #endif
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
     #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_SIG( ClassName, Name, Tags, Signature, ... ) \
-        INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ) , ClassName, Name, Tags, Signature, __VA_ARGS__ )
+        INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ) , ClassName, Name, Tags, Signature, __VA_ARGS__ )
 #else
-#define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_SIG( ClassName, Name, Tags, Signature, ... ) \
-        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____C_L_A_S_S____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ) , ClassName, Name, Tags, Signature, __VA_ARGS__ ) )
+    #define INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_SIG( ClassName, Name, Tags, Signature, ... ) \
+        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_C_L_A_S_S_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ) , ClassName, Name, Tags, Signature, __VA_ARGS__ ) )
 #endif
 
     #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2(TestNameClass, TestName, ClassName, Name, Tags, Signature, TmplTypes, TypesList)\
@@ -1278,7 +1274,7 @@ struct AutoReg : NonCopyable {
                     constexpr char const* tmpl_types[] = {CATCH_REC_LIST(INTERNAL_CATCH_STRINGIZE_WITHOUT_PARENS, INTERNAL_CATCH_REMOVE_PARENS(TmplTypes))};\
                     constexpr char const* types_list[] = {CATCH_REC_LIST(INTERNAL_CATCH_STRINGIZE_WITHOUT_PARENS, INTERNAL_CATCH_REMOVE_PARENS(TypesList))};\
                     constexpr auto num_types = sizeof(types_list) / sizeof(types_list[0]);\
-                    (void)expander{(Catch::AutoReg( Catch::makeTestInvoker( &TestName<Types>::test ), CATCH_INTERNAL_LINEINFO, #ClassName, Catch::NameAndTags{ Name " - " + std::string(tmpl_types[index / num_types]) + "<" + std::string(types_list[index % num_types]) + ">", Tags } ), index++, 0)... };/* NOLINT */ \
+                    (void)expander{(Catch::AutoReg( Catch::makeTestInvoker( &TestName<Types>::test ), CATCH_INTERNAL_LINEINFO, #ClassName, Catch::NameAndTags{ Name " - " + std::string(tmpl_types[index / num_types]) + "<" + std::string(types_list[index % num_types]) + ">", Tags } ), index++)... };/* NOLINT */ \
                 }\
             };\
             static int INTERNAL_CATCH_UNIQUE_NAME( globalRegistrar ) = [](){\
@@ -1295,18 +1291,18 @@ struct AutoReg : NonCopyable {
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
     #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD( ClassName, Name, Tags, ... )\
-        INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), ClassName, Name, Tags, typename T, __VA_ARGS__ )
+        INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), ClassName, Name, Tags, typename T, __VA_ARGS__ )
 #else
-#define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD( ClassName, Name, Tags, ... )\
-        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), ClassName, Name, Tags, typename T,__VA_ARGS__ ) )
+    #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD( ClassName, Name, Tags, ... )\
+        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), ClassName, Name, Tags, typename T,__VA_ARGS__ ) )
 #endif
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
     #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG( ClassName, Name, Tags, Signature, ... )\
-        INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), ClassName, Name, Tags, Signature, __VA_ARGS__ )
+        INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), ClassName, Name, Tags, Signature, __VA_ARGS__ )
 #else
-#define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG( ClassName, Name, Tags, Signature, ... )\
-        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), ClassName, Name, Tags, Signature,__VA_ARGS__ ) )
+    #define INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_SIG( ClassName, Name, Tags, Signature, ... )\
+        INTERNAL_CATCH_EXPAND_VARGS( INTERNAL_CATCH_TEMPLATE_PRODUCT_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), ClassName, Name, Tags, Signature,__VA_ARGS__ ) )
 #endif
 
     #define INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_METHOD_2( TestNameClass, TestName, ClassName, Name, Tags, TmplList) \
@@ -1325,7 +1321,7 @@ struct AutoReg : NonCopyable {
                 void reg_tests(){\
                     int index = 0;\
                     using expander = int[];\
-                    (void)expander{(Catch::AutoReg( Catch::makeTestInvoker( &TestName<Types>::test ), CATCH_INTERNAL_LINEINFO, #ClassName, Catch::NameAndTags{ Name " - " + std::string(INTERNAL_CATCH_STRINGIZE(TmplList)) + " - " + std::to_string(index), Tags } ), index++, 0)... };/* NOLINT */ \
+                    (void)expander{(Catch::AutoReg( Catch::makeTestInvoker( &TestName<Types>::test ), CATCH_INTERNAL_LINEINFO, #ClassName, Catch::NameAndTags{ Name " - " + std::string(INTERNAL_CATCH_STRINGIZE(TmplList)) + " - " + std::to_string(index), Tags } ), index++)... };/* NOLINT */ \
                 }\
             };\
             static int INTERNAL_CATCH_UNIQUE_NAME( globalRegistrar ) = [](){\
@@ -1340,7 +1336,7 @@ struct AutoReg : NonCopyable {
         void TestName<TestType>::test()
 
 #define INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_METHOD(ClassName, Name, Tags, TmplList) \
-        INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____ ), INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_M_P_L_A_T_E____T_E_S_T____F_U_N_C____ ), ClassName, Name, Tags, TmplList )
+        INTERNAL_CATCH_TEMPLATE_LIST_TEST_CASE_METHOD_2( INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_ ), INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_M_P_L_A_T_E_T_E_S_T_F_U_N_C_ ), ClassName, Name, Tags, TmplList )
 
 // end catch_test_registry.h
 // start catch_capture.hpp
@@ -1353,8 +1349,8 @@ struct AutoReg : NonCopyable {
 
 namespace Catch {
 
-// ResultWas::OfType enum
-struct ResultWas { enum OfType {
+    // ResultWas::OfType enum
+    struct ResultWas { enum OfType {
         Unknown = -1,
         Ok = 0,
         Info = 1,
@@ -1374,11 +1370,11 @@ struct ResultWas { enum OfType {
 
     }; };
 
-bool isOk( ResultWas::OfType resultType );
-bool isJustInfo( int flags );
+    bool isOk( ResultWas::OfType resultType );
+    bool isJustInfo( int flags );
 
-// ResultDisposition::Flags enum
-struct ResultDisposition { enum Flags {
+    // ResultDisposition::Flags enum
+    struct ResultDisposition { enum Flags {
         Normal = 0x01,
 
         ContinueOnFailure = 0x02,   // Failures fail test, but execution continues
@@ -1386,28 +1382,28 @@ struct ResultDisposition { enum Flags {
         SuppressFail = 0x08         // Failures are reported but do not fail the test
     }; };
 
-ResultDisposition::Flags operator | ( ResultDisposition::Flags lhs, ResultDisposition::Flags rhs );
+    ResultDisposition::Flags operator | ( ResultDisposition::Flags lhs, ResultDisposition::Flags rhs );
 
-bool shouldContinueOnFailure( int flags );
-inline bool isFalseTest( int flags ) { return ( flags & ResultDisposition::FalseTest ) != 0; }
-bool shouldSuppressFailure( int flags );
+    bool shouldContinueOnFailure( int flags );
+    inline bool isFalseTest( int flags ) { return ( flags & ResultDisposition::FalseTest ) != 0; }
+    bool shouldSuppressFailure( int flags );
 
 } // end namespace Catch
 
 // end catch_result_type.h
 namespace Catch {
 
-struct AssertionInfo
-{
-    StringRef macroName;
-    SourceLineInfo lineInfo;
-    StringRef capturedExpression;
-    ResultDisposition::Flags resultDisposition;
+    struct AssertionInfo
+    {
+        StringRef macroName;
+        SourceLineInfo lineInfo;
+        StringRef capturedExpression;
+        ResultDisposition::Flags resultDisposition;
 
-    // We want to delete this constructor but a compiler bug in 4.8 means
-    // the struct is then treated as non-aggregate
-    //AssertionInfo() = delete;
-};
+        // We want to delete this constructor but a compiler bug in 4.8 means
+        // the struct is then treated as non-aggregate
+        //AssertionInfo() = delete;
+    };
 
 } // end namespace Catch
 
@@ -1428,35 +1424,35 @@ struct AssertionInfo
 
 namespace Catch {
 
-std::ostream& cout();
-std::ostream& cerr();
-std::ostream& clog();
+    std::ostream& cout();
+    std::ostream& cerr();
+    std::ostream& clog();
 
-class StringRef;
+    class StringRef;
 
-struct IStream {
-    virtual ~IStream();
-    virtual std::ostream& stream() const = 0;
-};
+    struct IStream {
+        virtual ~IStream();
+        virtual std::ostream& stream() const = 0;
+    };
 
-auto makeStream( StringRef const &filename ) -> IStream const*;
+    auto makeStream( StringRef const &filename ) -> IStream const*;
 
-class ReusableStringStream : NonCopyable {
-    std::size_t m_index;
-    std::ostream* m_oss;
-public:
-    ReusableStringStream();
-    ~ReusableStringStream();
+    class ReusableStringStream : NonCopyable {
+        std::size_t m_index;
+        std::ostream* m_oss;
+    public:
+        ReusableStringStream();
+        ~ReusableStringStream();
 
-    auto str() const -> std::string;
+        auto str() const -> std::string;
 
-    template<typename T>
-    auto operator << ( T const& value ) -> ReusableStringStream& {
-        *m_oss << value;
-        return *this;
-    }
-    auto get() -> std::ostream& { return *m_oss; }
-};
+        template<typename T>
+        auto operator << ( T const& value ) -> ReusableStringStream& {
+            *m_oss << value;
+            return *this;
+        }
+        auto get() -> std::ostream& { return *m_oss; }
+    };
 }
 
 // end catch_stream.h
@@ -1466,32 +1462,32 @@ public:
 
 namespace Catch {
 
-namespace Detail {
-struct EnumInfo {
-    StringRef m_name;
-    std::vector<std::pair<int, StringRef>> m_values;
+    namespace Detail {
+        struct EnumInfo {
+            StringRef m_name;
+            std::vector<std::pair<int, StringRef>> m_values;
 
-    ~EnumInfo();
+            ~EnumInfo();
 
-    StringRef lookup( int value ) const;
-};
-} // namespace Detail
+            StringRef lookup( int value ) const;
+        };
+    } // namespace Detail
 
-struct IMutableEnumValuesRegistry {
-    virtual ~IMutableEnumValuesRegistry();
+    struct IMutableEnumValuesRegistry {
+        virtual ~IMutableEnumValuesRegistry();
 
-    virtual Detail::EnumInfo const& registerEnum( StringRef enumName, StringRef allEnums, std::vector<int> const& values ) = 0;
+        virtual Detail::EnumInfo const& registerEnum( StringRef enumName, StringRef allEnums, std::vector<int> const& values ) = 0;
 
-    template<typename E>
-    Detail::EnumInfo const& registerEnum( StringRef enumName, StringRef allEnums, std::initializer_list<E> values ) {
-        static_assert(sizeof(int) >= sizeof(E), "Cannot serialize enum to int");
-        std::vector<int> intValues;
-        intValues.reserve( values.size() );
-        for( auto enumValue : values )
-            intValues.push_back( static_cast<int>( enumValue ) );
-        return registerEnum( enumName, allEnums, intValues );
-    }
-};
+        template<typename E>
+        Detail::EnumInfo const& registerEnum( StringRef enumName, StringRef allEnums, std::initializer_list<E> values ) {
+            static_assert(sizeof(int) >= sizeof(E), "Cannot serialize enum to int");
+            std::vector<int> intValues;
+            intValues.reserve( values.size() );
+            for( auto enumValue : values )
+                intValues.push_back( static_cast<int>( enumValue ) );
+            return registerEnum( enumName, allEnums, intValues );
+        }
+    };
 
 } // Catch
 
@@ -1553,55 +1549,55 @@ inline id performOptionalSelector( id obj, SEL sel ) {
 #endif
 
 namespace Catch {
-namespace Detail {
+    namespace Detail {
 
-extern const std::string unprintableString;
+        extern const std::string unprintableString;
 
-std::string rawMemoryToString( const void *object, std::size_t size );
+        std::string rawMemoryToString( const void *object, std::size_t size );
 
-template<typename T>
-std::string rawMemoryToString( const T& object ) {
-    return rawMemoryToString( &object, sizeof(object) );
-}
+        template<typename T>
+        std::string rawMemoryToString( const T& object ) {
+          return rawMemoryToString( &object, sizeof(object) );
+        }
 
-template<typename T>
-class IsStreamInsertable {
-    template<typename Stream, typename U>
-    static auto test(int)
-    -> decltype(std::declval<Stream&>() << std::declval<U>(), std::true_type());
+        template<typename T>
+        class IsStreamInsertable {
+            template<typename Stream, typename U>
+            static auto test(int)
+                -> decltype(std::declval<Stream&>() << std::declval<U>(), std::true_type());
 
-    template<typename, typename>
-    static auto test(...)->std::false_type;
+            template<typename, typename>
+            static auto test(...)->std::false_type;
 
-public:
-    static const bool value = decltype(test<std::ostream, const T&>(0))::value;
-};
+        public:
+            static const bool value = decltype(test<std::ostream, const T&>(0))::value;
+        };
 
-template<typename E>
-std::string convertUnknownEnumToString( E e );
+        template<typename E>
+        std::string convertUnknownEnumToString( E e );
 
-template<typename T>
-typename std::enable_if<
-    !std::is_enum<T>::value && !std::is_base_of<std::exception, T>::value,
-    std::string>::type convertUnstreamable( T const& ) {
-    return Detail::unprintableString;
-}
-template<typename T>
-typename std::enable_if<
-    !std::is_enum<T>::value && std::is_base_of<std::exception, T>::value,
-    std::string>::type convertUnstreamable(T const& ex) {
-    return ex.what();
-}
+        template<typename T>
+        typename std::enable_if<
+            !std::is_enum<T>::value && !std::is_base_of<std::exception, T>::value,
+        std::string>::type convertUnstreamable( T const& ) {
+            return Detail::unprintableString;
+        }
+        template<typename T>
+        typename std::enable_if<
+            !std::is_enum<T>::value && std::is_base_of<std::exception, T>::value,
+         std::string>::type convertUnstreamable(T const& ex) {
+            return ex.what();
+        }
 
-template<typename T>
-typename std::enable_if<
-    std::is_enum<T>::value
-    , std::string>::type convertUnstreamable( T const& value ) {
-    return convertUnknownEnumToString( value );
-}
+        template<typename T>
+        typename std::enable_if<
+            std::is_enum<T>::value
+        , std::string>::type convertUnstreamable( T const& value ) {
+            return convertUnknownEnumToString( value );
+        }
 
 #if defined(_MANAGED)
-//! Convert a CLR string to a utf8 std::string
+        //! Convert a CLR string to a utf8 std::string
         template<typename T>
         std::string clrReferenceToString( T^ ref ) {
             if (ref == nullptr)
@@ -1612,215 +1608,215 @@ typename std::enable_if<
         }
 #endif
 
-} // namespace Detail
+    } // namespace Detail
 
-// If we decide for C++14, change these to enable_if_ts
-template <typename T, typename = void>
-struct StringMaker {
-    template <typename Fake = T>
-    static
-    typename std::enable_if<::Catch::Detail::IsStreamInsertable<Fake>::value, std::string>::type
-    convert(const Fake& value) {
-        ReusableStringStream rss;
-        // NB: call using the function-like syntax to avoid ambiguity with
-        // user-defined templated operator<< under clang.
-        rss.operator<<(value);
-        return rss.str();
-    }
+    // If we decide for C++14, change these to enable_if_ts
+    template <typename T, typename = void>
+    struct StringMaker {
+        template <typename Fake = T>
+        static
+        typename std::enable_if<::Catch::Detail::IsStreamInsertable<Fake>::value, std::string>::type
+            convert(const Fake& value) {
+                ReusableStringStream rss;
+                // NB: call using the function-like syntax to avoid ambiguity with
+                // user-defined templated operator<< under clang.
+                rss.operator<<(value);
+                return rss.str();
+        }
 
-    template <typename Fake = T>
-    static
-    typename std::enable_if<!::Catch::Detail::IsStreamInsertable<Fake>::value, std::string>::type
-    convert( const Fake& value ) {
+        template <typename Fake = T>
+        static
+        typename std::enable_if<!::Catch::Detail::IsStreamInsertable<Fake>::value, std::string>::type
+            convert( const Fake& value ) {
 #if !defined(CATCH_CONFIG_FALLBACK_STRINGIFIER)
-        return Detail::convertUnstreamable(value);
+            return Detail::convertUnstreamable(value);
 #else
-        return CATCH_CONFIG_FALLBACK_STRINGIFIER(value);
+            return CATCH_CONFIG_FALLBACK_STRINGIFIER(value);
 #endif
-    }
-};
+        }
+    };
 
-namespace Detail {
+    namespace Detail {
 
-// This function dispatches all stringification requests inside of Catch.
-// Should be preferably called fully qualified, like ::Catch::Detail::stringify
-template <typename T>
-std::string stringify(const T& e) {
-    return ::Catch::StringMaker<typename std::remove_cv<typename std::remove_reference<T>::type>::type>::convert(e);
-}
+        // This function dispatches all stringification requests inside of Catch.
+        // Should be preferably called fully qualified, like ::Catch::Detail::stringify
+        template <typename T>
+        std::string stringify(const T& e) {
+            return ::Catch::StringMaker<typename std::remove_cv<typename std::remove_reference<T>::type>::type>::convert(e);
+        }
 
-template<typename E>
-std::string convertUnknownEnumToString( E e ) {
-    return ::Catch::Detail::stringify(static_cast<typename std::underlying_type<E>::type>(e));
-}
+        template<typename E>
+        std::string convertUnknownEnumToString( E e ) {
+            return ::Catch::Detail::stringify(static_cast<typename std::underlying_type<E>::type>(e));
+        }
 
 #if defined(_MANAGED)
-template <typename T>
+        template <typename T>
         std::string stringify( T^ e ) {
             return ::Catch::StringMaker<T^>::convert(e);
         }
 #endif
 
-} // namespace Detail
+    } // namespace Detail
 
-// Some predefined specializations
+    // Some predefined specializations
 
-template<>
-struct StringMaker<std::string> {
-    static std::string convert(const std::string& str);
-};
+    template<>
+    struct StringMaker<std::string> {
+        static std::string convert(const std::string& str);
+    };
 
 #ifdef CATCH_CONFIG_CPP17_STRING_VIEW
-template<>
-struct StringMaker<std::string_view> {
-    static std::string convert(std::string_view str);
-};
+    template<>
+    struct StringMaker<std::string_view> {
+        static std::string convert(std::string_view str);
+    };
 #endif
 
-template<>
-struct StringMaker<char const *> {
-    static std::string convert(char const * str);
-};
-template<>
-struct StringMaker<char *> {
-    static std::string convert(char * str);
-};
+    template<>
+    struct StringMaker<char const *> {
+        static std::string convert(char const * str);
+    };
+    template<>
+    struct StringMaker<char *> {
+        static std::string convert(char * str);
+    };
 
 #ifdef CATCH_CONFIG_WCHAR
-template<>
-struct StringMaker<std::wstring> {
-    static std::string convert(const std::wstring& wstr);
-};
+    template<>
+    struct StringMaker<std::wstring> {
+        static std::string convert(const std::wstring& wstr);
+    };
 
 # ifdef CATCH_CONFIG_CPP17_STRING_VIEW
-template<>
-struct StringMaker<std::wstring_view> {
-    static std::string convert(std::wstring_view str);
-};
+    template<>
+    struct StringMaker<std::wstring_view> {
+        static std::string convert(std::wstring_view str);
+    };
 # endif
 
-template<>
-struct StringMaker<wchar_t const *> {
-    static std::string convert(wchar_t const * str);
-};
-template<>
-struct StringMaker<wchar_t *> {
-    static std::string convert(wchar_t * str);
-};
+    template<>
+    struct StringMaker<wchar_t const *> {
+        static std::string convert(wchar_t const * str);
+    };
+    template<>
+    struct StringMaker<wchar_t *> {
+        static std::string convert(wchar_t * str);
+    };
 #endif
 
-// TBD: Should we use `strnlen` to ensure that we don't go out of the buffer,
-//      while keeping string semantics?
-template<int SZ>
-struct StringMaker<char[SZ]> {
-    static std::string convert(char const* str) {
-        return ::Catch::Detail::stringify(std::string{ str });
-    }
-};
-template<int SZ>
-struct StringMaker<signed char[SZ]> {
-    static std::string convert(signed char const* str) {
-        return ::Catch::Detail::stringify(std::string{ reinterpret_cast<char const *>(str) });
-    }
-};
-template<int SZ>
-struct StringMaker<unsigned char[SZ]> {
-    static std::string convert(unsigned char const* str) {
-        return ::Catch::Detail::stringify(std::string{ reinterpret_cast<char const *>(str) });
-    }
-};
+    // TBD: Should we use `strnlen` to ensure that we don't go out of the buffer,
+    //      while keeping string semantics?
+    template<int SZ>
+    struct StringMaker<char[SZ]> {
+        static std::string convert(char const* str) {
+            return ::Catch::Detail::stringify(std::string{ str });
+        }
+    };
+    template<int SZ>
+    struct StringMaker<signed char[SZ]> {
+        static std::string convert(signed char const* str) {
+            return ::Catch::Detail::stringify(std::string{ reinterpret_cast<char const *>(str) });
+        }
+    };
+    template<int SZ>
+    struct StringMaker<unsigned char[SZ]> {
+        static std::string convert(unsigned char const* str) {
+            return ::Catch::Detail::stringify(std::string{ reinterpret_cast<char const *>(str) });
+        }
+    };
 
 #if defined(CATCH_CONFIG_CPP17_BYTE)
-template<>
-struct StringMaker<std::byte> {
-    static std::string convert(std::byte value);
-};
+    template<>
+    struct StringMaker<std::byte> {
+        static std::string convert(std::byte value);
+    };
 #endif // defined(CATCH_CONFIG_CPP17_BYTE)
-template<>
-struct StringMaker<int> {
-    static std::string convert(int value);
-};
-template<>
-struct StringMaker<long> {
-    static std::string convert(long value);
-};
-template<>
-struct StringMaker<long long> {
-    static std::string convert(long long value);
-};
-template<>
-struct StringMaker<unsigned int> {
-    static std::string convert(unsigned int value);
-};
-template<>
-struct StringMaker<unsigned long> {
-    static std::string convert(unsigned long value);
-};
-template<>
-struct StringMaker<unsigned long long> {
-    static std::string convert(unsigned long long value);
-};
+    template<>
+    struct StringMaker<int> {
+        static std::string convert(int value);
+    };
+    template<>
+    struct StringMaker<long> {
+        static std::string convert(long value);
+    };
+    template<>
+    struct StringMaker<long long> {
+        static std::string convert(long long value);
+    };
+    template<>
+    struct StringMaker<unsigned int> {
+        static std::string convert(unsigned int value);
+    };
+    template<>
+    struct StringMaker<unsigned long> {
+        static std::string convert(unsigned long value);
+    };
+    template<>
+    struct StringMaker<unsigned long long> {
+        static std::string convert(unsigned long long value);
+    };
 
-template<>
-struct StringMaker<bool> {
-    static std::string convert(bool b);
-};
+    template<>
+    struct StringMaker<bool> {
+        static std::string convert(bool b);
+    };
 
-template<>
-struct StringMaker<char> {
-    static std::string convert(char c);
-};
-template<>
-struct StringMaker<signed char> {
-    static std::string convert(signed char c);
-};
-template<>
-struct StringMaker<unsigned char> {
-    static std::string convert(unsigned char c);
-};
+    template<>
+    struct StringMaker<char> {
+        static std::string convert(char c);
+    };
+    template<>
+    struct StringMaker<signed char> {
+        static std::string convert(signed char c);
+    };
+    template<>
+    struct StringMaker<unsigned char> {
+        static std::string convert(unsigned char c);
+    };
 
-template<>
-struct StringMaker<std::nullptr_t> {
-    static std::string convert(std::nullptr_t);
-};
+    template<>
+    struct StringMaker<std::nullptr_t> {
+        static std::string convert(std::nullptr_t);
+    };
 
-template<>
-struct StringMaker<float> {
-    static std::string convert(float value);
-    static int precision;
-};
+    template<>
+    struct StringMaker<float> {
+        static std::string convert(float value);
+        static int precision;
+    };
 
-template<>
-struct StringMaker<double> {
-    static std::string convert(double value);
-    static int precision;
-};
+    template<>
+    struct StringMaker<double> {
+        static std::string convert(double value);
+        static int precision;
+    };
 
-template <typename T>
-struct StringMaker<T*> {
-    template <typename U>
-    static std::string convert(U* p) {
-        if (p) {
-            return ::Catch::Detail::rawMemoryToString(p);
-        } else {
-            return "nullptr";
+    template <typename T>
+    struct StringMaker<T*> {
+        template <typename U>
+        static std::string convert(U* p) {
+            if (p) {
+                return ::Catch::Detail::rawMemoryToString(p);
+            } else {
+                return "nullptr";
+            }
         }
-    }
-};
+    };
 
-template <typename R, typename C>
-struct StringMaker<R C::*> {
-    static std::string convert(R C::* p) {
-        if (p) {
-            return ::Catch::Detail::rawMemoryToString(p);
-        } else {
-            return "nullptr";
+    template <typename R, typename C>
+    struct StringMaker<R C::*> {
+        static std::string convert(R C::* p) {
+            if (p) {
+                return ::Catch::Detail::rawMemoryToString(p);
+            } else {
+                return "nullptr";
+            }
         }
-    }
-};
+    };
 
 #if defined(_MANAGED)
-template <typename T>
+    template <typename T>
     struct StringMaker<T^> {
         static std::string convert( T^ ref ) {
             return ::Catch::Detail::clrReferenceToString(ref);
@@ -1828,23 +1824,23 @@ template <typename T>
     };
 #endif
 
-namespace Detail {
-template<typename InputIterator>
-std::string rangeToString(InputIterator first, InputIterator last) {
-    ReusableStringStream rss;
-    rss << "{ ";
-    if (first != last) {
-        rss << ::Catch::Detail::stringify(*first);
-        for (++first; first != last; ++first)
-            rss << ", " << ::Catch::Detail::stringify(*first);
+    namespace Detail {
+        template<typename InputIterator, typename Sentinel = InputIterator>
+        std::string rangeToString(InputIterator first, Sentinel last) {
+            ReusableStringStream rss;
+            rss << "{ ";
+            if (first != last) {
+                rss << ::Catch::Detail::stringify(*first);
+                for (++first; first != last; ++first)
+                    rss << ", " << ::Catch::Detail::stringify(*first);
+            }
+            rss << " }";
+            return rss.str();
+        }
     }
-    rss << " }";
-    return rss.str();
-}
-}
 
 #ifdef __OBJC__
-template<>
+    template<>
     struct StringMaker<NSString*> {
         static std::string convert(NSString * nsstring) {
             if (!nsstring)
@@ -1988,71 +1984,71 @@ namespace Catch {
 #endif // CATCH_CONFIG_ENABLE_VARIANT_STRINGMAKER
 
 namespace Catch {
-// Import begin/ end from std here
-using std::begin;
-using std::end;
+    // Import begin/ end from std here
+    using std::begin;
+    using std::end;
 
-namespace detail {
-template <typename...>
-struct void_type {
-    using type = void;
-};
+    namespace detail {
+        template <typename...>
+        struct void_type {
+            using type = void;
+        };
 
-template <typename T, typename = void>
-struct is_range_impl : std::false_type {
-};
+        template <typename T, typename = void>
+        struct is_range_impl : std::false_type {
+        };
 
-template <typename T>
-struct is_range_impl<T, typename void_type<decltype(begin(std::declval<T>()))>::type> : std::true_type {
-};
-} // namespace detail
+        template <typename T>
+        struct is_range_impl<T, typename void_type<decltype(begin(std::declval<T>()))>::type> : std::true_type {
+        };
+    } // namespace detail
 
-template <typename T>
-struct is_range : detail::is_range_impl<T> {
-};
+    template <typename T>
+    struct is_range : detail::is_range_impl<T> {
+    };
 
 #if defined(_MANAGED) // Managed types are never ranges
-template <typename T>
+    template <typename T>
     struct is_range<T^> {
         static const bool value = false;
     };
 #endif
 
-template<typename Range>
-std::string rangeToString( Range const& range ) {
-    return ::Catch::Detail::rangeToString( begin( range ), end( range ) );
-}
-
-// Handle vector<bool> specially
-template<typename Allocator>
-std::string rangeToString( std::vector<bool, Allocator> const& v ) {
-    ReusableStringStream rss;
-    rss << "{ ";
-    bool first = true;
-    for( bool b : v ) {
-        if( first )
-            first = false;
-        else
-            rss << ", ";
-        rss << ::Catch::Detail::stringify( b );
+    template<typename Range>
+    std::string rangeToString( Range const& range ) {
+        return ::Catch::Detail::rangeToString( begin( range ), end( range ) );
     }
-    rss << " }";
-    return rss.str();
-}
 
-template<typename R>
-struct StringMaker<R, typename std::enable_if<is_range<R>::value && !::Catch::Detail::IsStreamInsertable<R>::value>::type> {
-    static std::string convert( R const& range ) {
-        return rangeToString( range );
+    // Handle vector<bool> specially
+    template<typename Allocator>
+    std::string rangeToString( std::vector<bool, Allocator> const& v ) {
+        ReusableStringStream rss;
+        rss << "{ ";
+        bool first = true;
+        for( bool b : v ) {
+            if( first )
+                first = false;
+            else
+                rss << ", ";
+            rss << ::Catch::Detail::stringify( b );
+        }
+        rss << " }";
+        return rss.str();
     }
-};
 
-template <typename T, int SZ>
-struct StringMaker<T[SZ]> {
-    static std::string convert(T const(&arr)[SZ]) {
-        return rangeToString(arr);
-    }
-};
+    template<typename R>
+    struct StringMaker<R, typename std::enable_if<is_range<R>::value && !::Catch::Detail::IsStreamInsertable<R>::value>::type> {
+        static std::string convert( R const& range ) {
+            return rangeToString( range );
+        }
+    };
+
+    template <typename T, int SZ>
+    struct StringMaker<T[SZ]> {
+        static std::string convert(T const(&arr)[SZ]) {
+            return rangeToString(arr);
+        }
+    };
 
 } // namespace Catch
 
@@ -2101,75 +2097,75 @@ struct ratio_string<std::milli> {
     static std::string symbol();
 };
 
-////////////
-// std::chrono::duration specializations
-template<typename Value, typename Ratio>
-struct StringMaker<std::chrono::duration<Value, Ratio>> {
-    static std::string convert(std::chrono::duration<Value, Ratio> const& duration) {
-        ReusableStringStream rss;
-        rss << duration.count() << ' ' << ratio_string<Ratio>::symbol() << 's';
-        return rss.str();
-    }
-};
-template<typename Value>
-struct StringMaker<std::chrono::duration<Value, std::ratio<1>>> {
-    static std::string convert(std::chrono::duration<Value, std::ratio<1>> const& duration) {
-        ReusableStringStream rss;
-        rss << duration.count() << " s";
-        return rss.str();
-    }
-};
-template<typename Value>
-struct StringMaker<std::chrono::duration<Value, std::ratio<60>>> {
-    static std::string convert(std::chrono::duration<Value, std::ratio<60>> const& duration) {
-        ReusableStringStream rss;
-        rss << duration.count() << " m";
-        return rss.str();
-    }
-};
-template<typename Value>
-struct StringMaker<std::chrono::duration<Value, std::ratio<3600>>> {
-    static std::string convert(std::chrono::duration<Value, std::ratio<3600>> const& duration) {
-        ReusableStringStream rss;
-        rss << duration.count() << " h";
-        return rss.str();
-    }
-};
+    ////////////
+    // std::chrono::duration specializations
+    template<typename Value, typename Ratio>
+    struct StringMaker<std::chrono::duration<Value, Ratio>> {
+        static std::string convert(std::chrono::duration<Value, Ratio> const& duration) {
+            ReusableStringStream rss;
+            rss << duration.count() << ' ' << ratio_string<Ratio>::symbol() << 's';
+            return rss.str();
+        }
+    };
+    template<typename Value>
+    struct StringMaker<std::chrono::duration<Value, std::ratio<1>>> {
+        static std::string convert(std::chrono::duration<Value, std::ratio<1>> const& duration) {
+            ReusableStringStream rss;
+            rss << duration.count() << " s";
+            return rss.str();
+        }
+    };
+    template<typename Value>
+    struct StringMaker<std::chrono::duration<Value, std::ratio<60>>> {
+        static std::string convert(std::chrono::duration<Value, std::ratio<60>> const& duration) {
+            ReusableStringStream rss;
+            rss << duration.count() << " m";
+            return rss.str();
+        }
+    };
+    template<typename Value>
+    struct StringMaker<std::chrono::duration<Value, std::ratio<3600>>> {
+        static std::string convert(std::chrono::duration<Value, std::ratio<3600>> const& duration) {
+            ReusableStringStream rss;
+            rss << duration.count() << " h";
+            return rss.str();
+        }
+    };
 
-////////////
-// std::chrono::time_point specialization
-// Generic time_point cannot be specialized, only std::chrono::time_point<system_clock>
-template<typename Clock, typename Duration>
-struct StringMaker<std::chrono::time_point<Clock, Duration>> {
-    static std::string convert(std::chrono::time_point<Clock, Duration> const& time_point) {
-        return ::Catch::Detail::stringify(time_point.time_since_epoch()) + " since epoch";
-    }
-};
-// std::chrono::time_point<system_clock> specialization
-template<typename Duration>
-struct StringMaker<std::chrono::time_point<std::chrono::system_clock, Duration>> {
-    static std::string convert(std::chrono::time_point<std::chrono::system_clock, Duration> const& time_point) {
-        auto converted = std::chrono::system_clock::to_time_t(time_point);
+    ////////////
+    // std::chrono::time_point specialization
+    // Generic time_point cannot be specialized, only std::chrono::time_point<system_clock>
+    template<typename Clock, typename Duration>
+    struct StringMaker<std::chrono::time_point<Clock, Duration>> {
+        static std::string convert(std::chrono::time_point<Clock, Duration> const& time_point) {
+            return ::Catch::Detail::stringify(time_point.time_since_epoch()) + " since epoch";
+        }
+    };
+    // std::chrono::time_point<system_clock> specialization
+    template<typename Duration>
+    struct StringMaker<std::chrono::time_point<std::chrono::system_clock, Duration>> {
+        static std::string convert(std::chrono::time_point<std::chrono::system_clock, Duration> const& time_point) {
+            auto converted = std::chrono::system_clock::to_time_t(time_point);
 
 #ifdef _MSC_VER
-        std::tm timeInfo = {};
+            std::tm timeInfo = {};
             gmtime_s(&timeInfo, &converted);
 #else
-        std::tm* timeInfo = std::gmtime(&converted);
+            std::tm* timeInfo = std::gmtime(&converted);
 #endif
 
-        auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");
-        char timeStamp[timeStampSize];
-        const char * const fmt = "%Y-%m-%dT%H:%M:%SZ";
+            auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");
+            char timeStamp[timeStampSize];
+            const char * const fmt = "%Y-%m-%dT%H:%M:%SZ";
 
 #ifdef _MSC_VER
-        std::strftime(timeStamp, timeStampSize, fmt, &timeInfo);
+            std::strftime(timeStamp, timeStampSize, fmt, &timeInfo);
 #else
-        std::strftime(timeStamp, timeStampSize, fmt, timeInfo);
+            std::strftime(timeStamp, timeStampSize, fmt, timeInfo);
 #endif
-        return std::string(timeStamp);
-    }
-};
+            return std::string(timeStamp);
+        }
+    };
 }
 #endif // CATCH_CONFIG_ENABLE_CHRONO_STRINGMAKER
 
@@ -2203,228 +2199,228 @@ namespace Catch { \
 
 namespace Catch {
 
-struct ITransientExpression {
-    auto isBinaryExpression() const -> bool { return m_isBinaryExpression; }
-    auto getResult() const -> bool { return m_result; }
-    virtual void streamReconstructedExpression( std::ostream &os ) const = 0;
+    struct ITransientExpression {
+        auto isBinaryExpression() const -> bool { return m_isBinaryExpression; }
+        auto getResult() const -> bool { return m_result; }
+        virtual void streamReconstructedExpression( std::ostream &os ) const = 0;
 
-    ITransientExpression( bool isBinaryExpression, bool result )
+        ITransientExpression( bool isBinaryExpression, bool result )
         :   m_isBinaryExpression( isBinaryExpression ),
             m_result( result )
-    {}
+        {}
 
-    // We don't actually need a virtual destructor, but many static analysers
-    // complain if it's not here :-(
-    virtual ~ITransientExpression();
+        // We don't actually need a virtual destructor, but many static analysers
+        // complain if it's not here :-(
+        virtual ~ITransientExpression();
 
-    bool m_isBinaryExpression;
-    bool m_result;
+        bool m_isBinaryExpression;
+        bool m_result;
 
-};
+    };
 
-void formatReconstructedExpression( std::ostream &os, std::string const& lhs, StringRef op, std::string const& rhs );
+    void formatReconstructedExpression( std::ostream &os, std::string const& lhs, StringRef op, std::string const& rhs );
 
-template<typename LhsT, typename RhsT>
-class BinaryExpr  : public ITransientExpression {
-    LhsT m_lhs;
-    StringRef m_op;
-    RhsT m_rhs;
+    template<typename LhsT, typename RhsT>
+    class BinaryExpr  : public ITransientExpression {
+        LhsT m_lhs;
+        StringRef m_op;
+        RhsT m_rhs;
 
-    void streamReconstructedExpression( std::ostream &os ) const override {
-        formatReconstructedExpression
-            ( os, Catch::Detail::stringify( m_lhs ), m_op, Catch::Detail::stringify( m_rhs ) );
-    }
+        void streamReconstructedExpression( std::ostream &os ) const override {
+            formatReconstructedExpression
+                    ( os, Catch::Detail::stringify( m_lhs ), m_op, Catch::Detail::stringify( m_rhs ) );
+        }
 
-public:
-    BinaryExpr( bool comparisonResult, LhsT lhs, StringRef op, RhsT rhs )
+    public:
+        BinaryExpr( bool comparisonResult, LhsT lhs, StringRef op, RhsT rhs )
         :   ITransientExpression{ true, comparisonResult },
             m_lhs( lhs ),
             m_op( op ),
             m_rhs( rhs )
-    {}
+        {}
 
-    template<typename T>
-    auto operator && ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
-        static_assert(always_false<T>::value,
-                      "chained comparisons are not supported inside assertions, "
-                      "wrap the expression inside parentheses, or decompose it");
-    }
+        template<typename T>
+        auto operator && ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
+            static_assert(always_false<T>::value,
+            "chained comparisons are not supported inside assertions, "
+            "wrap the expression inside parentheses, or decompose it");
+        }
 
-    template<typename T>
-    auto operator || ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
-        static_assert(always_false<T>::value,
-                      "chained comparisons are not supported inside assertions, "
-                      "wrap the expression inside parentheses, or decompose it");
-    }
+        template<typename T>
+        auto operator || ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
+            static_assert(always_false<T>::value,
+            "chained comparisons are not supported inside assertions, "
+            "wrap the expression inside parentheses, or decompose it");
+        }
 
-    template<typename T>
-    auto operator == ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
-        static_assert(always_false<T>::value,
-                      "chained comparisons are not supported inside assertions, "
-                      "wrap the expression inside parentheses, or decompose it");
-    }
+        template<typename T>
+        auto operator == ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
+            static_assert(always_false<T>::value,
+            "chained comparisons are not supported inside assertions, "
+            "wrap the expression inside parentheses, or decompose it");
+        }
 
-    template<typename T>
-    auto operator != ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
-        static_assert(always_false<T>::value,
-                      "chained comparisons are not supported inside assertions, "
-                      "wrap the expression inside parentheses, or decompose it");
-    }
+        template<typename T>
+        auto operator != ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
+            static_assert(always_false<T>::value,
+            "chained comparisons are not supported inside assertions, "
+            "wrap the expression inside parentheses, or decompose it");
+        }
 
-    template<typename T>
-    auto operator > ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
-        static_assert(always_false<T>::value,
-                      "chained comparisons are not supported inside assertions, "
-                      "wrap the expression inside parentheses, or decompose it");
-    }
+        template<typename T>
+        auto operator > ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
+            static_assert(always_false<T>::value,
+            "chained comparisons are not supported inside assertions, "
+            "wrap the expression inside parentheses, or decompose it");
+        }
 
-    template<typename T>
-    auto operator < ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
-        static_assert(always_false<T>::value,
-                      "chained comparisons are not supported inside assertions, "
-                      "wrap the expression inside parentheses, or decompose it");
-    }
+        template<typename T>
+        auto operator < ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
+            static_assert(always_false<T>::value,
+            "chained comparisons are not supported inside assertions, "
+            "wrap the expression inside parentheses, or decompose it");
+        }
 
-    template<typename T>
-    auto operator >= ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
-        static_assert(always_false<T>::value,
-                      "chained comparisons are not supported inside assertions, "
-                      "wrap the expression inside parentheses, or decompose it");
-    }
+        template<typename T>
+        auto operator >= ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
+            static_assert(always_false<T>::value,
+            "chained comparisons are not supported inside assertions, "
+            "wrap the expression inside parentheses, or decompose it");
+        }
 
-    template<typename T>
-    auto operator <= ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
-        static_assert(always_false<T>::value,
-                      "chained comparisons are not supported inside assertions, "
-                      "wrap the expression inside parentheses, or decompose it");
-    }
-};
+        template<typename T>
+        auto operator <= ( T ) const -> BinaryExpr<LhsT, RhsT const&> const {
+            static_assert(always_false<T>::value,
+            "chained comparisons are not supported inside assertions, "
+            "wrap the expression inside parentheses, or decompose it");
+        }
+    };
 
-template<typename LhsT>
-class UnaryExpr : public ITransientExpression {
-    LhsT m_lhs;
+    template<typename LhsT>
+    class UnaryExpr : public ITransientExpression {
+        LhsT m_lhs;
 
-    void streamReconstructedExpression( std::ostream &os ) const override {
-        os << Catch::Detail::stringify( m_lhs );
-    }
+        void streamReconstructedExpression( std::ostream &os ) const override {
+            os << Catch::Detail::stringify( m_lhs );
+        }
 
-public:
-    explicit UnaryExpr( LhsT lhs )
+    public:
+        explicit UnaryExpr( LhsT lhs )
         :   ITransientExpression{ false, static_cast<bool>(lhs) },
             m_lhs( lhs )
-    {}
-};
+        {}
+    };
 
-// Specialised comparison functions to handle equality comparisons between ints and pointers (NULL deduces as an int)
-template<typename LhsT, typename RhsT>
-auto compareEqual( LhsT const& lhs, RhsT const& rhs ) -> bool { return static_cast<bool>(lhs == rhs); }
-template<typename T>
-auto compareEqual( T* const& lhs, int rhs ) -> bool { return lhs == reinterpret_cast<void const*>( rhs ); }
-template<typename T>
-auto compareEqual( T* const& lhs, long rhs ) -> bool { return lhs == reinterpret_cast<void const*>( rhs ); }
-template<typename T>
-auto compareEqual( int lhs, T* const& rhs ) -> bool { return reinterpret_cast<void const*>( lhs ) == rhs; }
-template<typename T>
-auto compareEqual( long lhs, T* const& rhs ) -> bool { return reinterpret_cast<void const*>( lhs ) == rhs; }
-
-template<typename LhsT, typename RhsT>
-auto compareNotEqual( LhsT const& lhs, RhsT&& rhs ) -> bool { return static_cast<bool>(lhs != rhs); }
-template<typename T>
-auto compareNotEqual( T* const& lhs, int rhs ) -> bool { return lhs != reinterpret_cast<void const*>( rhs ); }
-template<typename T>
-auto compareNotEqual( T* const& lhs, long rhs ) -> bool { return lhs != reinterpret_cast<void const*>( rhs ); }
-template<typename T>
-auto compareNotEqual( int lhs, T* const& rhs ) -> bool { return reinterpret_cast<void const*>( lhs ) != rhs; }
-template<typename T>
-auto compareNotEqual( long lhs, T* const& rhs ) -> bool { return reinterpret_cast<void const*>( lhs ) != rhs; }
-
-template<typename LhsT>
-class ExprLhs {
-    LhsT m_lhs;
-public:
-    explicit ExprLhs( LhsT lhs ) : m_lhs( lhs ) {}
-
-    template<typename RhsT>
-    auto operator == ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
-        return { compareEqual( m_lhs, rhs ), m_lhs, "==", rhs };
-    }
-    auto operator == ( bool rhs ) -> BinaryExpr<LhsT, bool> const {
-        return { m_lhs == rhs, m_lhs, "==", rhs };
-    }
-
-    template<typename RhsT>
-    auto operator != ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
-        return { compareNotEqual( m_lhs, rhs ), m_lhs, "!=", rhs };
-    }
-    auto operator != ( bool rhs ) -> BinaryExpr<LhsT, bool> const {
-        return { m_lhs != rhs, m_lhs, "!=", rhs };
-    }
-
-    template<typename RhsT>
-    auto operator > ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
-        return { static_cast<bool>(m_lhs > rhs), m_lhs, ">", rhs };
-    }
-    template<typename RhsT>
-    auto operator < ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
-        return { static_cast<bool>(m_lhs < rhs), m_lhs, "<", rhs };
-    }
-    template<typename RhsT>
-    auto operator >= ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
-        return { static_cast<bool>(m_lhs >= rhs), m_lhs, ">=", rhs };
-    }
-    template<typename RhsT>
-    auto operator <= ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
-        return { static_cast<bool>(m_lhs <= rhs), m_lhs, "<=", rhs };
-    }
-    template <typename RhsT>
-    auto operator | (RhsT const& rhs) -> BinaryExpr<LhsT, RhsT const&> const {
-        return { static_cast<bool>(m_lhs | rhs), m_lhs, "|", rhs };
-    }
-    template <typename RhsT>
-    auto operator & (RhsT const& rhs) -> BinaryExpr<LhsT, RhsT const&> const {
-        return { static_cast<bool>(m_lhs & rhs), m_lhs, "&", rhs };
-    }
-    template <typename RhsT>
-    auto operator ^ (RhsT const& rhs) -> BinaryExpr<LhsT, RhsT const&> const {
-        return { static_cast<bool>(m_lhs ^ rhs), m_lhs, "^", rhs };
-    }
-
-    template<typename RhsT>
-    auto operator && ( RhsT const& ) -> BinaryExpr<LhsT, RhsT const&> const {
-        static_assert(always_false<RhsT>::value,
-                      "operator&& is not supported inside assertions, "
-                      "wrap the expression inside parentheses, or decompose it");
-    }
-
-    template<typename RhsT>
-    auto operator || ( RhsT const& ) -> BinaryExpr<LhsT, RhsT const&> const {
-        static_assert(always_false<RhsT>::value,
-                      "operator|| is not supported inside assertions, "
-                      "wrap the expression inside parentheses, or decompose it");
-    }
-
-    auto makeUnaryExpr() const -> UnaryExpr<LhsT> {
-        return UnaryExpr<LhsT>{ m_lhs };
-    }
-};
-
-void handleExpression( ITransientExpression const& expr );
-
-template<typename T>
-void handleExpression( ExprLhs<T> const& expr ) {
-    handleExpression( expr.makeUnaryExpr() );
-}
-
-struct Decomposer {
+    // Specialised comparison functions to handle equality comparisons between ints and pointers (NULL deduces as an int)
+    template<typename LhsT, typename RhsT>
+    auto compareEqual( LhsT const& lhs, RhsT const& rhs ) -> bool { return static_cast<bool>(lhs == rhs); }
     template<typename T>
-    auto operator <= ( T const& lhs ) -> ExprLhs<T const&> {
-        return ExprLhs<T const&>{ lhs };
+    auto compareEqual( T* const& lhs, int rhs ) -> bool { return lhs == reinterpret_cast<void const*>( rhs ); }
+    template<typename T>
+    auto compareEqual( T* const& lhs, long rhs ) -> bool { return lhs == reinterpret_cast<void const*>( rhs ); }
+    template<typename T>
+    auto compareEqual( int lhs, T* const& rhs ) -> bool { return reinterpret_cast<void const*>( lhs ) == rhs; }
+    template<typename T>
+    auto compareEqual( long lhs, T* const& rhs ) -> bool { return reinterpret_cast<void const*>( lhs ) == rhs; }
+
+    template<typename LhsT, typename RhsT>
+    auto compareNotEqual( LhsT const& lhs, RhsT&& rhs ) -> bool { return static_cast<bool>(lhs != rhs); }
+    template<typename T>
+    auto compareNotEqual( T* const& lhs, int rhs ) -> bool { return lhs != reinterpret_cast<void const*>( rhs ); }
+    template<typename T>
+    auto compareNotEqual( T* const& lhs, long rhs ) -> bool { return lhs != reinterpret_cast<void const*>( rhs ); }
+    template<typename T>
+    auto compareNotEqual( int lhs, T* const& rhs ) -> bool { return reinterpret_cast<void const*>( lhs ) != rhs; }
+    template<typename T>
+    auto compareNotEqual( long lhs, T* const& rhs ) -> bool { return reinterpret_cast<void const*>( lhs ) != rhs; }
+
+    template<typename LhsT>
+    class ExprLhs {
+        LhsT m_lhs;
+    public:
+        explicit ExprLhs( LhsT lhs ) : m_lhs( lhs ) {}
+
+        template<typename RhsT>
+        auto operator == ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
+            return { compareEqual( m_lhs, rhs ), m_lhs, "==", rhs };
+        }
+        auto operator == ( bool rhs ) -> BinaryExpr<LhsT, bool> const {
+            return { m_lhs == rhs, m_lhs, "==", rhs };
+        }
+
+        template<typename RhsT>
+        auto operator != ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
+            return { compareNotEqual( m_lhs, rhs ), m_lhs, "!=", rhs };
+        }
+        auto operator != ( bool rhs ) -> BinaryExpr<LhsT, bool> const {
+            return { m_lhs != rhs, m_lhs, "!=", rhs };
+        }
+
+        template<typename RhsT>
+        auto operator > ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
+            return { static_cast<bool>(m_lhs > rhs), m_lhs, ">", rhs };
+        }
+        template<typename RhsT>
+        auto operator < ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
+            return { static_cast<bool>(m_lhs < rhs), m_lhs, "<", rhs };
+        }
+        template<typename RhsT>
+        auto operator >= ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
+            return { static_cast<bool>(m_lhs >= rhs), m_lhs, ">=", rhs };
+        }
+        template<typename RhsT>
+        auto operator <= ( RhsT const& rhs ) -> BinaryExpr<LhsT, RhsT const&> const {
+            return { static_cast<bool>(m_lhs <= rhs), m_lhs, "<=", rhs };
+        }
+        template <typename RhsT>
+        auto operator | (RhsT const& rhs) -> BinaryExpr<LhsT, RhsT const&> const {
+            return { static_cast<bool>(m_lhs | rhs), m_lhs, "|", rhs };
+        }
+        template <typename RhsT>
+        auto operator & (RhsT const& rhs) -> BinaryExpr<LhsT, RhsT const&> const {
+            return { static_cast<bool>(m_lhs & rhs), m_lhs, "&", rhs };
+        }
+        template <typename RhsT>
+        auto operator ^ (RhsT const& rhs) -> BinaryExpr<LhsT, RhsT const&> const {
+            return { static_cast<bool>(m_lhs ^ rhs), m_lhs, "^", rhs };
+        }
+
+        template<typename RhsT>
+        auto operator && ( RhsT const& ) -> BinaryExpr<LhsT, RhsT const&> const {
+            static_assert(always_false<RhsT>::value,
+            "operator&& is not supported inside assertions, "
+            "wrap the expression inside parentheses, or decompose it");
+        }
+
+        template<typename RhsT>
+        auto operator || ( RhsT const& ) -> BinaryExpr<LhsT, RhsT const&> const {
+            static_assert(always_false<RhsT>::value,
+            "operator|| is not supported inside assertions, "
+            "wrap the expression inside parentheses, or decompose it");
+        }
+
+        auto makeUnaryExpr() const -> UnaryExpr<LhsT> {
+            return UnaryExpr<LhsT>{ m_lhs };
+        }
+    };
+
+    void handleExpression( ITransientExpression const& expr );
+
+    template<typename T>
+    void handleExpression( ExprLhs<T> const& expr ) {
+        handleExpression( expr.makeUnaryExpr() );
     }
 
-    auto operator <=( bool value ) -> ExprLhs<bool> {
-        return ExprLhs<bool>{ value };
-    }
-};
+    struct Decomposer {
+        template<typename T>
+        auto operator <= ( T const& lhs ) -> ExprLhs<T const&> {
+            return ExprLhs<T const&>{ lhs };
+        }
+
+        auto operator <=( bool value ) -> ExprLhs<bool> {
+            return ExprLhs<bool>{ value };
+        }
+    };
 
 } // end namespace Catch
 
@@ -2440,155 +2436,155 @@ struct Decomposer {
 
 namespace Catch {
 
-class AssertionResult;
-struct AssertionInfo;
-struct SectionInfo;
-struct SectionEndInfo;
-struct MessageInfo;
-struct MessageBuilder;
-struct Counts;
-struct AssertionReaction;
-struct SourceLineInfo;
+    class AssertionResult;
+    struct AssertionInfo;
+    struct SectionInfo;
+    struct SectionEndInfo;
+    struct MessageInfo;
+    struct MessageBuilder;
+    struct Counts;
+    struct AssertionReaction;
+    struct SourceLineInfo;
 
-struct ITransientExpression;
-struct IGeneratorTracker;
+    struct ITransientExpression;
+    struct IGeneratorTracker;
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
-struct BenchmarkInfo;
+    struct BenchmarkInfo;
     template <typename Duration = std::chrono::duration<double, std::nano>>
     struct BenchmarkStats;
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-struct IResultCapture {
+    struct IResultCapture {
 
-    virtual ~IResultCapture();
+        virtual ~IResultCapture();
 
-    virtual bool sectionStarted(    SectionInfo const& sectionInfo,
-                                    Counts& assertions ) = 0;
-    virtual void sectionEnded( SectionEndInfo const& endInfo ) = 0;
-    virtual void sectionEndedEarly( SectionEndInfo const& endInfo ) = 0;
+        virtual bool sectionStarted(    SectionInfo const& sectionInfo,
+                                        Counts& assertions ) = 0;
+        virtual void sectionEnded( SectionEndInfo const& endInfo ) = 0;
+        virtual void sectionEndedEarly( SectionEndInfo const& endInfo ) = 0;
 
-    virtual auto acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker& = 0;
+        virtual auto acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker& = 0;
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
-    virtual void benchmarkPreparing( std::string const& name ) = 0;
+        virtual void benchmarkPreparing( std::string const& name ) = 0;
         virtual void benchmarkStarting( BenchmarkInfo const& info ) = 0;
         virtual void benchmarkEnded( BenchmarkStats<> const& stats ) = 0;
         virtual void benchmarkFailed( std::string const& error ) = 0;
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-    virtual void pushScopedMessage( MessageInfo const& message ) = 0;
-    virtual void popScopedMessage( MessageInfo const& message ) = 0;
+        virtual void pushScopedMessage( MessageInfo const& message ) = 0;
+        virtual void popScopedMessage( MessageInfo const& message ) = 0;
 
-    virtual void emplaceUnscopedMessage( MessageBuilder const& builder ) = 0;
+        virtual void emplaceUnscopedMessage( MessageBuilder const& builder ) = 0;
 
-    virtual void handleFatalErrorCondition( StringRef message ) = 0;
+        virtual void handleFatalErrorCondition( StringRef message ) = 0;
 
-    virtual void handleExpr
-        (   AssertionInfo const& info,
-            ITransientExpression const& expr,
-            AssertionReaction& reaction ) = 0;
-    virtual void handleMessage
-        (   AssertionInfo const& info,
-            ResultWas::OfType resultType,
-            StringRef const& message,
-            AssertionReaction& reaction ) = 0;
-    virtual void handleUnexpectedExceptionNotThrown
-        (   AssertionInfo const& info,
-            AssertionReaction& reaction ) = 0;
-    virtual void handleUnexpectedInflightException
-        (   AssertionInfo const& info,
-            std::string const& message,
-            AssertionReaction& reaction ) = 0;
-    virtual void handleIncomplete
-        (   AssertionInfo const& info ) = 0;
-    virtual void handleNonExpr
-        (   AssertionInfo const &info,
-            ResultWas::OfType resultType,
-            AssertionReaction &reaction ) = 0;
+        virtual void handleExpr
+                (   AssertionInfo const& info,
+                    ITransientExpression const& expr,
+                    AssertionReaction& reaction ) = 0;
+        virtual void handleMessage
+                (   AssertionInfo const& info,
+                    ResultWas::OfType resultType,
+                    StringRef const& message,
+                    AssertionReaction& reaction ) = 0;
+        virtual void handleUnexpectedExceptionNotThrown
+                (   AssertionInfo const& info,
+                    AssertionReaction& reaction ) = 0;
+        virtual void handleUnexpectedInflightException
+                (   AssertionInfo const& info,
+                    std::string const& message,
+                    AssertionReaction& reaction ) = 0;
+        virtual void handleIncomplete
+                (   AssertionInfo const& info ) = 0;
+        virtual void handleNonExpr
+                (   AssertionInfo const &info,
+                    ResultWas::OfType resultType,
+                    AssertionReaction &reaction ) = 0;
 
-    virtual bool lastAssertionPassed() = 0;
-    virtual void assertionPassed() = 0;
+        virtual bool lastAssertionPassed() = 0;
+        virtual void assertionPassed() = 0;
 
-    // Deprecated, do not use:
-    virtual std::string getCurrentTestName() const = 0;
-    virtual const AssertionResult* getLastResult() const = 0;
-    virtual void exceptionEarlyReported() = 0;
-};
+        // Deprecated, do not use:
+        virtual std::string getCurrentTestName() const = 0;
+        virtual const AssertionResult* getLastResult() const = 0;
+        virtual void exceptionEarlyReported() = 0;
+    };
 
-IResultCapture& getResultCapture();
+    IResultCapture& getResultCapture();
 }
 
 // end catch_interfaces_capture.h
 namespace Catch {
 
-struct TestFailureException{};
-struct AssertionResultData;
-struct IResultCapture;
-class RunContext;
+    struct TestFailureException{};
+    struct AssertionResultData;
+    struct IResultCapture;
+    class RunContext;
 
-class LazyExpression {
-    friend class AssertionHandler;
-    friend struct AssertionStats;
-    friend class RunContext;
+    class LazyExpression {
+        friend class AssertionHandler;
+        friend struct AssertionStats;
+        friend class RunContext;
 
-    ITransientExpression const* m_transientExpression = nullptr;
-    bool m_isNegated;
-public:
-    LazyExpression( bool isNegated );
-    LazyExpression( LazyExpression const& other );
-    LazyExpression& operator = ( LazyExpression const& ) = delete;
+        ITransientExpression const* m_transientExpression = nullptr;
+        bool m_isNegated;
+    public:
+        LazyExpression( bool isNegated );
+        LazyExpression( LazyExpression const& other );
+        LazyExpression& operator = ( LazyExpression const& ) = delete;
 
-    explicit operator bool() const;
+        explicit operator bool() const;
 
-    friend auto operator << ( std::ostream& os, LazyExpression const& lazyExpr ) -> std::ostream&;
-};
+        friend auto operator << ( std::ostream& os, LazyExpression const& lazyExpr ) -> std::ostream&;
+    };
 
-struct AssertionReaction {
-    bool shouldDebugBreak = false;
-    bool shouldThrow = false;
-};
+    struct AssertionReaction {
+        bool shouldDebugBreak = false;
+        bool shouldThrow = false;
+    };
 
-class AssertionHandler {
-    AssertionInfo m_assertionInfo;
-    AssertionReaction m_reaction;
-    bool m_completed = false;
-    IResultCapture& m_resultCapture;
+    class AssertionHandler {
+        AssertionInfo m_assertionInfo;
+        AssertionReaction m_reaction;
+        bool m_completed = false;
+        IResultCapture& m_resultCapture;
 
-public:
-    AssertionHandler
-        (   StringRef const& macroName,
-            SourceLineInfo const& lineInfo,
-            StringRef capturedExpression,
-            ResultDisposition::Flags resultDisposition );
-    ~AssertionHandler() {
-        if ( !m_completed ) {
-            m_resultCapture.handleIncomplete( m_assertionInfo );
+    public:
+        AssertionHandler
+            (   StringRef const& macroName,
+                SourceLineInfo const& lineInfo,
+                StringRef capturedExpression,
+                ResultDisposition::Flags resultDisposition );
+        ~AssertionHandler() {
+            if ( !m_completed ) {
+                m_resultCapture.handleIncomplete( m_assertionInfo );
+            }
         }
-    }
 
-    template<typename T>
-    void handleExpr( ExprLhs<T> const& expr ) {
-        handleExpr( expr.makeUnaryExpr() );
-    }
-    void handleExpr( ITransientExpression const& expr );
+        template<typename T>
+        void handleExpr( ExprLhs<T> const& expr ) {
+            handleExpr( expr.makeUnaryExpr() );
+        }
+        void handleExpr( ITransientExpression const& expr );
 
-    void handleMessage(ResultWas::OfType resultType, StringRef const& message);
+        void handleMessage(ResultWas::OfType resultType, StringRef const& message);
 
-    void handleExceptionThrownAsExpected();
-    void handleUnexpectedExceptionNotThrown();
-    void handleExceptionNotThrownAsExpected();
-    void handleThrowingCallSkipped();
-    void handleUnexpectedInflightException();
+        void handleExceptionThrownAsExpected();
+        void handleUnexpectedExceptionNotThrown();
+        void handleExceptionNotThrownAsExpected();
+        void handleThrowingCallSkipped();
+        void handleUnexpectedInflightException();
 
-    void complete();
-    void setCompleted();
+        void complete();
+        void setCompleted();
 
-    // query
-    auto allowThrows() const -> bool;
-};
+        // query
+        auto allowThrows() const -> bool;
+    };
 
-void handleExceptionMatchExpr( AssertionHandler& handler, std::string const& str, StringRef const& matcherString );
+    void handleExceptionMatchExpr( AssertionHandler& handler, std::string const& str, StringRef const& matcherString );
 
 } // namespace Catch
 
@@ -2600,80 +2596,80 @@ void handleExceptionMatchExpr( AssertionHandler& handler, std::string const& str
 
 namespace Catch {
 
-struct MessageInfo {
-    MessageInfo(    StringRef const& _macroName,
-                    SourceLineInfo const& _lineInfo,
-                    ResultWas::OfType _type );
+    struct MessageInfo {
+        MessageInfo(    StringRef const& _macroName,
+                        SourceLineInfo const& _lineInfo,
+                        ResultWas::OfType _type );
 
-    StringRef macroName;
-    std::string message;
-    SourceLineInfo lineInfo;
-    ResultWas::OfType type;
-    unsigned int sequence;
+        StringRef macroName;
+        std::string message;
+        SourceLineInfo lineInfo;
+        ResultWas::OfType type;
+        unsigned int sequence;
 
-    bool operator == ( MessageInfo const& other ) const;
-    bool operator < ( MessageInfo const& other ) const;
-private:
-    static unsigned int globalCount;
-};
+        bool operator == ( MessageInfo const& other ) const;
+        bool operator < ( MessageInfo const& other ) const;
+    private:
+        static unsigned int globalCount;
+    };
 
-struct MessageStream {
+    struct MessageStream {
 
-    template<typename T>
-    MessageStream& operator << ( T const& value ) {
-        m_stream << value;
-        return *this;
-    }
+        template<typename T>
+        MessageStream& operator << ( T const& value ) {
+            m_stream << value;
+            return *this;
+        }
 
-    ReusableStringStream m_stream;
-};
+        ReusableStringStream m_stream;
+    };
 
-struct MessageBuilder : MessageStream {
-    MessageBuilder( StringRef const& macroName,
-                    SourceLineInfo const& lineInfo,
-                    ResultWas::OfType type );
+    struct MessageBuilder : MessageStream {
+        MessageBuilder( StringRef const& macroName,
+                        SourceLineInfo const& lineInfo,
+                        ResultWas::OfType type );
 
-    template<typename T>
-    MessageBuilder& operator << ( T const& value ) {
-        m_stream << value;
-        return *this;
-    }
+        template<typename T>
+        MessageBuilder& operator << ( T const& value ) {
+            m_stream << value;
+            return *this;
+        }
 
-    MessageInfo m_info;
-};
+        MessageInfo m_info;
+    };
 
-class ScopedMessage {
-public:
-    explicit ScopedMessage( MessageBuilder const& builder );
-    ScopedMessage( ScopedMessage& duplicate ) = delete;
-    ScopedMessage( ScopedMessage&& old );
-    ~ScopedMessage();
+    class ScopedMessage {
+    public:
+        explicit ScopedMessage( MessageBuilder const& builder );
+        ScopedMessage( ScopedMessage& duplicate ) = delete;
+        ScopedMessage( ScopedMessage&& old );
+        ~ScopedMessage();
 
-    MessageInfo m_info;
-    bool m_moved;
-};
+        MessageInfo m_info;
+        bool m_moved;
+    };
 
-class Capturer {
-    std::vector<MessageInfo> m_messages;
-    IResultCapture& m_resultCapture = getResultCapture();
-    size_t m_captured = 0;
-public:
-    Capturer( StringRef macroName, SourceLineInfo const& lineInfo, ResultWas::OfType resultType, StringRef names );
-    ~Capturer();
+    class Capturer {
+        std::vector<MessageInfo> m_messages;
+        IResultCapture& m_resultCapture = getResultCapture();
+        size_t m_captured = 0;
+    public:
+        Capturer( StringRef macroName, SourceLineInfo const& lineInfo, ResultWas::OfType resultType, StringRef names );
+        ~Capturer();
 
-    void captureValue( size_t index, std::string const& value );
+        void captureValue( size_t index, std::string const& value );
 
-    template<typename T>
-    void captureValues( size_t index, T const& value ) {
-        captureValue( index, Catch::Detail::stringify( value ) );
-    }
+        template<typename T>
+        void captureValues( size_t index, T const& value ) {
+            captureValue( index, Catch::Detail::stringify( value ) );
+        }
 
-    template<typename T, typename... Ts>
-    void captureValues( size_t index, T const& value, Ts const&... values ) {
-        captureValue( index, Catch::Detail::stringify(value) );
-        captureValues( index+1, values... );
-    }
-};
+        template<typename T, typename... Ts>
+        void captureValues( size_t index, T const& value, Ts const&... values ) {
+            captureValue( index, Catch::Detail::stringify(value) );
+            captureValues( index+1, values... );
+        }
+    };
 
 } // end namespace Catch
 
@@ -2681,9 +2677,9 @@ public:
 #if !defined(CATCH_CONFIG_DISABLE)
 
 #if !defined(CATCH_CONFIG_DISABLE_STRINGIFICATION)
-    #define CATCH_INTERNAL_STRINGIFY(...) #__VA_ARGS__
+  #define CATCH_INTERNAL_STRINGIFY(...) #__VA_ARGS__
 #else
-    #define CATCH_INTERNAL_STRINGIFY(...) "Disabled by CATCH_CONFIG_DISABLE_STRINGIFICATION"
+  #define CATCH_INTERNAL_STRINGIFY(...) "Disabled by CATCH_CONFIG_DISABLE_STRINGIFICATION"
 #endif
 
 #if defined(CATCH_CONFIG_FAST_COMPILE) || defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
@@ -2830,30 +2826,30 @@ public:
 
 namespace Catch {
 
-struct Counts {
-    Counts operator - ( Counts const& other ) const;
-    Counts& operator += ( Counts const& other );
+    struct Counts {
+        Counts operator - ( Counts const& other ) const;
+        Counts& operator += ( Counts const& other );
 
-    std::size_t total() const;
-    bool allPassed() const;
-    bool allOk() const;
+        std::size_t total() const;
+        bool allPassed() const;
+        bool allOk() const;
 
-    std::size_t passed = 0;
-    std::size_t failed = 0;
-    std::size_t failedButOk = 0;
-};
+        std::size_t passed = 0;
+        std::size_t failed = 0;
+        std::size_t failedButOk = 0;
+    };
 
-struct Totals {
+    struct Totals {
 
-    Totals operator - ( Totals const& other ) const;
-    Totals& operator += ( Totals const& other );
+        Totals operator - ( Totals const& other ) const;
+        Totals& operator += ( Totals const& other );
 
-    Totals delta( Totals const& prevTotals ) const;
+        Totals delta( Totals const& prevTotals ) const;
 
-    int error = 0;
-    Counts assertions;
-    Counts testCases;
-};
+        int error = 0;
+        Counts assertions;
+        Counts testCases;
+    };
 }
 
 // end catch_totals.h
@@ -2861,27 +2857,27 @@ struct Totals {
 
 namespace Catch {
 
-struct SectionInfo {
-    SectionInfo
-        (   SourceLineInfo const& _lineInfo,
-            std::string const& _name );
+    struct SectionInfo {
+        SectionInfo
+            (   SourceLineInfo const& _lineInfo,
+                std::string const& _name );
 
-    // Deprecated
-    SectionInfo
-        (   SourceLineInfo const& _lineInfo,
-            std::string const& _name,
-            std::string const& ) : SectionInfo( _lineInfo, _name ) {}
+        // Deprecated
+        SectionInfo
+            (   SourceLineInfo const& _lineInfo,
+                std::string const& _name,
+                std::string const& ) : SectionInfo( _lineInfo, _name ) {}
 
-    std::string name;
-    std::string description; // !Deprecated: this will always be empty
-    SourceLineInfo lineInfo;
-};
+        std::string name;
+        std::string description; // !Deprecated: this will always be empty
+        SourceLineInfo lineInfo;
+    };
 
-struct SectionEndInfo {
-    SectionInfo sectionInfo;
-    Counts prevAssertions;
-    double durationInSeconds;
-};
+    struct SectionEndInfo {
+        SectionInfo sectionInfo;
+        Counts prevAssertions;
+        double durationInSeconds;
+    };
 
 } // end namespace Catch
 
@@ -2892,18 +2888,18 @@ struct SectionEndInfo {
 
 namespace Catch {
 
-auto getCurrentNanosecondsSinceEpoch() -> uint64_t;
-auto getEstimatedClockResolution() -> uint64_t;
+    auto getCurrentNanosecondsSinceEpoch() -> uint64_t;
+    auto getEstimatedClockResolution() -> uint64_t;
 
-class Timer {
-    uint64_t m_nanoseconds = 0;
-public:
-    void start();
-    auto getElapsedNanoseconds() const -> uint64_t;
-    auto getElapsedMicroseconds() const -> uint64_t;
-    auto getElapsedMilliseconds() const -> unsigned int;
-    auto getElapsedSeconds() const -> double;
-};
+    class Timer {
+        uint64_t m_nanoseconds = 0;
+    public:
+        void start();
+        auto getElapsedNanoseconds() const -> uint64_t;
+        auto getElapsedMicroseconds() const -> uint64_t;
+        auto getElapsedMilliseconds() const -> unsigned int;
+        auto getElapsedSeconds() const -> double;
+    };
 
 } // namespace Catch
 
@@ -2912,22 +2908,22 @@ public:
 
 namespace Catch {
 
-class Section : NonCopyable {
-public:
-    Section( SectionInfo const& info );
-    ~Section();
+    class Section : NonCopyable {
+    public:
+        Section( SectionInfo const& info );
+        ~Section();
 
-    // This indicates whether the section should be executed or not
-    explicit operator bool() const;
+        // This indicates whether the section should be executed or not
+        explicit operator bool() const;
 
-private:
-    SectionInfo m_info;
+    private:
+        SectionInfo m_info;
 
-    std::string m_name;
-    Counts m_assertions;
-    bool m_sectionIncluded;
-    Timer m_timer;
-};
+        std::string m_name;
+        Counts m_assertions;
+        bool m_sectionIncluded;
+        Timer m_timer;
+    };
 
 } // end namespace Catch
 
@@ -2953,51 +2949,51 @@ private:
 
 namespace Catch {
 
-class TestCase;
-struct ITestCaseRegistry;
-struct IExceptionTranslatorRegistry;
-struct IExceptionTranslator;
-struct IReporterRegistry;
-struct IReporterFactory;
-struct ITagAliasRegistry;
-struct IMutableEnumValuesRegistry;
+    class TestCase;
+    struct ITestCaseRegistry;
+    struct IExceptionTranslatorRegistry;
+    struct IExceptionTranslator;
+    struct IReporterRegistry;
+    struct IReporterFactory;
+    struct ITagAliasRegistry;
+    struct IMutableEnumValuesRegistry;
 
-class StartupExceptionRegistry;
+    class StartupExceptionRegistry;
 
-using IReporterFactoryPtr = std::shared_ptr<IReporterFactory>;
+    using IReporterFactoryPtr = std::shared_ptr<IReporterFactory>;
 
-struct IRegistryHub {
-    virtual ~IRegistryHub();
+    struct IRegistryHub {
+        virtual ~IRegistryHub();
 
-    virtual IReporterRegistry const& getReporterRegistry() const = 0;
-    virtual ITestCaseRegistry const& getTestCaseRegistry() const = 0;
-    virtual ITagAliasRegistry const& getTagAliasRegistry() const = 0;
-    virtual IExceptionTranslatorRegistry const& getExceptionTranslatorRegistry() const = 0;
+        virtual IReporterRegistry const& getReporterRegistry() const = 0;
+        virtual ITestCaseRegistry const& getTestCaseRegistry() const = 0;
+        virtual ITagAliasRegistry const& getTagAliasRegistry() const = 0;
+        virtual IExceptionTranslatorRegistry const& getExceptionTranslatorRegistry() const = 0;
 
-    virtual StartupExceptionRegistry const& getStartupExceptionRegistry() const = 0;
-};
+        virtual StartupExceptionRegistry const& getStartupExceptionRegistry() const = 0;
+    };
 
-struct IMutableRegistryHub {
-    virtual ~IMutableRegistryHub();
-    virtual void registerReporter( std::string const& name, IReporterFactoryPtr const& factory ) = 0;
-    virtual void registerListener( IReporterFactoryPtr const& factory ) = 0;
-    virtual void registerTest( TestCase const& testInfo ) = 0;
-    virtual void registerTranslator( const IExceptionTranslator* translator ) = 0;
-    virtual void registerTagAlias( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo ) = 0;
-    virtual void registerStartupException() noexcept = 0;
-    virtual IMutableEnumValuesRegistry& getMutableEnumValuesRegistry() = 0;
-};
+    struct IMutableRegistryHub {
+        virtual ~IMutableRegistryHub();
+        virtual void registerReporter( std::string const& name, IReporterFactoryPtr const& factory ) = 0;
+        virtual void registerListener( IReporterFactoryPtr const& factory ) = 0;
+        virtual void registerTest( TestCase const& testInfo ) = 0;
+        virtual void registerTranslator( const IExceptionTranslator* translator ) = 0;
+        virtual void registerTagAlias( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo ) = 0;
+        virtual void registerStartupException() noexcept = 0;
+        virtual IMutableEnumValuesRegistry& getMutableEnumValuesRegistry() = 0;
+    };
 
-IRegistryHub const& getRegistryHub();
-IMutableRegistryHub& getMutableRegistryHub();
-void cleanUp();
-std::string translateActiveException();
+    IRegistryHub const& getRegistryHub();
+    IMutableRegistryHub& getMutableRegistryHub();
+    void cleanUp();
+    std::string translateActiveException();
 
 }
 
 // end catch_interfaces_registry_hub.h
 #if defined(CATCH_CONFIG_DISABLE)
-#define INTERNAL_CATCH_TRANSLATE_EXCEPTION_NO_REG( translatorName, signature) \
+    #define INTERNAL_CATCH_TRANSLATE_EXCEPTION_NO_REG( translatorName, signature) \
         static std::string translatorName( signature )
 #endif
 
@@ -3006,58 +3002,58 @@ std::string translateActiveException();
 #include <vector>
 
 namespace Catch {
-using exceptionTranslateFunction = std::string(*)();
+    using exceptionTranslateFunction = std::string(*)();
 
-struct IExceptionTranslator;
-using ExceptionTranslators = std::vector<std::unique_ptr<IExceptionTranslator const>>;
+    struct IExceptionTranslator;
+    using ExceptionTranslators = std::vector<std::unique_ptr<IExceptionTranslator const>>;
 
-struct IExceptionTranslator {
-    virtual ~IExceptionTranslator();
-    virtual std::string translate( ExceptionTranslators::const_iterator it, ExceptionTranslators::const_iterator itEnd ) const = 0;
-};
-
-struct IExceptionTranslatorRegistry {
-    virtual ~IExceptionTranslatorRegistry();
-
-    virtual std::string translateActiveException() const = 0;
-};
-
-class ExceptionTranslatorRegistrar {
-    template<typename T>
-    class ExceptionTranslator : public IExceptionTranslator {
-    public:
-
-        ExceptionTranslator( std::string(*translateFunction)( T& ) )
-            : m_translateFunction( translateFunction )
-        {}
-
-        std::string translate( ExceptionTranslators::const_iterator it, ExceptionTranslators::const_iterator itEnd ) const override {
-#if defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
-            return "";
-#else
-            try {
-                if( it == itEnd )
-                    std::rethrow_exception(std::current_exception());
-                else
-                    return (*it)->translate( it+1, itEnd );
-            }
-            catch( T& ex ) {
-                return m_translateFunction( ex );
-            }
-#endif
-        }
-
-    protected:
-        std::string(*m_translateFunction)( T& );
+    struct IExceptionTranslator {
+        virtual ~IExceptionTranslator();
+        virtual std::string translate( ExceptionTranslators::const_iterator it, ExceptionTranslators::const_iterator itEnd ) const = 0;
     };
 
-public:
-    template<typename T>
-    ExceptionTranslatorRegistrar( std::string(*translateFunction)( T& ) ) {
-        getMutableRegistryHub().registerTranslator
-            ( new ExceptionTranslator<T>( translateFunction ) );
-    }
-};
+    struct IExceptionTranslatorRegistry {
+        virtual ~IExceptionTranslatorRegistry();
+
+        virtual std::string translateActiveException() const = 0;
+    };
+
+    class ExceptionTranslatorRegistrar {
+        template<typename T>
+        class ExceptionTranslator : public IExceptionTranslator {
+        public:
+
+            ExceptionTranslator( std::string(*translateFunction)( T& ) )
+            : m_translateFunction( translateFunction )
+            {}
+
+            std::string translate( ExceptionTranslators::const_iterator it, ExceptionTranslators::const_iterator itEnd ) const override {
+#if defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
+                return "";
+#else
+                try {
+                    if( it == itEnd )
+                        std::rethrow_exception(std::current_exception());
+                    else
+                        return (*it)->translate( it+1, itEnd );
+                }
+                catch( T& ex ) {
+                    return m_translateFunction( ex );
+                }
+#endif
+            }
+
+        protected:
+            std::string(*m_translateFunction)( T& );
+        };
+
+    public:
+        template<typename T>
+        ExceptionTranslatorRegistrar( std::string(*translateFunction)( T& ) ) {
+            getMutableRegistryHub().registerTranslator
+                ( new ExceptionTranslator<T>( translateFunction ) );
+        }
+    };
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -3079,110 +3075,110 @@ public:
 namespace Catch {
 namespace Detail {
 
-class Approx {
-private:
-    bool equalityComparisonImpl(double other) const;
-    // Validates the new margin (margin >= 0)
-    // out-of-line to avoid including stdexcept in the header
-    void setMargin(double margin);
-    // Validates the new epsilon (0 < epsilon < 1)
-    // out-of-line to avoid including stdexcept in the header
-    void setEpsilon(double epsilon);
+    class Approx {
+    private:
+        bool equalityComparisonImpl(double other) const;
+        // Validates the new margin (margin >= 0)
+        // out-of-line to avoid including stdexcept in the header
+        void setMargin(double margin);
+        // Validates the new epsilon (0 < epsilon < 1)
+        // out-of-line to avoid including stdexcept in the header
+        void setEpsilon(double epsilon);
 
-public:
-    explicit Approx ( double value );
+    public:
+        explicit Approx ( double value );
 
-    static Approx custom();
+        static Approx custom();
 
-    Approx operator-() const;
+        Approx operator-() const;
 
-    template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-    Approx operator()( T const& value ) {
-        Approx approx( static_cast<double>(value) );
-        approx.m_epsilon = m_epsilon;
-        approx.m_margin = m_margin;
-        approx.m_scale = m_scale;
-        return approx;
-    }
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        Approx operator()( T const& value ) const {
+            Approx approx( static_cast<double>(value) );
+            approx.m_epsilon = m_epsilon;
+            approx.m_margin = m_margin;
+            approx.m_scale = m_scale;
+            return approx;
+        }
 
-    template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-    explicit Approx( T const& value ): Approx(static_cast<double>(value))
-    {}
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        explicit Approx( T const& value ): Approx(static_cast<double>(value))
+        {}
 
-    template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-    friend bool operator == ( const T& lhs, Approx const& rhs ) {
-        auto lhs_v = static_cast<double>(lhs);
-        return rhs.equalityComparisonImpl(lhs_v);
-    }
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        friend bool operator == ( const T& lhs, Approx const& rhs ) {
+            auto lhs_v = static_cast<double>(lhs);
+            return rhs.equalityComparisonImpl(lhs_v);
+        }
 
-    template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-    friend bool operator == ( Approx const& lhs, const T& rhs ) {
-        return operator==( rhs, lhs );
-    }
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        friend bool operator == ( Approx const& lhs, const T& rhs ) {
+            return operator==( rhs, lhs );
+        }
 
-    template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-    friend bool operator != ( T const& lhs, Approx const& rhs ) {
-        return !operator==( lhs, rhs );
-    }
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        friend bool operator != ( T const& lhs, Approx const& rhs ) {
+            return !operator==( lhs, rhs );
+        }
 
-    template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-    friend bool operator != ( Approx const& lhs, T const& rhs ) {
-        return !operator==( rhs, lhs );
-    }
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        friend bool operator != ( Approx const& lhs, T const& rhs ) {
+            return !operator==( rhs, lhs );
+        }
 
-    template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-    friend bool operator <= ( T const& lhs, Approx const& rhs ) {
-        return static_cast<double>(lhs) < rhs.m_value || lhs == rhs;
-    }
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        friend bool operator <= ( T const& lhs, Approx const& rhs ) {
+            return static_cast<double>(lhs) < rhs.m_value || lhs == rhs;
+        }
 
-    template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-    friend bool operator <= ( Approx const& lhs, T const& rhs ) {
-        return lhs.m_value < static_cast<double>(rhs) || lhs == rhs;
-    }
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        friend bool operator <= ( Approx const& lhs, T const& rhs ) {
+            return lhs.m_value < static_cast<double>(rhs) || lhs == rhs;
+        }
 
-    template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-    friend bool operator >= ( T const& lhs, Approx const& rhs ) {
-        return static_cast<double>(lhs) > rhs.m_value || lhs == rhs;
-    }
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        friend bool operator >= ( T const& lhs, Approx const& rhs ) {
+            return static_cast<double>(lhs) > rhs.m_value || lhs == rhs;
+        }
 
-    template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-    friend bool operator >= ( Approx const& lhs, T const& rhs ) {
-        return lhs.m_value > static_cast<double>(rhs) || lhs == rhs;
-    }
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        friend bool operator >= ( Approx const& lhs, T const& rhs ) {
+            return lhs.m_value > static_cast<double>(rhs) || lhs == rhs;
+        }
 
-    template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-    Approx& epsilon( T const& newEpsilon ) {
-        double epsilonAsDouble = static_cast<double>(newEpsilon);
-        setEpsilon(epsilonAsDouble);
-        return *this;
-    }
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        Approx& epsilon( T const& newEpsilon ) {
+            double epsilonAsDouble = static_cast<double>(newEpsilon);
+            setEpsilon(epsilonAsDouble);
+            return *this;
+        }
 
-    template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-    Approx& margin( T const& newMargin ) {
-        double marginAsDouble = static_cast<double>(newMargin);
-        setMargin(marginAsDouble);
-        return *this;
-    }
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        Approx& margin( T const& newMargin ) {
+            double marginAsDouble = static_cast<double>(newMargin);
+            setMargin(marginAsDouble);
+            return *this;
+        }
 
-    template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-    Approx& scale( T const& newScale ) {
-        m_scale = static_cast<double>(newScale);
-        return *this;
-    }
+        template <typename T, typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+        Approx& scale( T const& newScale ) {
+            m_scale = static_cast<double>(newScale);
+            return *this;
+        }
 
-    std::string toString() const;
+        std::string toString() const;
 
-private:
-    double m_epsilon;
-    double m_margin;
-    double m_scale;
-    double m_value;
-};
+    private:
+        double m_epsilon;
+        double m_margin;
+        double m_scale;
+        double m_value;
+    };
 } // end namespace Detail
 
 namespace literals {
-Detail::Approx operator "" _a(long double val);
-Detail::Approx operator "" _a(unsigned long long val);
+    Detail::Approx operator "" _a(long double val);
+    Detail::Approx operator "" _a(unsigned long long val);
 } // end namespace literals
 
 template<>
@@ -3201,30 +3197,30 @@ struct StringMaker<Catch::Detail::Approx> {
 
 namespace Catch {
 
-bool startsWith( std::string const& s, std::string const& prefix );
-bool startsWith( std::string const& s, char prefix );
-bool endsWith( std::string const& s, std::string const& suffix );
-bool endsWith( std::string const& s, char suffix );
-bool contains( std::string const& s, std::string const& infix );
-void toLowerInPlace( std::string& s );
-std::string toLower( std::string const& s );
-//! Returns a new string without whitespace at the start/end
-std::string trim( std::string const& str );
-//! Returns a substring of the original ref without whitespace. Beware lifetimes!
-StringRef trim(StringRef ref);
+    bool startsWith( std::string const& s, std::string const& prefix );
+    bool startsWith( std::string const& s, char prefix );
+    bool endsWith( std::string const& s, std::string const& suffix );
+    bool endsWith( std::string const& s, char suffix );
+    bool contains( std::string const& s, std::string const& infix );
+    void toLowerInPlace( std::string& s );
+    std::string toLower( std::string const& s );
+    //! Returns a new string without whitespace at the start/end
+    std::string trim( std::string const& str );
+    //! Returns a substring of the original ref without whitespace. Beware lifetimes!
+    StringRef trim(StringRef ref);
 
-// !!! Be aware, returns refs into original string - make sure original string outlives them
-std::vector<StringRef> splitStringRef( StringRef str, char delimiter );
-bool replaceInPlace( std::string& str, std::string const& replaceThis, std::string const& withThis );
+    // !!! Be aware, returns refs into original string - make sure original string outlives them
+    std::vector<StringRef> splitStringRef( StringRef str, char delimiter );
+    bool replaceInPlace( std::string& str, std::string const& replaceThis, std::string const& withThis );
 
-struct pluralise {
-    pluralise( std::size_t count, std::string const& label );
+    struct pluralise {
+        pluralise( std::size_t count, std::string const& label );
 
-    friend std::ostream& operator << ( std::ostream& os, pluralise const& pluraliser );
+        friend std::ostream& operator << ( std::ostream& os, pluralise const& pluraliser );
 
-    std::size_t m_count;
-    std::string m_label;
-};
+        std::size_t m_count;
+        std::string m_label;
+    };
 }
 
 // end catch_string_manip.h
@@ -3238,37 +3234,37 @@ struct pluralise {
 
 namespace Catch {
 namespace Matchers {
-namespace Impl {
+    namespace Impl {
 
-template<typename ArgT> struct MatchAllOf;
-template<typename ArgT> struct MatchAnyOf;
-template<typename ArgT> struct MatchNotOf;
+        template<typename ArgT> struct MatchAllOf;
+        template<typename ArgT> struct MatchAnyOf;
+        template<typename ArgT> struct MatchNotOf;
 
-class MatcherUntypedBase {
-public:
-    MatcherUntypedBase() = default;
-    MatcherUntypedBase ( MatcherUntypedBase const& ) = default;
-    MatcherUntypedBase& operator = ( MatcherUntypedBase const& ) = delete;
-    std::string toString() const;
+        class MatcherUntypedBase {
+        public:
+            MatcherUntypedBase() = default;
+            MatcherUntypedBase ( MatcherUntypedBase const& ) = default;
+            MatcherUntypedBase& operator = ( MatcherUntypedBase const& ) = delete;
+            std::string toString() const;
 
-protected:
-    virtual ~MatcherUntypedBase();
-    virtual std::string describe() const = 0;
-    mutable std::string m_cachedToString;
-};
+        protected:
+            virtual ~MatcherUntypedBase();
+            virtual std::string describe() const = 0;
+            mutable std::string m_cachedToString;
+        };
 
 #ifdef __clang__
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wnon-virtual-dtor"
 #endif
 
-template<typename ObjectT>
-struct MatcherMethod {
-    virtual bool match( ObjectT const& arg ) const = 0;
-};
+        template<typename ObjectT>
+        struct MatcherMethod {
+            virtual bool match( ObjectT const& arg ) const = 0;
+        };
 
 #if defined(__OBJC__)
-// Hack to fix Catch GH issue #1661. Could use id for generic Object support.
+        // Hack to fix Catch GH issue #1661. Could use id for generic Object support.
         // use of const for Object pointers is very uncommon and under ARC it causes some kind of signature mismatch that breaks compilation
         template<>
         struct MatcherMethod<NSString*> {
@@ -3280,111 +3276,111 @@ struct MatcherMethod {
 #    pragma clang diagnostic pop
 #endif
 
-template<typename T>
-struct MatcherBase : MatcherUntypedBase, MatcherMethod<T> {
+        template<typename T>
+        struct MatcherBase : MatcherUntypedBase, MatcherMethod<T> {
 
-    MatchAllOf<T> operator && ( MatcherBase const& other ) const;
-    MatchAnyOf<T> operator || ( MatcherBase const& other ) const;
-    MatchNotOf<T> operator ! () const;
-};
+            MatchAllOf<T> operator && ( MatcherBase const& other ) const;
+            MatchAnyOf<T> operator || ( MatcherBase const& other ) const;
+            MatchNotOf<T> operator ! () const;
+        };
 
-template<typename ArgT>
-struct MatchAllOf : MatcherBase<ArgT> {
-    bool match( ArgT const& arg ) const override {
-        for( auto matcher : m_matchers ) {
-            if (!matcher->match(arg))
-                return false;
-        }
-        return true;
-    }
-    std::string describe() const override {
-        std::string description;
-        description.reserve( 4 + m_matchers.size()*32 );
-        description += "( ";
-        bool first = true;
-        for( auto matcher : m_matchers ) {
-            if( first )
-                first = false;
-            else
-                description += " and ";
-            description += matcher->toString();
-        }
-        description += " )";
-        return description;
-    }
-
-    MatchAllOf<ArgT> operator && ( MatcherBase<ArgT> const& other ) {
-        auto copy(*this);
-        copy.m_matchers.push_back( &other );
-        return copy;
-    }
-
-    std::vector<MatcherBase<ArgT> const*> m_matchers;
-};
-template<typename ArgT>
-struct MatchAnyOf : MatcherBase<ArgT> {
-
-    bool match( ArgT const& arg ) const override {
-        for( auto matcher : m_matchers ) {
-            if (matcher->match(arg))
+        template<typename ArgT>
+        struct MatchAllOf : MatcherBase<ArgT> {
+            bool match( ArgT const& arg ) const override {
+                for( auto matcher : m_matchers ) {
+                    if (!matcher->match(arg))
+                        return false;
+                }
                 return true;
+            }
+            std::string describe() const override {
+                std::string description;
+                description.reserve( 4 + m_matchers.size()*32 );
+                description += "( ";
+                bool first = true;
+                for( auto matcher : m_matchers ) {
+                    if( first )
+                        first = false;
+                    else
+                        description += " and ";
+                    description += matcher->toString();
+                }
+                description += " )";
+                return description;
+            }
+
+            MatchAllOf<ArgT> operator && ( MatcherBase<ArgT> const& other ) {
+                auto copy(*this);
+                copy.m_matchers.push_back( &other );
+                return copy;
+            }
+
+            std::vector<MatcherBase<ArgT> const*> m_matchers;
+        };
+        template<typename ArgT>
+        struct MatchAnyOf : MatcherBase<ArgT> {
+
+            bool match( ArgT const& arg ) const override {
+                for( auto matcher : m_matchers ) {
+                    if (matcher->match(arg))
+                        return true;
+                }
+                return false;
+            }
+            std::string describe() const override {
+                std::string description;
+                description.reserve( 4 + m_matchers.size()*32 );
+                description += "( ";
+                bool first = true;
+                for( auto matcher : m_matchers ) {
+                    if( first )
+                        first = false;
+                    else
+                        description += " or ";
+                    description += matcher->toString();
+                }
+                description += " )";
+                return description;
+            }
+
+            MatchAnyOf<ArgT> operator || ( MatcherBase<ArgT> const& other ) {
+                auto copy(*this);
+                copy.m_matchers.push_back( &other );
+                return copy;
+            }
+
+            std::vector<MatcherBase<ArgT> const*> m_matchers;
+        };
+
+        template<typename ArgT>
+        struct MatchNotOf : MatcherBase<ArgT> {
+
+            MatchNotOf( MatcherBase<ArgT> const& underlyingMatcher ) : m_underlyingMatcher( underlyingMatcher ) {}
+
+            bool match( ArgT const& arg ) const override {
+                return !m_underlyingMatcher.match( arg );
+            }
+
+            std::string describe() const override {
+                return "not " + m_underlyingMatcher.toString();
+            }
+            MatcherBase<ArgT> const& m_underlyingMatcher;
+        };
+
+        template<typename T>
+        MatchAllOf<T> MatcherBase<T>::operator && ( MatcherBase const& other ) const {
+            return MatchAllOf<T>() && *this && other;
         }
-        return false;
-    }
-    std::string describe() const override {
-        std::string description;
-        description.reserve( 4 + m_matchers.size()*32 );
-        description += "( ";
-        bool first = true;
-        for( auto matcher : m_matchers ) {
-            if( first )
-                first = false;
-            else
-                description += " or ";
-            description += matcher->toString();
+        template<typename T>
+        MatchAnyOf<T> MatcherBase<T>::operator || ( MatcherBase const& other ) const {
+            return MatchAnyOf<T>() || *this || other;
         }
-        description += " )";
-        return description;
-    }
+        template<typename T>
+        MatchNotOf<T> MatcherBase<T>::operator ! () const {
+            return MatchNotOf<T>( *this );
+        }
 
-    MatchAnyOf<ArgT> operator || ( MatcherBase<ArgT> const& other ) {
-        auto copy(*this);
-        copy.m_matchers.push_back( &other );
-        return copy;
-    }
-
-    std::vector<MatcherBase<ArgT> const*> m_matchers;
-};
-
-template<typename ArgT>
-struct MatchNotOf : MatcherBase<ArgT> {
-
-    MatchNotOf( MatcherBase<ArgT> const& underlyingMatcher ) : m_underlyingMatcher( underlyingMatcher ) {}
-
-    bool match( ArgT const& arg ) const override {
-        return !m_underlyingMatcher.match( arg );
-    }
-
-    std::string describe() const override {
-        return "not " + m_underlyingMatcher.toString();
-    }
-    MatcherBase<ArgT> const& m_underlyingMatcher;
-};
-
-template<typename T>
-MatchAllOf<T> MatcherBase<T>::operator && ( MatcherBase const& other ) const {
-    return MatchAllOf<T>() && *this && other;
-}
-template<typename T>
-MatchAnyOf<T> MatcherBase<T>::operator || ( MatcherBase const& other ) const {
-    return MatchAnyOf<T>() || *this || other;
-}
-template<typename T>
-MatchNotOf<T> MatcherBase<T>::operator ! () const {
-    return MatchNotOf<T>( *this );
-}
-
-} // namespace Impl
+    } // namespace Impl
 
 } // namespace Matchers
 
@@ -3426,57 +3422,57 @@ Exception::ExceptionMessageMatcher Message(std::string const& message);
 namespace Catch {
 namespace Matchers {
 
-namespace Floating {
+    namespace Floating {
 
-enum class FloatingPointKind : uint8_t;
+        enum class FloatingPointKind : uint8_t;
 
-struct WithinAbsMatcher : MatcherBase<double> {
-    WithinAbsMatcher(double target, double margin);
-    bool match(double const& matchee) const override;
-    std::string describe() const override;
-private:
-    double m_target;
-    double m_margin;
-};
+        struct WithinAbsMatcher : MatcherBase<double> {
+            WithinAbsMatcher(double target, double margin);
+            bool match(double const& matchee) const override;
+            std::string describe() const override;
+        private:
+            double m_target;
+            double m_margin;
+        };
 
-struct WithinUlpsMatcher : MatcherBase<double> {
-    WithinUlpsMatcher(double target, uint64_t ulps, FloatingPointKind baseType);
-    bool match(double const& matchee) const override;
-    std::string describe() const override;
-private:
-    double m_target;
-    uint64_t m_ulps;
-    FloatingPointKind m_type;
-};
+        struct WithinUlpsMatcher : MatcherBase<double> {
+            WithinUlpsMatcher(double target, uint64_t ulps, FloatingPointKind baseType);
+            bool match(double const& matchee) const override;
+            std::string describe() const override;
+        private:
+            double m_target;
+            uint64_t m_ulps;
+            FloatingPointKind m_type;
+        };
 
-// Given IEEE-754 format for floats and doubles, we can assume
-// that float -> double promotion is lossless. Given this, we can
-// assume that if we do the standard relative comparison of
-// |lhs - rhs| <= epsilon * max(fabs(lhs), fabs(rhs)), then we get
-// the same result if we do this for floats, as if we do this for
-// doubles that were promoted from floats.
-struct WithinRelMatcher : MatcherBase<double> {
-    WithinRelMatcher(double target, double epsilon);
-    bool match(double const& matchee) const override;
-    std::string describe() const override;
-private:
-    double m_target;
-    double m_epsilon;
-};
+        // Given IEEE-754 format for floats and doubles, we can assume
+        // that float -> double promotion is lossless. Given this, we can
+        // assume that if we do the standard relative comparison of
+        // |lhs - rhs| <= epsilon * max(fabs(lhs), fabs(rhs)), then we get
+        // the same result if we do this for floats, as if we do this for
+        // doubles that were promoted from floats.
+        struct WithinRelMatcher : MatcherBase<double> {
+            WithinRelMatcher(double target, double epsilon);
+            bool match(double const& matchee) const override;
+            std::string describe() const override;
+        private:
+            double m_target;
+            double m_epsilon;
+        };
 
-} // namespace Floating
+    } // namespace Floating
 
-// The following functions create the actual matcher objects.
-// This allows the types to be inferred
-Floating::WithinUlpsMatcher WithinULP(double target, uint64_t maxUlpDiff);
-Floating::WithinUlpsMatcher WithinULP(float target, uint64_t maxUlpDiff);
-Floating::WithinAbsMatcher WithinAbs(double target, double margin);
-Floating::WithinRelMatcher WithinRel(double target, double eps);
-// defaults epsilon to 100*numeric_limits<double>::epsilon()
-Floating::WithinRelMatcher WithinRel(double target);
-Floating::WithinRelMatcher WithinRel(float target, float eps);
-// defaults epsilon to 100*numeric_limits<float>::epsilon()
-Floating::WithinRelMatcher WithinRel(float target);
+    // The following functions create the actual matcher objects.
+    // This allows the types to be inferred
+    Floating::WithinUlpsMatcher WithinULP(double target, uint64_t maxUlpDiff);
+    Floating::WithinUlpsMatcher WithinULP(float target, uint64_t maxUlpDiff);
+    Floating::WithinAbsMatcher WithinAbs(double target, double margin);
+    Floating::WithinRelMatcher WithinRel(double target, double eps);
+    // defaults epsilon to 100*numeric_limits<double>::epsilon()
+    Floating::WithinRelMatcher WithinRel(double target);
+    Floating::WithinRelMatcher WithinRel(float target, float eps);
+    // defaults epsilon to 100*numeric_limits<float>::epsilon()
+    Floating::WithinRelMatcher WithinRel(float target);
 
 } // namespace Matchers
 } // namespace Catch
@@ -3492,7 +3488,7 @@ namespace Matchers {
 namespace Generic {
 
 namespace Detail {
-std::string finalizeDescription(const std::string& desc);
+    std::string finalizeDescription(const std::string& desc);
 }
 
 template <typename T>
@@ -3503,7 +3499,7 @@ public:
 
     PredicateMatcher(std::function<bool(T const&)> const& elem, std::string const& descr)
         :m_predicate(std::move(elem)),
-         m_description(Detail::finalizeDescription(descr))
+        m_description(Detail::finalizeDescription(descr))
     {}
 
     bool match( T const& item ) const override {
@@ -3517,14 +3513,14 @@ public:
 
 } // namespace Generic
 
-// The following functions create the actual matcher objects.
-// The user has to explicitly specify type to the function, because
-// inferring std::function<bool(T const&)> is hard (but possible) and
-// requires a lot of TMP.
-template<typename T>
-Generic::PredicateMatcher<T> Predicate(std::function<bool(T const&)> const& predicate, std::string const& description = "") {
-    return Generic::PredicateMatcher<T>(predicate, description);
-}
+    // The following functions create the actual matcher objects.
+    // The user has to explicitly specify type to the function, because
+    // inferring std::function<bool(T const&)> is hard (but possible) and
+    // requires a lot of TMP.
+    template<typename T>
+    Generic::PredicateMatcher<T> Predicate(std::function<bool(T const&)> const& predicate, std::string const& description = "") {
+        return Generic::PredicateMatcher<T>(predicate, description);
+    }
 
 } // namespace Matchers
 } // namespace Catch
@@ -3537,63 +3533,63 @@ Generic::PredicateMatcher<T> Predicate(std::function<bool(T const&)> const& pred
 namespace Catch {
 namespace Matchers {
 
-namespace StdString {
+    namespace StdString {
 
-struct CasedString
-{
-    CasedString( std::string const& str, CaseSensitive::Choice caseSensitivity );
-    std::string adjustString( std::string const& str ) const;
-    std::string caseSensitivitySuffix() const;
+        struct CasedString
+        {
+            CasedString( std::string const& str, CaseSensitive::Choice caseSensitivity );
+            std::string adjustString( std::string const& str ) const;
+            std::string caseSensitivitySuffix() const;
 
-    CaseSensitive::Choice m_caseSensitivity;
-    std::string m_str;
-};
+            CaseSensitive::Choice m_caseSensitivity;
+            std::string m_str;
+        };
 
-struct StringMatcherBase : MatcherBase<std::string> {
-    StringMatcherBase( std::string const& operation, CasedString const& comparator );
-    std::string describe() const override;
+        struct StringMatcherBase : MatcherBase<std::string> {
+            StringMatcherBase( std::string const& operation, CasedString const& comparator );
+            std::string describe() const override;
 
-    CasedString m_comparator;
-    std::string m_operation;
-};
+            CasedString m_comparator;
+            std::string m_operation;
+        };
 
-struct EqualsMatcher : StringMatcherBase {
-    EqualsMatcher( CasedString const& comparator );
-    bool match( std::string const& source ) const override;
-};
-struct ContainsMatcher : StringMatcherBase {
-    ContainsMatcher( CasedString const& comparator );
-    bool match( std::string const& source ) const override;
-};
-struct StartsWithMatcher : StringMatcherBase {
-    StartsWithMatcher( CasedString const& comparator );
-    bool match( std::string const& source ) const override;
-};
-struct EndsWithMatcher : StringMatcherBase {
-    EndsWithMatcher( CasedString const& comparator );
-    bool match( std::string const& source ) const override;
-};
+        struct EqualsMatcher : StringMatcherBase {
+            EqualsMatcher( CasedString const& comparator );
+            bool match( std::string const& source ) const override;
+        };
+        struct ContainsMatcher : StringMatcherBase {
+            ContainsMatcher( CasedString const& comparator );
+            bool match( std::string const& source ) const override;
+        };
+        struct StartsWithMatcher : StringMatcherBase {
+            StartsWithMatcher( CasedString const& comparator );
+            bool match( std::string const& source ) const override;
+        };
+        struct EndsWithMatcher : StringMatcherBase {
+            EndsWithMatcher( CasedString const& comparator );
+            bool match( std::string const& source ) const override;
+        };
 
-struct RegexMatcher : MatcherBase<std::string> {
-    RegexMatcher( std::string regex, CaseSensitive::Choice caseSensitivity );
-    bool match( std::string const& matchee ) const override;
-    std::string describe() const override;
+        struct RegexMatcher : MatcherBase<std::string> {
+            RegexMatcher( std::string regex, CaseSensitive::Choice caseSensitivity );
+            bool match( std::string const& matchee ) const override;
+            std::string describe() const override;
 
-private:
-    std::string m_regex;
-    CaseSensitive::Choice m_caseSensitivity;
-};
+        private:
+            std::string m_regex;
+            CaseSensitive::Choice m_caseSensitivity;
+        };
 
-} // namespace StdString
+    } // namespace StdString
 
-// The following functions create the actual matcher objects.
-// This allows the types to be inferred
+    // The following functions create the actual matcher objects.
+    // This allows the types to be inferred
 
-StdString::EqualsMatcher Equals( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
-StdString::ContainsMatcher Contains( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
-StdString::EndsWithMatcher EndsWith( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
-StdString::StartsWithMatcher StartsWith( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
-StdString::RegexMatcher Matches( std::string const& regex, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
+    StdString::EqualsMatcher Equals( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
+    StdString::ContainsMatcher Contains( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
+    StdString::EndsWithMatcher EndsWith( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
+    StdString::StartsWithMatcher StartsWith( std::string const& str, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
+    StdString::RegexMatcher Matches( std::string const& regex, CaseSensitive::Choice caseSensitivity = CaseSensitive::Yes );
 
 } // namespace Matchers
 } // namespace Catch
@@ -3606,163 +3602,163 @@ StdString::RegexMatcher Matches( std::string const& regex, CaseSensitive::Choice
 namespace Catch {
 namespace Matchers {
 
-namespace Vector {
-template<typename T, typename Alloc>
-struct ContainsElementMatcher : MatcherBase<std::vector<T, Alloc>> {
+    namespace Vector {
+        template<typename T, typename Alloc>
+        struct ContainsElementMatcher : MatcherBase<std::vector<T, Alloc>> {
 
-    ContainsElementMatcher(T const &comparator) : m_comparator( comparator) {}
+            ContainsElementMatcher(T const &comparator) : m_comparator( comparator) {}
 
-    bool match(std::vector<T, Alloc> const &v) const override {
-        for (auto const& el : v) {
-            if (el == m_comparator) {
+            bool match(std::vector<T, Alloc> const &v) const override {
+                for (auto const& el : v) {
+                    if (el == m_comparator) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            std::string describe() const override {
+                return "Contains: " + ::Catch::Detail::stringify( m_comparator );
+            }
+
+            T const& m_comparator;
+        };
+
+        template<typename T, typename AllocComp, typename AllocMatch>
+        struct ContainsMatcher : MatcherBase<std::vector<T, AllocMatch>> {
+
+            ContainsMatcher(std::vector<T, AllocComp> const &comparator) : m_comparator( comparator ) {}
+
+            bool match(std::vector<T, AllocMatch> const &v) const override {
+                // !TBD: see note in EqualsMatcher
+                if (m_comparator.size() > v.size())
+                    return false;
+                for (auto const& comparator : m_comparator) {
+                    auto present = false;
+                    for (const auto& el : v) {
+                        if (el == comparator) {
+                            present = true;
+                            break;
+                        }
+                    }
+                    if (!present) {
+                        return false;
+                    }
+                }
                 return true;
             }
-        }
-        return false;
-    }
+            std::string describe() const override {
+                return "Contains: " + ::Catch::Detail::stringify( m_comparator );
+            }
 
-    std::string describe() const override {
-        return "Contains: " + ::Catch::Detail::stringify( m_comparator );
-    }
+            std::vector<T, AllocComp> const& m_comparator;
+        };
 
-    T const& m_comparator;
-};
+        template<typename T, typename AllocComp, typename AllocMatch>
+        struct EqualsMatcher : MatcherBase<std::vector<T, AllocMatch>> {
 
-template<typename T, typename AllocComp, typename AllocMatch>
-struct ContainsMatcher : MatcherBase<std::vector<T, AllocMatch>> {
+            EqualsMatcher(std::vector<T, AllocComp> const &comparator) : m_comparator( comparator ) {}
 
-    ContainsMatcher(std::vector<T, AllocComp> const &comparator) : m_comparator( comparator ) {}
+            bool match(std::vector<T, AllocMatch> const &v) const override {
+                // !TBD: This currently works if all elements can be compared using !=
+                // - a more general approach would be via a compare template that defaults
+                // to using !=. but could be specialised for, e.g. std::vector<T, Alloc> etc
+                // - then just call that directly
+                if (m_comparator.size() != v.size())
+                    return false;
+                for (std::size_t i = 0; i < v.size(); ++i)
+                    if (m_comparator[i] != v[i])
+                        return false;
+                return true;
+            }
+            std::string describe() const override {
+                return "Equals: " + ::Catch::Detail::stringify( m_comparator );
+            }
+            std::vector<T, AllocComp> const& m_comparator;
+        };
 
-    bool match(std::vector<T, AllocMatch> const &v) const override {
-        // !TBD: see note in EqualsMatcher
-        if (m_comparator.size() > v.size())
-            return false;
-        for (auto const& comparator : m_comparator) {
-            auto present = false;
-            for (const auto& el : v) {
-                if (el == comparator) {
-                    present = true;
-                    break;
+        template<typename T, typename AllocComp, typename AllocMatch>
+        struct ApproxMatcher : MatcherBase<std::vector<T, AllocMatch>> {
+
+            ApproxMatcher(std::vector<T, AllocComp> const& comparator) : m_comparator( comparator ) {}
+
+            bool match(std::vector<T, AllocMatch> const &v) const override {
+                if (m_comparator.size() != v.size())
+                    return false;
+                for (std::size_t i = 0; i < v.size(); ++i)
+                    if (m_comparator[i] != approx(v[i]))
+                        return false;
+                return true;
+            }
+            std::string describe() const override {
+                return "is approx: " + ::Catch::Detail::stringify( m_comparator );
+            }
+            template <typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            ApproxMatcher& epsilon( T const& newEpsilon ) {
+                approx.epsilon(newEpsilon);
+                return *this;
+            }
+            template <typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            ApproxMatcher& margin( T const& newMargin ) {
+                approx.margin(newMargin);
+                return *this;
+            }
+            template <typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
+            ApproxMatcher& scale( T const& newScale ) {
+                approx.scale(newScale);
+                return *this;
+            }
+
+            std::vector<T, AllocComp> const& m_comparator;
+            mutable Catch::Detail::Approx approx = Catch::Detail::Approx::custom();
+        };
+
+        template<typename T, typename AllocComp, typename AllocMatch>
+        struct UnorderedEqualsMatcher : MatcherBase<std::vector<T, AllocMatch>> {
+            UnorderedEqualsMatcher(std::vector<T, AllocComp> const& target) : m_target(target) {}
+            bool match(std::vector<T, AllocMatch> const& vec) const override {
+                if (m_target.size() != vec.size()) {
+                    return false;
                 }
+                return std::is_permutation(m_target.begin(), m_target.end(), vec.begin());
             }
-            if (!present) {
-                return false;
+
+            std::string describe() const override {
+                return "UnorderedEquals: " + ::Catch::Detail::stringify(m_target);
             }
-        }
-        return true;
-    }
-    std::string describe() const override {
-        return "Contains: " + ::Catch::Detail::stringify( m_comparator );
-    }
+        private:
+            std::vector<T, AllocComp> const& m_target;
+        };
 
-    std::vector<T, AllocComp> const& m_comparator;
-};
+    } // namespace Vector
 
-template<typename T, typename AllocComp, typename AllocMatch>
-struct EqualsMatcher : MatcherBase<std::vector<T, AllocMatch>> {
+    // The following functions create the actual matcher objects.
+    // This allows the types to be inferred
 
-    EqualsMatcher(std::vector<T, AllocComp> const &comparator) : m_comparator( comparator ) {}
-
-    bool match(std::vector<T, AllocMatch> const &v) const override {
-        // !TBD: This currently works if all elements can be compared using !=
-        // - a more general approach would be via a compare template that defaults
-        // to using !=. but could be specialised for, e.g. std::vector<T, Alloc> etc
-        // - then just call that directly
-        if (m_comparator.size() != v.size())
-            return false;
-        for (std::size_t i = 0; i < v.size(); ++i)
-            if (m_comparator[i] != v[i])
-                return false;
-        return true;
-    }
-    std::string describe() const override {
-        return "Equals: " + ::Catch::Detail::stringify( m_comparator );
-    }
-    std::vector<T, AllocComp> const& m_comparator;
-};
-
-template<typename T, typename AllocComp, typename AllocMatch>
-struct ApproxMatcher : MatcherBase<std::vector<T, AllocMatch>> {
-
-    ApproxMatcher(std::vector<T, AllocComp> const& comparator) : m_comparator( comparator ) {}
-
-    bool match(std::vector<T, AllocMatch> const &v) const override {
-        if (m_comparator.size() != v.size())
-            return false;
-        for (std::size_t i = 0; i < v.size(); ++i)
-            if (m_comparator[i] != approx(v[i]))
-                return false;
-        return true;
-    }
-    std::string describe() const override {
-        return "is approx: " + ::Catch::Detail::stringify( m_comparator );
-    }
-    template <typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-    ApproxMatcher& epsilon( T const& newEpsilon ) {
-        approx.epsilon(newEpsilon);
-        return *this;
-    }
-    template <typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-    ApproxMatcher& margin( T const& newMargin ) {
-        approx.margin(newMargin);
-        return *this;
-    }
-    template <typename = typename std::enable_if<std::is_constructible<double, T>::value>::type>
-    ApproxMatcher& scale( T const& newScale ) {
-        approx.scale(newScale);
-        return *this;
+    template<typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
+    Vector::ContainsMatcher<T, AllocComp, AllocMatch> Contains( std::vector<T, AllocComp> const& comparator ) {
+        return Vector::ContainsMatcher<T, AllocComp, AllocMatch>( comparator );
     }
 
-    std::vector<T, AllocComp> const& m_comparator;
-    mutable Catch::Detail::Approx approx = Catch::Detail::Approx::custom();
-};
-
-template<typename T, typename AllocComp, typename AllocMatch>
-struct UnorderedEqualsMatcher : MatcherBase<std::vector<T, AllocMatch>> {
-    UnorderedEqualsMatcher(std::vector<T, AllocComp> const& target) : m_target(target) {}
-    bool match(std::vector<T, AllocMatch> const& vec) const override {
-        if (m_target.size() != vec.size()) {
-            return false;
-        }
-        return std::is_permutation(m_target.begin(), m_target.end(), vec.begin());
+    template<typename T, typename Alloc = std::allocator<T>>
+    Vector::ContainsElementMatcher<T, Alloc> VectorContains( T const& comparator ) {
+        return Vector::ContainsElementMatcher<T, Alloc>( comparator );
     }
 
-    std::string describe() const override {
-        return "UnorderedEquals: " + ::Catch::Detail::stringify(m_target);
+    template<typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
+    Vector::EqualsMatcher<T, AllocComp, AllocMatch> Equals( std::vector<T, AllocComp> const& comparator ) {
+        return Vector::EqualsMatcher<T, AllocComp, AllocMatch>( comparator );
     }
-private:
-    std::vector<T, AllocComp> const& m_target;
-};
 
-} // namespace Vector
+    template<typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
+    Vector::ApproxMatcher<T, AllocComp, AllocMatch> Approx( std::vector<T, AllocComp> const& comparator ) {
+        return Vector::ApproxMatcher<T, AllocComp, AllocMatch>( comparator );
+    }
 
-// The following functions create the actual matcher objects.
-// This allows the types to be inferred
-
-template<typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
-Vector::ContainsMatcher<T, AllocComp, AllocMatch> Contains( std::vector<T, AllocComp> const& comparator ) {
-    return Vector::ContainsMatcher<T, AllocComp, AllocMatch>( comparator );
-}
-
-template<typename T, typename Alloc = std::allocator<T>>
-Vector::ContainsElementMatcher<T, Alloc> VectorContains( T const& comparator ) {
-    return Vector::ContainsElementMatcher<T, Alloc>( comparator );
-}
-
-template<typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
-Vector::EqualsMatcher<T, AllocComp, AllocMatch> Equals( std::vector<T, AllocComp> const& comparator ) {
-    return Vector::EqualsMatcher<T, AllocComp, AllocMatch>( comparator );
-}
-
-template<typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
-Vector::ApproxMatcher<T, AllocComp, AllocMatch> Approx( std::vector<T, AllocComp> const& comparator ) {
-    return Vector::ApproxMatcher<T, AllocComp, AllocMatch>( comparator );
-}
-
-template<typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
-Vector::UnorderedEqualsMatcher<T, AllocComp, AllocMatch> UnorderedEquals(std::vector<T, AllocComp> const& target) {
-    return Vector::UnorderedEqualsMatcher<T, AllocComp, AllocMatch>( target );
-}
+    template<typename T, typename AllocComp = std::allocator<T>, typename AllocMatch = AllocComp>
+    Vector::UnorderedEqualsMatcher<T, AllocComp, AllocMatch> UnorderedEquals(std::vector<T, AllocComp> const& target) {
+        return Vector::UnorderedEqualsMatcher<T, AllocComp, AllocMatch>( target );
+    }
 
 } // namespace Matchers
 } // namespace Catch
@@ -3770,37 +3766,37 @@ Vector::UnorderedEqualsMatcher<T, AllocComp, AllocMatch> UnorderedEquals(std::ve
 // end catch_matchers_vector.h
 namespace Catch {
 
-template<typename ArgT, typename MatcherT>
-class MatchExpr : public ITransientExpression {
-    ArgT const& m_arg;
-    MatcherT m_matcher;
-    StringRef m_matcherString;
-public:
-    MatchExpr( ArgT const& arg, MatcherT const& matcher, StringRef const& matcherString )
+    template<typename ArgT, typename MatcherT>
+    class MatchExpr : public ITransientExpression {
+        ArgT const& m_arg;
+        MatcherT m_matcher;
+        StringRef m_matcherString;
+    public:
+        MatchExpr( ArgT const& arg, MatcherT const& matcher, StringRef const& matcherString )
         :   ITransientExpression{ true, matcher.match( arg ) },
             m_arg( arg ),
             m_matcher( matcher ),
             m_matcherString( matcherString )
-    {}
+        {}
 
-    void streamReconstructedExpression( std::ostream &os ) const override {
-        auto matcherAsString = m_matcher.toString();
-        os << Catch::Detail::stringify( m_arg ) << ' ';
-        if( matcherAsString == Detail::unprintableString )
-            os << m_matcherString;
-        else
-            os << matcherAsString;
+        void streamReconstructedExpression( std::ostream &os ) const override {
+            auto matcherAsString = m_matcher.toString();
+            os << Catch::Detail::stringify( m_arg ) << ' ';
+            if( matcherAsString == Detail::unprintableString )
+                os << m_matcherString;
+            else
+                os << matcherAsString;
+        }
+    };
+
+    using StringMatcher = Matchers::Impl::MatcherBase<std::string>;
+
+    void handleExceptionMatchExpr( AssertionHandler& handler, StringMatcher const& matcher, StringRef const& matcherString  );
+
+    template<typename ArgT, typename MatcherT>
+    auto makeMatchExpr( ArgT const& arg, MatcherT const& matcher, StringRef const& matcherString  ) -> MatchExpr<ArgT, MatcherT> {
+        return MatchExpr<ArgT, MatcherT>( arg, matcher, matcherString );
     }
-};
-
-using StringMatcher = Matchers::Impl::MatcherBase<std::string>;
-
-void handleExceptionMatchExpr( AssertionHandler& handler, StringMatcher const& matcher, StringRef const& matcherString  );
-
-template<typename ArgT, typename MatcherT>
-auto makeMatchExpr( ArgT const& arg, MatcherT const& matcher, StringRef const& matcherString  ) -> MatchExpr<ArgT, MatcherT> {
-    return MatchExpr<ArgT, MatcherT>( arg, matcher, matcherString );
-}
 
 } // namespace Catch
 
@@ -3845,27 +3841,27 @@ auto makeMatchExpr( ArgT const& arg, MatcherT const& matcher, StringRef const& m
 
 namespace Catch {
 
-namespace Generators {
-class GeneratorUntypedBase {
-public:
-    GeneratorUntypedBase() = default;
-    virtual ~GeneratorUntypedBase();
-    // Attempts to move the generator to the next element
-    //
-    // Returns true iff the move succeeded (and a valid element
-    // can be retrieved).
-    virtual bool next() = 0;
-};
-using GeneratorBasePtr = std::unique_ptr<GeneratorUntypedBase>;
+    namespace Generators {
+        class GeneratorUntypedBase {
+        public:
+            GeneratorUntypedBase() = default;
+            virtual ~GeneratorUntypedBase();
+            // Attempts to move the generator to the next element
+             //
+             // Returns true iff the move succeeded (and a valid element
+             // can be retrieved).
+            virtual bool next() = 0;
+        };
+        using GeneratorBasePtr = std::unique_ptr<GeneratorUntypedBase>;
 
-} // namespace Generators
+    } // namespace Generators
 
-struct IGeneratorTracker {
-    virtual ~IGeneratorTracker();
-    virtual auto hasGenerator() const -> bool = 0;
-    virtual auto getGenerator() const -> Generators::GeneratorBasePtr const& = 0;
-    virtual void setGenerator( Generators::GeneratorBasePtr&& generator ) = 0;
-};
+    struct IGeneratorTracker {
+        virtual ~IGeneratorTracker();
+        virtual auto hasGenerator() const -> bool = 0;
+        virtual auto getGenerator() const -> Generators::GeneratorBasePtr const& = 0;
+        virtual void setGenerator( Generators::GeneratorBasePtr&& generator ) = 0;
+    };
 
 } // namespace Catch
 
@@ -3876,22 +3872,22 @@ struct IGeneratorTracker {
 
 namespace Catch {
 #if !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
-template <typename Ex>
-[[noreturn]]
-void throw_exception(Ex const& e) {
-    throw e;
-}
+    template <typename Ex>
+    [[noreturn]]
+    void throw_exception(Ex const& e) {
+        throw e;
+    }
 #else // ^^ Exceptions are enabled //  Exceptions are disabled vv
-[[noreturn]]
+    [[noreturn]]
     void throw_exception(std::exception const& e);
 #endif
 
-[[noreturn]]
-void throw_logic_error(std::string const& msg);
-[[noreturn]]
-void throw_domain_error(std::string const& msg);
-[[noreturn]]
-void throw_runtime_error(std::string const& msg);
+    [[noreturn]]
+    void throw_logic_error(std::string const& msg);
+    [[noreturn]]
+    void throw_domain_error(std::string const& msg);
+    [[noreturn]]
+    void throw_runtime_error(std::string const& msg);
 
 } // namespace Catch;
 
@@ -3933,170 +3929,170 @@ public:
 
 namespace Generators {
 
-// !TBD move this into its own location?
-namespace pf{
-template<typename T, typename... Args>
-std::unique_ptr<T> make_unique( Args&&... args ) {
-    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
-}
-
-template<typename T>
-struct IGenerator : GeneratorUntypedBase {
-    virtual ~IGenerator() = default;
-
-    // Returns the current element of the generator
-    //
-    // \Precondition The generator is either freshly constructed,
-    // or the last call to `next()` returned true
-    virtual T const& get() const = 0;
-    using type = T;
-};
-
-template<typename T>
-class SingleValueGenerator final : public IGenerator<T> {
-    T m_value;
-public:
-    SingleValueGenerator(T&& value) : m_value(std::move(value)) {}
-
-    T const& get() const override {
-        return m_value;
-    }
-    bool next() override {
-        return false;
-    }
-};
-
-template<typename T>
-class FixedValuesGenerator final : public IGenerator<T> {
-    static_assert(!std::is_same<T, bool>::value,
-                  "FixedValuesGenerator does not support bools because of std::vector<bool>"
-                  "specialization, use SingleValue Generator instead.");
-    std::vector<T> m_values;
-    size_t m_idx = 0;
-public:
-    FixedValuesGenerator( std::initializer_list<T> values ) : m_values( values ) {}
-
-    T const& get() const override {
-        return m_values[m_idx];
-    }
-    bool next() override {
-        ++m_idx;
-        return m_idx < m_values.size();
-    }
-};
-
-template <typename T>
-class GeneratorWrapper final {
-    std::unique_ptr<IGenerator<T>> m_generator;
-public:
-    GeneratorWrapper(std::unique_ptr<IGenerator<T>> generator):
-        m_generator(std::move(generator))
-    {}
-    T const& get() const {
-        return m_generator->get();
-    }
-    bool next() {
-        return m_generator->next();
-    }
-};
-
-template <typename T>
-GeneratorWrapper<T> value(T&& value) {
-    return GeneratorWrapper<T>(pf::make_unique<SingleValueGenerator<T>>(std::forward<T>(value)));
-}
-template <typename T>
-GeneratorWrapper<T> values(std::initializer_list<T> values) {
-    return GeneratorWrapper<T>(pf::make_unique<FixedValuesGenerator<T>>(values));
-}
-
-template<typename T>
-class Generators : public IGenerator<T> {
-    std::vector<GeneratorWrapper<T>> m_generators;
-    size_t m_current = 0;
-
-    void populate(GeneratorWrapper<T>&& generator) {
-        m_generators.emplace_back(std::move(generator));
-    }
-    void populate(T&& val) {
-        m_generators.emplace_back(value(std::forward<T>(val)));
-    }
-    template<typename U>
-    void populate(U&& val) {
-        populate(T(std::forward<U>(val)));
-    }
-    template<typename U, typename... Gs>
-    void populate(U&& valueOrGenerator, Gs &&... moreGenerators) {
-        populate(std::forward<U>(valueOrGenerator));
-        populate(std::forward<Gs>(moreGenerators)...);
+    // !TBD move this into its own location?
+    namespace pf{
+        template<typename T, typename... Args>
+        std::unique_ptr<T> make_unique( Args&&... args ) {
+            return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+        }
     }
 
-public:
-    template <typename... Gs>
-    Generators(Gs &&... moreGenerators) {
-        m_generators.reserve(sizeof...(Gs));
-        populate(std::forward<Gs>(moreGenerators)...);
-    }
+    template<typename T>
+    struct IGenerator : GeneratorUntypedBase {
+        virtual ~IGenerator() = default;
 
-    T const& get() const override {
-        return m_generators[m_current].get();
-    }
+        // Returns the current element of the generator
+        //
+        // \Precondition The generator is either freshly constructed,
+        // or the last call to `next()` returned true
+        virtual T const& get() const = 0;
+        using type = T;
+    };
 
-    bool next() override {
-        if (m_current >= m_generators.size()) {
+    template<typename T>
+    class SingleValueGenerator final : public IGenerator<T> {
+        T m_value;
+    public:
+        SingleValueGenerator(T&& value) : m_value(std::move(value)) {}
+
+        T const& get() const override {
+            return m_value;
+        }
+        bool next() override {
             return false;
         }
-        const bool current_status = m_generators[m_current].next();
-        if (!current_status) {
-            ++m_current;
+    };
+
+    template<typename T>
+    class FixedValuesGenerator final : public IGenerator<T> {
+        static_assert(!std::is_same<T, bool>::value,
+            "FixedValuesGenerator does not support bools because of std::vector<bool>"
+            "specialization, use SingleValue Generator instead.");
+        std::vector<T> m_values;
+        size_t m_idx = 0;
+    public:
+        FixedValuesGenerator( std::initializer_list<T> values ) : m_values( values ) {}
+
+        T const& get() const override {
+            return m_values[m_idx];
         }
-        return m_current < m_generators.size();
+        bool next() override {
+            ++m_idx;
+            return m_idx < m_values.size();
+        }
+    };
+
+    template <typename T>
+    class GeneratorWrapper final {
+        std::unique_ptr<IGenerator<T>> m_generator;
+    public:
+        GeneratorWrapper(std::unique_ptr<IGenerator<T>> generator):
+            m_generator(std::move(generator))
+        {}
+        T const& get() const {
+            return m_generator->get();
+        }
+        bool next() {
+            return m_generator->next();
+        }
+    };
+
+    template <typename T>
+    GeneratorWrapper<T> value(T&& value) {
+        return GeneratorWrapper<T>(pf::make_unique<SingleValueGenerator<T>>(std::forward<T>(value)));
     }
-};
-
-template<typename... Ts>
-GeneratorWrapper<std::tuple<Ts...>> table( std::initializer_list<std::tuple<typename std::decay<Ts>::type...>> tuples ) {
-    return values<std::tuple<Ts...>>( tuples );
-}
-
-// Tag type to signal that a generator sequence should convert arguments to a specific type
-template <typename T>
-struct as {};
-
-template<typename T, typename... Gs>
-auto makeGenerators( GeneratorWrapper<T>&& generator, Gs &&... moreGenerators ) -> Generators<T> {
-    return Generators<T>(std::move(generator), std::forward<Gs>(moreGenerators)...);
-}
-template<typename T>
-auto makeGenerators( GeneratorWrapper<T>&& generator ) -> Generators<T> {
-    return Generators<T>(std::move(generator));
-}
-template<typename T, typename... Gs>
-auto makeGenerators( T&& val, Gs &&... moreGenerators ) -> Generators<T> {
-    return makeGenerators( value( std::forward<T>( val ) ), std::forward<Gs>( moreGenerators )... );
-}
-template<typename T, typename U, typename... Gs>
-auto makeGenerators( as<T>, U&& val, Gs &&... moreGenerators ) -> Generators<T> {
-    return makeGenerators( value( T( std::forward<U>( val ) ) ), std::forward<Gs>( moreGenerators )... );
-}
-
-auto acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker&;
-
-template<typename L>
-// Note: The type after -> is weird, because VS2015 cannot parse
-//       the expression used in the typedef inside, when it is in
-//       return type. Yeah.
-auto generate( StringRef generatorName, SourceLineInfo const& lineInfo, L const& generatorExpression ) -> decltype(std::declval<decltype(generatorExpression())>().get()) {
-    using UnderlyingType = typename decltype(generatorExpression())::type;
-
-    IGeneratorTracker& tracker = acquireGeneratorTracker( generatorName, lineInfo );
-    if (!tracker.hasGenerator()) {
-        tracker.setGenerator(pf::make_unique<Generators<UnderlyingType>>(generatorExpression()));
+    template <typename T>
+    GeneratorWrapper<T> values(std::initializer_list<T> values) {
+        return GeneratorWrapper<T>(pf::make_unique<FixedValuesGenerator<T>>(values));
     }
 
-    auto const& generator = static_cast<IGenerator<UnderlyingType> const&>( *tracker.getGenerator() );
-    return generator.get();
-}
+    template<typename T>
+    class Generators : public IGenerator<T> {
+        std::vector<GeneratorWrapper<T>> m_generators;
+        size_t m_current = 0;
+
+        void populate(GeneratorWrapper<T>&& generator) {
+            m_generators.emplace_back(std::move(generator));
+        }
+        void populate(T&& val) {
+            m_generators.emplace_back(value(std::forward<T>(val)));
+        }
+        template<typename U>
+        void populate(U&& val) {
+            populate(T(std::forward<U>(val)));
+        }
+        template<typename U, typename... Gs>
+        void populate(U&& valueOrGenerator, Gs &&... moreGenerators) {
+            populate(std::forward<U>(valueOrGenerator));
+            populate(std::forward<Gs>(moreGenerators)...);
+        }
+
+    public:
+        template <typename... Gs>
+        Generators(Gs &&... moreGenerators) {
+            m_generators.reserve(sizeof...(Gs));
+            populate(std::forward<Gs>(moreGenerators)...);
+        }
+
+        T const& get() const override {
+            return m_generators[m_current].get();
+        }
+
+        bool next() override {
+            if (m_current >= m_generators.size()) {
+                return false;
+            }
+            const bool current_status = m_generators[m_current].next();
+            if (!current_status) {
+                ++m_current;
+            }
+            return m_current < m_generators.size();
+        }
+    };
+
+    template<typename... Ts>
+    GeneratorWrapper<std::tuple<Ts...>> table( std::initializer_list<std::tuple<typename std::decay<Ts>::type...>> tuples ) {
+        return values<std::tuple<Ts...>>( tuples );
+    }
+
+    // Tag type to signal that a generator sequence should convert arguments to a specific type
+    template <typename T>
+    struct as {};
+
+    template<typename T, typename... Gs>
+    auto makeGenerators( GeneratorWrapper<T>&& generator, Gs &&... moreGenerators ) -> Generators<T> {
+        return Generators<T>(std::move(generator), std::forward<Gs>(moreGenerators)...);
+    }
+    template<typename T>
+    auto makeGenerators( GeneratorWrapper<T>&& generator ) -> Generators<T> {
+        return Generators<T>(std::move(generator));
+    }
+    template<typename T, typename... Gs>
+    auto makeGenerators( T&& val, Gs &&... moreGenerators ) -> Generators<T> {
+        return makeGenerators( value( std::forward<T>( val ) ), std::forward<Gs>( moreGenerators )... );
+    }
+    template<typename T, typename U, typename... Gs>
+    auto makeGenerators( as<T>, U&& val, Gs &&... moreGenerators ) -> Generators<T> {
+        return makeGenerators( value( T( std::forward<U>( val ) ) ), std::forward<Gs>( moreGenerators )... );
+    }
+
+    auto acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker&;
+
+    template<typename L>
+    // Note: The type after -> is weird, because VS2015 cannot parse
+    //       the expression used in the typedef inside, when it is in
+    //       return type. Yeah.
+    auto generate( StringRef generatorName, SourceLineInfo const& lineInfo, L const& generatorExpression ) -> decltype(std::declval<decltype(generatorExpression())>().get()) {
+        using UnderlyingType = typename decltype(generatorExpression())::type;
+
+        IGeneratorTracker& tracker = acquireGeneratorTracker( generatorName, lineInfo );
+        if (!tracker.hasGenerator()) {
+            tracker.setGenerator(pf::make_unique<Generators<UnderlyingType>>(generatorExpression()));
+        }
+
+        auto const& generator = static_cast<IGenerator<UnderlyingType> const&>( *tracker.getGenerator() );
+        return generator.get();
+    }
 
 } // namespace Generators
 } // namespace Catch
@@ -4120,220 +4116,225 @@ auto generate( StringRef generatorName, SourceLineInfo const& lineInfo, L const&
 namespace Catch {
 namespace Generators {
 
-template <typename T>
-class TakeGenerator : public IGenerator<T> {
-    GeneratorWrapper<T> m_generator;
-    size_t m_returned = 0;
-    size_t m_target;
-public:
-    TakeGenerator(size_t target, GeneratorWrapper<T>&& generator):
-        m_generator(std::move(generator)),
-        m_target(target)
-    {
-        assert(target != 0 && "Empty generators are not allowed");
-    }
-    T const& get() const override {
-        return m_generator.get();
-    }
-    bool next() override {
-        ++m_returned;
-        if (m_returned >= m_target) {
-            return false;
+    template <typename T>
+    class TakeGenerator : public IGenerator<T> {
+        GeneratorWrapper<T> m_generator;
+        size_t m_returned = 0;
+        size_t m_target;
+    public:
+        TakeGenerator(size_t target, GeneratorWrapper<T>&& generator):
+            m_generator(std::move(generator)),
+            m_target(target)
+        {
+            assert(target != 0 && "Empty generators are not allowed");
         }
-
-        const auto success = m_generator.next();
-        // If the underlying generator does not contain enough values
-        // then we cut short as well
-        if (!success) {
-            m_returned = m_target;
+        T const& get() const override {
+            return m_generator.get();
         }
-        return success;
+        bool next() override {
+            ++m_returned;
+            if (m_returned >= m_target) {
+                return false;
+            }
+
+            const auto success = m_generator.next();
+            // If the underlying generator does not contain enough values
+            // then we cut short as well
+            if (!success) {
+                m_returned = m_target;
+            }
+            return success;
+        }
+    };
+
+    template <typename T>
+    GeneratorWrapper<T> take(size_t target, GeneratorWrapper<T>&& generator) {
+        return GeneratorWrapper<T>(pf::make_unique<TakeGenerator<T>>(target, std::move(generator)));
     }
-};
 
-template <typename T>
-GeneratorWrapper<T> take(size_t target, GeneratorWrapper<T>&& generator) {
-    return GeneratorWrapper<T>(pf::make_unique<TakeGenerator<T>>(target, std::move(generator)));
-}
-
-template <typename T, typename Predicate>
-class FilterGenerator : public IGenerator<T> {
-    GeneratorWrapper<T> m_generator;
-    Predicate m_predicate;
-public:
-    template <typename P = Predicate>
-    FilterGenerator(P&& pred, GeneratorWrapper<T>&& generator):
-        m_generator(std::move(generator)),
-        m_predicate(std::forward<P>(pred))
-    {
-        if (!m_predicate(m_generator.get())) {
-            // It might happen that there are no values that pass the
-            // filter. In that case we throw an exception.
-            auto has_initial_value = next();
-            if (!has_initial_value) {
-                Catch::throw_exception(GeneratorException("No valid value found in filtered generator"));
+    template <typename T, typename Predicate>
+    class FilterGenerator : public IGenerator<T> {
+        GeneratorWrapper<T> m_generator;
+        Predicate m_predicate;
+    public:
+        template <typename P = Predicate>
+        FilterGenerator(P&& pred, GeneratorWrapper<T>&& generator):
+            m_generator(std::move(generator)),
+            m_predicate(std::forward<P>(pred))
+        {
+            if (!m_predicate(m_generator.get())) {
+                // It might happen that there are no values that pass the
+                // filter. In that case we throw an exception.
+                auto has_initial_value = nextImpl();
+                if (!has_initial_value) {
+                    Catch::throw_exception(GeneratorException("No valid value found in filtered generator"));
+                }
             }
         }
-    }
 
-    T const& get() const override {
-        return m_generator.get();
-    }
-
-    bool next() override {
-        bool success = m_generator.next();
-        if (!success) {
-            return false;
+        T const& get() const override {
+            return m_generator.get();
         }
-        while (!m_predicate(m_generator.get()) && (success = m_generator.next()) == true);
-        return success;
-    }
-};
 
-template <typename T, typename Predicate>
-GeneratorWrapper<T> filter(Predicate&& pred, GeneratorWrapper<T>&& generator) {
-    return GeneratorWrapper<T>(std::unique_ptr<IGenerator<T>>(pf::make_unique<FilterGenerator<T, Predicate>>(std::forward<Predicate>(pred), std::move(generator))));
-}
-
-template <typename T>
-class RepeatGenerator : public IGenerator<T> {
-    static_assert(!std::is_same<T, bool>::value,
-                  "RepeatGenerator currently does not support bools"
-                  "because of std::vector<bool> specialization");
-    GeneratorWrapper<T> m_generator;
-    mutable std::vector<T> m_returned;
-    size_t m_target_repeats;
-    size_t m_current_repeat = 0;
-    size_t m_repeat_index = 0;
-public:
-    RepeatGenerator(size_t repeats, GeneratorWrapper<T>&& generator):
-        m_generator(std::move(generator)),
-        m_target_repeats(repeats)
-    {
-        assert(m_target_repeats > 0 && "Repeat generator must repeat at least once");
-    }
-
-    T const& get() const override {
-        if (m_current_repeat == 0) {
-            m_returned.push_back(m_generator.get());
-            return m_returned.back();
+        bool next() override {
+            return nextImpl();
         }
-        return m_returned[m_repeat_index];
-    }
 
-    bool next() override {
-        // There are 2 basic cases:
-        // 1) We are still reading the generator
-        // 2) We are reading our own cache
-
-        // In the first case, we need to poke the underlying generator.
-        // If it happily moves, we are left in that state, otherwise it is time to start reading from our cache
-        if (m_current_repeat == 0) {
-            const auto success = m_generator.next();
+    private:
+        bool nextImpl() {
+            bool success = m_generator.next();
             if (!success) {
+                return false;
+            }
+            while (!m_predicate(m_generator.get()) && (success = m_generator.next()) == true);
+            return success;
+        }
+    };
+
+    template <typename T, typename Predicate>
+    GeneratorWrapper<T> filter(Predicate&& pred, GeneratorWrapper<T>&& generator) {
+        return GeneratorWrapper<T>(std::unique_ptr<IGenerator<T>>(pf::make_unique<FilterGenerator<T, Predicate>>(std::forward<Predicate>(pred), std::move(generator))));
+    }
+
+    template <typename T>
+    class RepeatGenerator : public IGenerator<T> {
+        static_assert(!std::is_same<T, bool>::value,
+            "RepeatGenerator currently does not support bools"
+            "because of std::vector<bool> specialization");
+        GeneratorWrapper<T> m_generator;
+        mutable std::vector<T> m_returned;
+        size_t m_target_repeats;
+        size_t m_current_repeat = 0;
+        size_t m_repeat_index = 0;
+    public:
+        RepeatGenerator(size_t repeats, GeneratorWrapper<T>&& generator):
+            m_generator(std::move(generator)),
+            m_target_repeats(repeats)
+        {
+            assert(m_target_repeats > 0 && "Repeat generator must repeat at least once");
+        }
+
+        T const& get() const override {
+            if (m_current_repeat == 0) {
+                m_returned.push_back(m_generator.get());
+                return m_returned.back();
+            }
+            return m_returned[m_repeat_index];
+        }
+
+        bool next() override {
+            // There are 2 basic cases:
+            // 1) We are still reading the generator
+            // 2) We are reading our own cache
+
+            // In the first case, we need to poke the underlying generator.
+            // If it happily moves, we are left in that state, otherwise it is time to start reading from our cache
+            if (m_current_repeat == 0) {
+                const auto success = m_generator.next();
+                if (!success) {
+                    ++m_current_repeat;
+                }
+                return m_current_repeat < m_target_repeats;
+            }
+
+            // In the second case, we need to move indices forward and check that we haven't run up against the end
+            ++m_repeat_index;
+            if (m_repeat_index == m_returned.size()) {
+                m_repeat_index = 0;
                 ++m_current_repeat;
             }
             return m_current_repeat < m_target_repeats;
         }
+    };
 
-        // In the second case, we need to move indices forward and check that we haven't run up against the end
-        ++m_repeat_index;
-        if (m_repeat_index == m_returned.size()) {
-            m_repeat_index = 0;
-            ++m_current_repeat;
+    template <typename T>
+    GeneratorWrapper<T> repeat(size_t repeats, GeneratorWrapper<T>&& generator) {
+        return GeneratorWrapper<T>(pf::make_unique<RepeatGenerator<T>>(repeats, std::move(generator)));
+    }
+
+    template <typename T, typename U, typename Func>
+    class MapGenerator : public IGenerator<T> {
+        // TBD: provide static assert for mapping function, for friendly error message
+        GeneratorWrapper<U> m_generator;
+        Func m_function;
+        // To avoid returning dangling reference, we have to save the values
+        T m_cache;
+    public:
+        template <typename F2 = Func>
+        MapGenerator(F2&& function, GeneratorWrapper<U>&& generator) :
+            m_generator(std::move(generator)),
+            m_function(std::forward<F2>(function)),
+            m_cache(m_function(m_generator.get()))
+        {}
+
+        T const& get() const override {
+            return m_cache;
         }
-        return m_current_repeat < m_target_repeats;
-    }
-};
-
-template <typename T>
-GeneratorWrapper<T> repeat(size_t repeats, GeneratorWrapper<T>&& generator) {
-    return GeneratorWrapper<T>(pf::make_unique<RepeatGenerator<T>>(repeats, std::move(generator)));
-}
-
-template <typename T, typename U, typename Func>
-class MapGenerator : public IGenerator<T> {
-    // TBD: provide static assert for mapping function, for friendly error message
-    GeneratorWrapper<U> m_generator;
-    Func m_function;
-    // To avoid returning dangling reference, we have to save the values
-    T m_cache;
-public:
-    template <typename F2 = Func>
-    MapGenerator(F2&& function, GeneratorWrapper<U>&& generator) :
-        m_generator(std::move(generator)),
-        m_function(std::forward<F2>(function)),
-        m_cache(m_function(m_generator.get()))
-    {}
-
-    T const& get() const override {
-        return m_cache;
-    }
-    bool next() override {
-        const auto success = m_generator.next();
-        if (success) {
-            m_cache = m_function(m_generator.get());
+        bool next() override {
+            const auto success = m_generator.next();
+            if (success) {
+                m_cache = m_function(m_generator.get());
+            }
+            return success;
         }
-        return success;
+    };
+
+    template <typename Func, typename U, typename T = FunctionReturnType<Func, U>>
+    GeneratorWrapper<T> map(Func&& function, GeneratorWrapper<U>&& generator) {
+        return GeneratorWrapper<T>(
+            pf::make_unique<MapGenerator<T, U, Func>>(std::forward<Func>(function), std::move(generator))
+        );
     }
-};
 
-template <typename Func, typename U, typename T = FunctionReturnType<Func, U>>
-GeneratorWrapper<T> map(Func&& function, GeneratorWrapper<U>&& generator) {
-    return GeneratorWrapper<T>(
-        pf::make_unique<MapGenerator<T, U, Func>>(std::forward<Func>(function), std::move(generator))
-    );
-}
+    template <typename T, typename U, typename Func>
+    GeneratorWrapper<T> map(Func&& function, GeneratorWrapper<U>&& generator) {
+        return GeneratorWrapper<T>(
+            pf::make_unique<MapGenerator<T, U, Func>>(std::forward<Func>(function), std::move(generator))
+        );
+    }
 
-template <typename T, typename U, typename Func>
-GeneratorWrapper<T> map(Func&& function, GeneratorWrapper<U>&& generator) {
-    return GeneratorWrapper<T>(
-        pf::make_unique<MapGenerator<T, U, Func>>(std::forward<Func>(function), std::move(generator))
-    );
-}
-
-template <typename T>
-class ChunkGenerator final : public IGenerator<std::vector<T>> {
-    std::vector<T> m_chunk;
-    size_t m_chunk_size;
-    GeneratorWrapper<T> m_generator;
-    bool m_used_up = false;
-public:
-    ChunkGenerator(size_t size, GeneratorWrapper<T> generator) :
-        m_chunk_size(size), m_generator(std::move(generator))
-    {
-        m_chunk.reserve(m_chunk_size);
-        if (m_chunk_size != 0) {
-            m_chunk.push_back(m_generator.get());
-            for (size_t i = 1; i < m_chunk_size; ++i) {
+    template <typename T>
+    class ChunkGenerator final : public IGenerator<std::vector<T>> {
+        std::vector<T> m_chunk;
+        size_t m_chunk_size;
+        GeneratorWrapper<T> m_generator;
+        bool m_used_up = false;
+    public:
+        ChunkGenerator(size_t size, GeneratorWrapper<T> generator) :
+            m_chunk_size(size), m_generator(std::move(generator))
+        {
+            m_chunk.reserve(m_chunk_size);
+            if (m_chunk_size != 0) {
+                m_chunk.push_back(m_generator.get());
+                for (size_t i = 1; i < m_chunk_size; ++i) {
+                    if (!m_generator.next()) {
+                        Catch::throw_exception(GeneratorException("Not enough values to initialize the first chunk"));
+                    }
+                    m_chunk.push_back(m_generator.get());
+                }
+            }
+        }
+        std::vector<T> const& get() const override {
+            return m_chunk;
+        }
+        bool next() override {
+            m_chunk.clear();
+            for (size_t idx = 0; idx < m_chunk_size; ++idx) {
                 if (!m_generator.next()) {
-                    Catch::throw_exception(GeneratorException("Not enough values to initialize the first chunk"));
+                    return false;
                 }
                 m_chunk.push_back(m_generator.get());
             }
+            return true;
         }
-    }
-    std::vector<T> const& get() const override {
-        return m_chunk;
-    }
-    bool next() override {
-        m_chunk.clear();
-        for (size_t idx = 0; idx < m_chunk_size; ++idx) {
-            if (!m_generator.next()) {
-                return false;
-            }
-            m_chunk.push_back(m_generator.get());
-        }
-        return true;
-    }
-};
+    };
 
-template <typename T>
-GeneratorWrapper<std::vector<T>> chunk(size_t size, GeneratorWrapper<T>&& generator) {
-    return GeneratorWrapper<std::vector<T>>(
-        pf::make_unique<ChunkGenerator<T>>(size, std::move(generator))
-    );
-}
+    template <typename T>
+    GeneratorWrapper<std::vector<T>> chunk(size_t size, GeneratorWrapper<T>&& generator) {
+        return GeneratorWrapper<std::vector<T>>(
+            pf::make_unique<ChunkGenerator<T>>(size, std::move(generator))
+        );
+    }
 
 } // namespace Generators
 } // namespace Catch
@@ -4347,53 +4348,53 @@ GeneratorWrapper<std::vector<T>> chunk(size_t size, GeneratorWrapper<T>&& genera
 
 namespace Catch {
 
-struct IResultCapture;
-struct IRunner;
-struct IConfig;
-struct IMutableContext;
+    struct IResultCapture;
+    struct IRunner;
+    struct IConfig;
+    struct IMutableContext;
 
-using IConfigPtr = std::shared_ptr<IConfig const>;
+    using IConfigPtr = std::shared_ptr<IConfig const>;
 
-struct IContext
-{
-    virtual ~IContext();
+    struct IContext
+    {
+        virtual ~IContext();
 
-    virtual IResultCapture* getResultCapture() = 0;
-    virtual IRunner* getRunner() = 0;
-    virtual IConfigPtr const& getConfig() const = 0;
-};
+        virtual IResultCapture* getResultCapture() = 0;
+        virtual IRunner* getRunner() = 0;
+        virtual IConfigPtr const& getConfig() const = 0;
+    };
 
-struct IMutableContext : IContext
-{
-    virtual ~IMutableContext();
-    virtual void setResultCapture( IResultCapture* resultCapture ) = 0;
-    virtual void setRunner( IRunner* runner ) = 0;
-    virtual void setConfig( IConfigPtr const& config ) = 0;
+    struct IMutableContext : IContext
+    {
+        virtual ~IMutableContext();
+        virtual void setResultCapture( IResultCapture* resultCapture ) = 0;
+        virtual void setRunner( IRunner* runner ) = 0;
+        virtual void setConfig( IConfigPtr const& config ) = 0;
 
-private:
-    static IMutableContext *currentContext;
-    friend IMutableContext& getCurrentMutableContext();
-    friend void cleanUpContext();
-    static void createContext();
-};
+    private:
+        static IMutableContext *currentContext;
+        friend IMutableContext& getCurrentMutableContext();
+        friend void cleanUpContext();
+        static void createContext();
+    };
 
-inline IMutableContext& getCurrentMutableContext()
-{
-    if( !IMutableContext::currentContext )
-        IMutableContext::createContext();
-    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
-    return *IMutableContext::currentContext;
-}
+    inline IMutableContext& getCurrentMutableContext()
+    {
+        if( !IMutableContext::currentContext )
+            IMutableContext::createContext();
+        // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
+        return *IMutableContext::currentContext;
+    }
 
-inline IContext& getCurrentContext()
-{
-    return getCurrentMutableContext();
-}
+    inline IContext& getCurrentContext()
+    {
+        return getCurrentMutableContext();
+    }
 
-void cleanUpContext();
+    void cleanUpContext();
 
-class SimplePcg32;
-SimplePcg32& rng();
+    class SimplePcg32;
+    SimplePcg32& rng();
 }
 
 // end catch_context.h
@@ -4403,63 +4404,63 @@ SimplePcg32& rng();
 
 namespace Catch {
 
-// An optional type
-template<typename T>
-class Option {
-public:
-    Option() : nullableValue( nullptr ) {}
-    Option( T const& _value )
+    // An optional type
+    template<typename T>
+    class Option {
+    public:
+        Option() : nullableValue( nullptr ) {}
+        Option( T const& _value )
         : nullableValue( new( storage ) T( _value ) )
-    {}
-    Option( Option const& _other )
+        {}
+        Option( Option const& _other )
         : nullableValue( _other ? new( storage ) T( *_other ) : nullptr )
-    {}
+        {}
 
-    ~Option() {
-        reset();
-    }
-
-    Option& operator= ( Option const& _other ) {
-        if( &_other != this ) {
+        ~Option() {
             reset();
-            if( _other )
-                nullableValue = new( storage ) T( *_other );
         }
-        return *this;
-    }
-    Option& operator = ( T const& _value ) {
-        reset();
-        nullableValue = new( storage ) T( _value );
-        return *this;
-    }
 
-    void reset() {
-        if( nullableValue )
-            nullableValue->~T();
-        nullableValue = nullptr;
-    }
+        Option& operator= ( Option const& _other ) {
+            if( &_other != this ) {
+                reset();
+                if( _other )
+                    nullableValue = new( storage ) T( *_other );
+            }
+            return *this;
+        }
+        Option& operator = ( T const& _value ) {
+            reset();
+            nullableValue = new( storage ) T( _value );
+            return *this;
+        }
 
-    T& operator*() { return *nullableValue; }
-    T const& operator*() const { return *nullableValue; }
-    T* operator->() { return nullableValue; }
-    const T* operator->() const { return nullableValue; }
+        void reset() {
+            if( nullableValue )
+                nullableValue->~T();
+            nullableValue = nullptr;
+        }
 
-    T valueOr( T const& defaultValue ) const {
-        return nullableValue ? *nullableValue : defaultValue;
-    }
+        T& operator*() { return *nullableValue; }
+        T const& operator*() const { return *nullableValue; }
+        T* operator->() { return nullableValue; }
+        const T* operator->() const { return nullableValue; }
 
-    bool some() const { return nullableValue != nullptr; }
-    bool none() const { return nullableValue == nullptr; }
+        T valueOr( T const& defaultValue ) const {
+            return nullableValue ? *nullableValue : defaultValue;
+        }
 
-    bool operator !() const { return nullableValue == nullptr; }
-    explicit operator bool() const {
-        return some();
-    }
+        bool some() const { return nullableValue != nullptr; }
+        bool none() const { return nullableValue == nullptr; }
 
-private:
-    T *nullableValue;
-    alignas(alignof(T)) char storage[sizeof(T)];
-};
+        bool operator !() const { return nullableValue == nullptr; }
+        explicit operator bool() const {
+            return some();
+        }
+
+    private:
+        T *nullableValue;
+        alignas(alignof(T)) char storage[sizeof(T)];
+    };
 
 } // end namespace Catch
 
@@ -4472,74 +4473,74 @@ private:
 
 namespace Catch {
 
-enum class Verbosity {
-    Quiet = 0,
-    Normal,
-    High
-};
+    enum class Verbosity {
+        Quiet = 0,
+        Normal,
+        High
+    };
 
-struct WarnAbout { enum What {
+    struct WarnAbout { enum What {
         Nothing = 0x00,
         NoAssertions = 0x01,
         NoTests = 0x02
     }; };
 
-struct ShowDurations { enum OrNot {
+    struct ShowDurations { enum OrNot {
         DefaultForReporter,
         Always,
         Never
     }; };
-struct RunTests { enum InWhatOrder {
+    struct RunTests { enum InWhatOrder {
         InDeclarationOrder,
         InLexicographicalOrder,
         InRandomOrder
     }; };
-struct UseColour { enum YesOrNo {
+    struct UseColour { enum YesOrNo {
         Auto,
         Yes,
         No
     }; };
-struct WaitForKeypress { enum When {
+    struct WaitForKeypress { enum When {
         Never,
         BeforeStart = 1,
         BeforeExit = 2,
         BeforeStartAndExit = BeforeStart | BeforeExit
     }; };
 
-class TestSpec;
+    class TestSpec;
 
-struct IConfig : NonCopyable {
+    struct IConfig : NonCopyable {
 
-    virtual ~IConfig();
+        virtual ~IConfig();
 
-    virtual bool allowThrows() const = 0;
-    virtual std::ostream& stream() const = 0;
-    virtual std::string name() const = 0;
-    virtual bool includeSuccessfulResults() const = 0;
-    virtual bool shouldDebugBreak() const = 0;
-    virtual bool warnAboutMissingAssertions() const = 0;
-    virtual bool warnAboutNoTests() const = 0;
-    virtual int abortAfter() const = 0;
-    virtual bool showInvisibles() const = 0;
-    virtual ShowDurations::OrNot showDurations() const = 0;
-    virtual double minDuration() const = 0;
-    virtual TestSpec const& testSpec() const = 0;
-    virtual bool hasTestFilters() const = 0;
-    virtual std::vector<std::string> const& getTestsOrTags() const = 0;
-    virtual RunTests::InWhatOrder runOrder() const = 0;
-    virtual unsigned int rngSeed() const = 0;
-    virtual UseColour::YesOrNo useColour() const = 0;
-    virtual std::vector<std::string> const& getSectionsToRun() const = 0;
-    virtual Verbosity verbosity() const = 0;
+        virtual bool allowThrows() const = 0;
+        virtual std::ostream& stream() const = 0;
+        virtual std::string name() const = 0;
+        virtual bool includeSuccessfulResults() const = 0;
+        virtual bool shouldDebugBreak() const = 0;
+        virtual bool warnAboutMissingAssertions() const = 0;
+        virtual bool warnAboutNoTests() const = 0;
+        virtual int abortAfter() const = 0;
+        virtual bool showInvisibles() const = 0;
+        virtual ShowDurations::OrNot showDurations() const = 0;
+        virtual double minDuration() const = 0;
+        virtual TestSpec const& testSpec() const = 0;
+        virtual bool hasTestFilters() const = 0;
+        virtual std::vector<std::string> const& getTestsOrTags() const = 0;
+        virtual RunTests::InWhatOrder runOrder() const = 0;
+        virtual unsigned int rngSeed() const = 0;
+        virtual UseColour::YesOrNo useColour() const = 0;
+        virtual std::vector<std::string> const& getSectionsToRun() const = 0;
+        virtual Verbosity verbosity() const = 0;
 
-    virtual bool benchmarkNoAnalysis() const = 0;
-    virtual int benchmarkSamples() const = 0;
-    virtual double benchmarkConfidenceInterval() const = 0;
-    virtual unsigned int benchmarkResamples() const = 0;
-    virtual std::chrono::milliseconds benchmarkWarmupTime() const = 0;
-};
+        virtual bool benchmarkNoAnalysis() const = 0;
+        virtual int benchmarkSamples() const = 0;
+        virtual double benchmarkConfidenceInterval() const = 0;
+        virtual unsigned int benchmarkResamples() const = 0;
+        virtual std::chrono::milliseconds benchmarkWarmupTime() const = 0;
+    };
 
-using IConfigPtr = std::shared_ptr<IConfig const>;
+    using IConfigPtr = std::shared_ptr<IConfig const>;
 }
 
 // end catch_interfaces_config.h
@@ -4549,46 +4550,46 @@ using IConfigPtr = std::shared_ptr<IConfig const>;
 
 namespace Catch {
 
-// This is a simple implementation of C++11 Uniform Random Number
-// Generator. It does not provide all operators, because Catch2
-// does not use it, but it should behave as expected inside stdlib's
-// distributions.
-// The implementation is based on the PCG family (http://pcg-random.org)
-class SimplePcg32 {
-    using state_type = std::uint64_t;
-public:
-    using result_type = std::uint32_t;
-    static constexpr result_type (min)() {
-        return 0;
-    }
-    static constexpr result_type (max)() {
-        return static_cast<result_type>(-1);
-    }
+    // This is a simple implementation of C++11 Uniform Random Number
+    // Generator. It does not provide all operators, because Catch2
+    // does not use it, but it should behave as expected inside stdlib's
+    // distributions.
+    // The implementation is based on the PCG family (http://pcg-random.org)
+    class SimplePcg32 {
+        using state_type = std::uint64_t;
+    public:
+        using result_type = std::uint32_t;
+        static constexpr result_type (min)() {
+            return 0;
+        }
+        static constexpr result_type (max)() {
+            return static_cast<result_type>(-1);
+        }
 
-    // Provide some default initial state for the default constructor
-    SimplePcg32():SimplePcg32(0xed743cc4U) {}
+        // Provide some default initial state for the default constructor
+        SimplePcg32():SimplePcg32(0xed743cc4U) {}
 
-    explicit SimplePcg32(result_type seed_);
+        explicit SimplePcg32(result_type seed_);
 
-    void seed(result_type seed_);
-    void discard(uint64_t skip);
+        void seed(result_type seed_);
+        void discard(uint64_t skip);
 
-    result_type operator()();
+        result_type operator()();
 
-private:
-    friend bool operator==(SimplePcg32 const& lhs, SimplePcg32 const& rhs);
-    friend bool operator!=(SimplePcg32 const& lhs, SimplePcg32 const& rhs);
+    private:
+        friend bool operator==(SimplePcg32 const& lhs, SimplePcg32 const& rhs);
+        friend bool operator!=(SimplePcg32 const& lhs, SimplePcg32 const& rhs);
 
-    // In theory we also need operator<< and operator>>
-    // In practice we do not use them, so we will skip them for now
+        // In theory we also need operator<< and operator>>
+        // In practice we do not use them, so we will skip them for now
 
-    std::uint64_t m_state;
-    // This part of the state determines which "stream" of the numbers
-    // is chosen -- we take it as a constant for Catch2, so we only
-    // need to deal with seeding the main state.
-    // Picked by reading 8 bytes from `/dev/random` :-)
-    static const std::uint64_t s_inc = (0x13ed0cc53f939476ULL << 1ULL) | 1ULL;
-};
+        std::uint64_t m_state;
+        // This part of the state determines which "stream" of the numbers
+        // is chosen -- we take it as a constant for Catch2, so we only
+        // need to deal with seeding the main state.
+        // Picked by reading 8 bytes from `/dev/random` :-)
+        static const std::uint64_t s_inc = (0x13ed0cc53f939476ULL << 1ULL) | 1ULL;
+    };
 
 } // end namespace Catch
 
@@ -4646,7 +4647,7 @@ public:
 //       but I don't expect users to run into that in practice.
 template <typename T>
 typename std::enable_if<std::is_integral<T>::value && !std::is_same<T, bool>::value,
-                        GeneratorWrapper<T>>::type
+GeneratorWrapper<T>>::type
 random(T a, T b) {
     return GeneratorWrapper<T>(
         pf::make_unique<RandomIntegerGenerator<T>>(a, b)
@@ -4655,7 +4656,7 @@ random(T a, T b) {
 
 template <typename T>
 typename std::enable_if<std::is_floating_point<T>::value,
-                        GeneratorWrapper<T>>::type
+GeneratorWrapper<T>>::type
 random(T a, T b) {
     return GeneratorWrapper<T>(
         pf::make_unique<RandomFloatingGenerator<T>>(a, b)
@@ -4710,8 +4711,8 @@ GeneratorWrapper<T> range(T const& start, T const& end) {
 template <typename T>
 class IteratorGenerator final : public IGenerator<T> {
     static_assert(!std::is_same<T, bool>::value,
-                  "IteratorGenerator currently does not support bools"
-                  "because of std::vector<bool> specialization");
+        "IteratorGenerator currently does not support bools"
+        "because of std::vector<bool> specialization");
 
     std::vector<T> m_elems;
     size_t m_current = 0;
@@ -4734,14 +4735,14 @@ public:
 };
 
 template <typename InputIterator,
-    typename InputSentinel,
-    typename ResultType = typename std::iterator_traits<InputIterator>::value_type>
+          typename InputSentinel,
+          typename ResultType = typename std::iterator_traits<InputIterator>::value_type>
 GeneratorWrapper<ResultType> from_range(InputIterator from, InputSentinel to) {
     return GeneratorWrapper<ResultType>(pf::make_unique<IteratorGenerator<ResultType>>(from, to));
 }
 
 template <typename Container,
-    typename ResultType = typename Container::value_type>
+          typename ResultType = typename Container::value_type>
 GeneratorWrapper<ResultType> from_range(Container const& cnt) {
     return GeneratorWrapper<ResultType>(pf::make_unique<IteratorGenerator<ResultType>>(cnt.begin(), cnt.end()));
 }
@@ -4766,65 +4767,65 @@ GeneratorWrapper<ResultType> from_range(Container const& cnt) {
 
 namespace Catch {
 
-struct ITestInvoker;
+    struct ITestInvoker;
 
-struct TestCaseInfo {
-    enum SpecialProperties{
-        None = 0,
-        IsHidden = 1 << 1,
-        ShouldFail = 1 << 2,
-        MayFail = 1 << 3,
-        Throws = 1 << 4,
-        NonPortable = 1 << 5,
-        Benchmark = 1 << 6
+    struct TestCaseInfo {
+        enum SpecialProperties{
+            None = 0,
+            IsHidden = 1 << 1,
+            ShouldFail = 1 << 2,
+            MayFail = 1 << 3,
+            Throws = 1 << 4,
+            NonPortable = 1 << 5,
+            Benchmark = 1 << 6
+        };
+
+        TestCaseInfo(   std::string const& _name,
+                        std::string const& _className,
+                        std::string const& _description,
+                        std::vector<std::string> const& _tags,
+                        SourceLineInfo const& _lineInfo );
+
+        friend void setTags( TestCaseInfo& testCaseInfo, std::vector<std::string> tags );
+
+        bool isHidden() const;
+        bool throws() const;
+        bool okToFail() const;
+        bool expectedToFail() const;
+
+        std::string tagsAsString() const;
+
+        std::string name;
+        std::string className;
+        std::string description;
+        std::vector<std::string> tags;
+        std::vector<std::string> lcaseTags;
+        SourceLineInfo lineInfo;
+        SpecialProperties properties;
     };
 
-    TestCaseInfo(   std::string const& _name,
-                    std::string const& _className,
-                    std::string const& _description,
-                    std::vector<std::string> const& _tags,
-                    SourceLineInfo const& _lineInfo );
+    class TestCase : public TestCaseInfo {
+    public:
 
-    friend void setTags( TestCaseInfo& testCaseInfo, std::vector<std::string> tags );
+        TestCase( ITestInvoker* testCase, TestCaseInfo&& info );
 
-    bool isHidden() const;
-    bool throws() const;
-    bool okToFail() const;
-    bool expectedToFail() const;
+        TestCase withName( std::string const& _newName ) const;
 
-    std::string tagsAsString() const;
+        void invoke() const;
 
-    std::string name;
-    std::string className;
-    std::string description;
-    std::vector<std::string> tags;
-    std::vector<std::string> lcaseTags;
-    SourceLineInfo lineInfo;
-    SpecialProperties properties;
-};
+        TestCaseInfo const& getTestCaseInfo() const;
 
-class TestCase : public TestCaseInfo {
-public:
+        bool operator == ( TestCase const& other ) const;
+        bool operator < ( TestCase const& other ) const;
 
-    TestCase( ITestInvoker* testCase, TestCaseInfo&& info );
+    private:
+        std::shared_ptr<ITestInvoker> test;
+    };
 
-    TestCase withName( std::string const& _newName ) const;
-
-    void invoke() const;
-
-    TestCaseInfo const& getTestCaseInfo() const;
-
-    bool operator == ( TestCase const& other ) const;
-    bool operator < ( TestCase const& other ) const;
-
-private:
-    std::shared_ptr<ITestInvoker> test;
-};
-
-TestCase makeTestCase(  ITestInvoker* testCase,
-                        std::string const& className,
-                        NameAndTags const& nameAndTags,
-                        SourceLineInfo const& lineInfo );
+    TestCase makeTestCase(  ITestInvoker* testCase,
+                            std::string const& className,
+                            NameAndTags const& nameAndTags,
+                            SourceLineInfo const& lineInfo );
 }
 
 #ifdef __clang__
@@ -4836,10 +4837,10 @@ TestCase makeTestCase(  ITestInvoker* testCase,
 
 namespace Catch {
 
-struct IRunner {
-    virtual ~IRunner();
-    virtual bool aborting() const = 0;
-};
+    struct IRunner {
+        virtual ~IRunner();
+        virtual bool aborting() const = 0;
+    };
 }
 
 // end catch_interfaces_runner.h
@@ -5076,26 +5077,26 @@ return @ desc; \
 
 namespace Catch
 {
-class WildcardPattern {
-    enum WildcardPosition {
-        NoWildcard = 0,
-        WildcardAtStart = 1,
-        WildcardAtEnd = 2,
-        WildcardAtBothEnds = WildcardAtStart | WildcardAtEnd
+    class WildcardPattern {
+        enum WildcardPosition {
+            NoWildcard = 0,
+            WildcardAtStart = 1,
+            WildcardAtEnd = 2,
+            WildcardAtBothEnds = WildcardAtStart | WildcardAtEnd
+        };
+
+    public:
+
+        WildcardPattern( std::string const& pattern, CaseSensitive::Choice caseSensitivity );
+        virtual ~WildcardPattern() = default;
+        virtual bool matches( std::string const& str ) const;
+
+    private:
+        std::string normaliseString( std::string const& str ) const;
+        CaseSensitive::Choice m_caseSensitivity;
+        WildcardPosition m_wildcard = NoWildcard;
+        std::string m_pattern;
     };
-
-public:
-
-    WildcardPattern( std::string const& pattern, CaseSensitive::Choice caseSensitivity );
-    virtual ~WildcardPattern() = default;
-    virtual bool matches( std::string const& str ) const;
-
-private:
-    std::string normaliseString( std::string const& str ) const;
-    CaseSensitive::Choice m_caseSensitivity;
-    WildcardPosition m_wildcard = NoWildcard;
-    std::string m_pattern;
-};
 }
 
 // end catch_wildcard_pattern.h
@@ -5105,69 +5106,69 @@ private:
 
 namespace Catch {
 
-struct IConfig;
+    struct IConfig;
 
-class TestSpec {
-    class Pattern {
+    class TestSpec {
+        class Pattern {
+        public:
+            explicit Pattern( std::string const& name );
+            virtual ~Pattern();
+            virtual bool matches( TestCaseInfo const& testCase ) const = 0;
+            std::string const& name() const;
+        private:
+            std::string const m_name;
+        };
+        using PatternPtr = std::shared_ptr<Pattern>;
+
+        class NamePattern : public Pattern {
+        public:
+            explicit NamePattern( std::string const& name, std::string const& filterString );
+            bool matches( TestCaseInfo const& testCase ) const override;
+        private:
+            WildcardPattern m_wildcardPattern;
+        };
+
+        class TagPattern : public Pattern {
+        public:
+            explicit TagPattern( std::string const& tag, std::string const& filterString );
+            bool matches( TestCaseInfo const& testCase ) const override;
+        private:
+            std::string m_tag;
+        };
+
+        class ExcludedPattern : public Pattern {
+        public:
+            explicit ExcludedPattern( PatternPtr const& underlyingPattern );
+            bool matches( TestCaseInfo const& testCase ) const override;
+        private:
+            PatternPtr m_underlyingPattern;
+        };
+
+        struct Filter {
+            std::vector<PatternPtr> m_patterns;
+
+            bool matches( TestCaseInfo const& testCase ) const;
+            std::string name() const;
+        };
+
     public:
-        explicit Pattern( std::string const& name );
-        virtual ~Pattern();
-        virtual bool matches( TestCaseInfo const& testCase ) const = 0;
-        std::string const& name() const;
-    private:
-        std::string const m_name;
-    };
-    using PatternPtr = std::shared_ptr<Pattern>;
+        struct FilterMatch {
+            std::string name;
+            std::vector<TestCase const*> tests;
+        };
+        using Matches = std::vector<FilterMatch>;
+        using vectorStrings = std::vector<std::string>;
 
-    class NamePattern : public Pattern {
-    public:
-        explicit NamePattern( std::string const& name, std::string const& filterString );
-        bool matches( TestCaseInfo const& testCase ) const override;
-    private:
-        WildcardPattern m_wildcardPattern;
-    };
-
-    class TagPattern : public Pattern {
-    public:
-        explicit TagPattern( std::string const& tag, std::string const& filterString );
-        bool matches( TestCaseInfo const& testCase ) const override;
-    private:
-        std::string m_tag;
-    };
-
-    class ExcludedPattern : public Pattern {
-    public:
-        explicit ExcludedPattern( PatternPtr const& underlyingPattern );
-        bool matches( TestCaseInfo const& testCase ) const override;
-    private:
-        PatternPtr m_underlyingPattern;
-    };
-
-    struct Filter {
-        std::vector<PatternPtr> m_patterns;
-
+        bool hasFilters() const;
         bool matches( TestCaseInfo const& testCase ) const;
-        std::string name() const;
+        Matches matchesByFilter( std::vector<TestCase> const& testCases, IConfig const& config ) const;
+        const vectorStrings & getInvalidArgs() const;
+
+    private:
+        std::vector<Filter> m_filters;
+        std::vector<std::string> m_invalidArgs;
+        friend class TestSpecParser;
     };
-
-public:
-    struct FilterMatch {
-        std::string name;
-        std::vector<TestCase const*> tests;
-    };
-    using Matches = std::vector<FilterMatch>;
-    using vectorStrings = std::vector<std::string>;
-
-    bool hasFilters() const;
-    bool matches( TestCaseInfo const& testCase ) const;
-    Matches matchesByFilter( std::vector<TestCase> const& testCases, IConfig const& config ) const;
-    const vectorStrings & getInvalidArgs() const;
-
-private:
-    std::vector<Filter> m_filters;
-    std::vector<std::string> m_invalidArgs;
-    friend class TestSpecParser;
-};
 }
 
 #ifdef __clang__
@@ -5181,72 +5182,72 @@ private:
 
 namespace Catch {
 
-struct TagAlias;
+    struct TagAlias;
 
-struct ITagAliasRegistry {
-    virtual ~ITagAliasRegistry();
-    // Nullptr if not present
-    virtual TagAlias const* find( std::string const& alias ) const = 0;
-    virtual std::string expandAliases( std::string const& unexpandedTestSpec ) const = 0;
+    struct ITagAliasRegistry {
+        virtual ~ITagAliasRegistry();
+        // Nullptr if not present
+        virtual TagAlias const* find( std::string const& alias ) const = 0;
+        virtual std::string expandAliases( std::string const& unexpandedTestSpec ) const = 0;
 
-    static ITagAliasRegistry const& get();
-};
+        static ITagAliasRegistry const& get();
+    };
 
 } // end namespace Catch
 
 // end catch_interfaces_tag_alias_registry.h
 namespace Catch {
 
-class TestSpecParser {
-    enum Mode{ None, Name, QuotedName, Tag, EscapedName };
-    Mode m_mode = None;
-    Mode lastMode = None;
-    bool m_exclusion = false;
-    std::size_t m_pos = 0;
-    std::size_t m_realPatternPos = 0;
-    std::string m_arg;
-    std::string m_substring;
-    std::string m_patternName;
-    std::vector<std::size_t> m_escapeChars;
-    TestSpec::Filter m_currentFilter;
-    TestSpec m_testSpec;
-    ITagAliasRegistry const* m_tagAliases = nullptr;
+    class TestSpecParser {
+        enum Mode{ None, Name, QuotedName, Tag, EscapedName };
+        Mode m_mode = None;
+        Mode lastMode = None;
+        bool m_exclusion = false;
+        std::size_t m_pos = 0;
+        std::size_t m_realPatternPos = 0;
+        std::string m_arg;
+        std::string m_substring;
+        std::string m_patternName;
+        std::vector<std::size_t> m_escapeChars;
+        TestSpec::Filter m_currentFilter;
+        TestSpec m_testSpec;
+        ITagAliasRegistry const* m_tagAliases = nullptr;
 
-public:
-    TestSpecParser( ITagAliasRegistry const& tagAliases );
+    public:
+        TestSpecParser( ITagAliasRegistry const& tagAliases );
 
-    TestSpecParser& parse( std::string const& arg );
-    TestSpec testSpec();
+        TestSpecParser& parse( std::string const& arg );
+        TestSpec testSpec();
 
-private:
-    bool visitChar( char c );
-    void startNewMode( Mode mode );
-    bool processNoneChar( char c );
-    void processNameChar( char c );
-    bool processOtherChar( char c );
-    void endMode();
-    void escape();
-    bool isControlChar( char c ) const;
-    void saveLastMode();
-    void revertBackToLastMode();
-    void addFilter();
-    bool separate();
+    private:
+        bool visitChar( char c );
+        void startNewMode( Mode mode );
+        bool processNoneChar( char c );
+        void processNameChar( char c );
+        bool processOtherChar( char c );
+        void endMode();
+        void escape();
+        bool isControlChar( char c ) const;
+        void saveLastMode();
+        void revertBackToLastMode();
+        void addFilter();
+        bool separate();
 
-    // Handles common preprocessing of the pattern for name/tag patterns
-    std::string preprocessPattern();
-    // Adds the current pattern as a test name
-    void addNamePattern();
-    // Adds the current pattern as a tag
-    void addTagPattern();
+        // Handles common preprocessing of the pattern for name/tag patterns
+        std::string preprocessPattern();
+        // Adds the current pattern as a test name
+        void addNamePattern();
+        // Adds the current pattern as a tag
+        void addTagPattern();
 
-    inline void addCharToPattern(char c) {
-        m_substring += c;
-        m_patternName += c;
-        m_realPatternPos++;
-    }
+        inline void addCharToPattern(char c) {
+            m_substring += c;
+            m_patternName += c;
+            m_realPatternPos++;
+        }
 
-};
-TestSpec parseTestSpec( std::string const& arg );
+    };
+    TestSpec parseTestSpec( std::string const& arg );
 
 } // namespace Catch
 
@@ -5267,108 +5268,108 @@ TestSpec parseTestSpec( std::string const& arg );
 
 namespace Catch {
 
-struct IStream;
+    struct IStream;
 
-struct ConfigData {
-    bool listTests = false;
-    bool listTags = false;
-    bool listReporters = false;
-    bool listTestNamesOnly = false;
+    struct ConfigData {
+        bool listTests = false;
+        bool listTags = false;
+        bool listReporters = false;
+        bool listTestNamesOnly = false;
 
-    bool showSuccessfulTests = false;
-    bool shouldDebugBreak = false;
-    bool noThrow = false;
-    bool showHelp = false;
-    bool showInvisibles = false;
-    bool filenamesAsTags = false;
-    bool libIdentify = false;
+        bool showSuccessfulTests = false;
+        bool shouldDebugBreak = false;
+        bool noThrow = false;
+        bool showHelp = false;
+        bool showInvisibles = false;
+        bool filenamesAsTags = false;
+        bool libIdentify = false;
 
-    int abortAfter = -1;
-    unsigned int rngSeed = 0;
+        int abortAfter = -1;
+        unsigned int rngSeed = 0;
 
-    bool benchmarkNoAnalysis = false;
-    unsigned int benchmarkSamples = 100;
-    double benchmarkConfidenceInterval = 0.95;
-    unsigned int benchmarkResamples = 100000;
-    std::chrono::milliseconds::rep benchmarkWarmupTime = 100;
+        bool benchmarkNoAnalysis = false;
+        unsigned int benchmarkSamples = 100;
+        double benchmarkConfidenceInterval = 0.95;
+        unsigned int benchmarkResamples = 100000;
+        std::chrono::milliseconds::rep benchmarkWarmupTime = 100;
 
-    Verbosity verbosity = Verbosity::Normal;
-    WarnAbout::What warnings = WarnAbout::Nothing;
-    ShowDurations::OrNot showDurations = ShowDurations::DefaultForReporter;
-    double minDuration = -1;
-    RunTests::InWhatOrder runOrder = RunTests::InDeclarationOrder;
-    UseColour::YesOrNo useColour = UseColour::Auto;
-    WaitForKeypress::When waitForKeypress = WaitForKeypress::Never;
+        Verbosity verbosity = Verbosity::Normal;
+        WarnAbout::What warnings = WarnAbout::Nothing;
+        ShowDurations::OrNot showDurations = ShowDurations::DefaultForReporter;
+        double minDuration = -1;
+        RunTests::InWhatOrder runOrder = RunTests::InDeclarationOrder;
+        UseColour::YesOrNo useColour = UseColour::Auto;
+        WaitForKeypress::When waitForKeypress = WaitForKeypress::Never;
 
-    std::string outputFilename;
-    std::string name;
-    std::string processName;
+        std::string outputFilename;
+        std::string name;
+        std::string processName;
 #ifndef CATCH_CONFIG_DEFAULT_REPORTER
 #define CATCH_CONFIG_DEFAULT_REPORTER "console"
 #endif
-    std::string reporterName = CATCH_CONFIG_DEFAULT_REPORTER;
+        std::string reporterName = CATCH_CONFIG_DEFAULT_REPORTER;
 #undef CATCH_CONFIG_DEFAULT_REPORTER
 
-    std::vector<std::string> testsOrTags;
-    std::vector<std::string> sectionsToRun;
-};
+        std::vector<std::string> testsOrTags;
+        std::vector<std::string> sectionsToRun;
+    };
 
-class Config : public IConfig {
-public:
+    class Config : public IConfig {
+    public:
 
-    Config() = default;
-    Config( ConfigData const& data );
-    virtual ~Config() = default;
+        Config() = default;
+        Config( ConfigData const& data );
+        virtual ~Config() = default;
 
-    std::string const& getFilename() const;
+        std::string const& getFilename() const;
 
-    bool listTests() const;
-    bool listTestNamesOnly() const;
-    bool listTags() const;
-    bool listReporters() const;
+        bool listTests() const;
+        bool listTestNamesOnly() const;
+        bool listTags() const;
+        bool listReporters() const;
 
-    std::string getProcessName() const;
-    std::string const& getReporterName() const;
+        std::string getProcessName() const;
+        std::string const& getReporterName() const;
 
-    std::vector<std::string> const& getTestsOrTags() const override;
-    std::vector<std::string> const& getSectionsToRun() const override;
+        std::vector<std::string> const& getTestsOrTags() const override;
+        std::vector<std::string> const& getSectionsToRun() const override;
 
-    TestSpec const& testSpec() const override;
-    bool hasTestFilters() const override;
+        TestSpec const& testSpec() const override;
+        bool hasTestFilters() const override;
 
-    bool showHelp() const;
+        bool showHelp() const;
 
-    // IConfig interface
-    bool allowThrows() const override;
-    std::ostream& stream() const override;
-    std::string name() const override;
-    bool includeSuccessfulResults() const override;
-    bool warnAboutMissingAssertions() const override;
-    bool warnAboutNoTests() const override;
-    ShowDurations::OrNot showDurations() const override;
-    double minDuration() const override;
-    RunTests::InWhatOrder runOrder() const override;
-    unsigned int rngSeed() const override;
-    UseColour::YesOrNo useColour() const override;
-    bool shouldDebugBreak() const override;
-    int abortAfter() const override;
-    bool showInvisibles() const override;
-    Verbosity verbosity() const override;
-    bool benchmarkNoAnalysis() const override;
-    int benchmarkSamples() const override;
-    double benchmarkConfidenceInterval() const override;
-    unsigned int benchmarkResamples() const override;
-    std::chrono::milliseconds benchmarkWarmupTime() const override;
+        // IConfig interface
+        bool allowThrows() const override;
+        std::ostream& stream() const override;
+        std::string name() const override;
+        bool includeSuccessfulResults() const override;
+        bool warnAboutMissingAssertions() const override;
+        bool warnAboutNoTests() const override;
+        ShowDurations::OrNot showDurations() const override;
+        double minDuration() const override;
+        RunTests::InWhatOrder runOrder() const override;
+        unsigned int rngSeed() const override;
+        UseColour::YesOrNo useColour() const override;
+        bool shouldDebugBreak() const override;
+        int abortAfter() const override;
+        bool showInvisibles() const override;
+        Verbosity verbosity() const override;
+        bool benchmarkNoAnalysis() const override;
+        int benchmarkSamples() const override;
+        double benchmarkConfidenceInterval() const override;
+        unsigned int benchmarkResamples() const override;
+        std::chrono::milliseconds benchmarkWarmupTime() const override;
 
-private:
+    private:
 
-    IStream const* openStream();
-    ConfigData m_data;
+        IStream const* openStream();
+        ConfigData m_data;
 
-    std::unique_ptr<IStream const> m_stream;
-    TestSpec m_testSpec;
-    bool m_hasTestFilters = false;
-};
+        std::unique_ptr<IStream const> m_stream;
+        TestSpec m_testSpec;
+        bool m_hasTestFilters = false;
+    };
 
 } // end namespace Catch
 
@@ -5379,42 +5380,42 @@ private:
 
 namespace Catch {
 
-struct AssertionResultData
-{
-    AssertionResultData() = delete;
+    struct AssertionResultData
+    {
+        AssertionResultData() = delete;
 
-    AssertionResultData( ResultWas::OfType _resultType, LazyExpression const& _lazyExpression );
+        AssertionResultData( ResultWas::OfType _resultType, LazyExpression const& _lazyExpression );
 
-    std::string message;
-    mutable std::string reconstructedExpression;
-    LazyExpression lazyExpression;
-    ResultWas::OfType resultType;
+        std::string message;
+        mutable std::string reconstructedExpression;
+        LazyExpression lazyExpression;
+        ResultWas::OfType resultType;
 
-    std::string reconstructExpression() const;
-};
+        std::string reconstructExpression() const;
+    };
 
-class AssertionResult {
-public:
-    AssertionResult() = delete;
-    AssertionResult( AssertionInfo const& info, AssertionResultData const& data );
+    class AssertionResult {
+    public:
+        AssertionResult() = delete;
+        AssertionResult( AssertionInfo const& info, AssertionResultData const& data );
 
-    bool isOk() const;
-    bool succeeded() const;
-    ResultWas::OfType getResultType() const;
-    bool hasExpression() const;
-    bool hasMessage() const;
-    std::string getExpression() const;
-    std::string getExpressionInMacro() const;
-    bool hasExpandedExpression() const;
-    std::string getExpandedExpression() const;
-    std::string getMessage() const;
-    SourceLineInfo getSourceInfo() const;
-    StringRef getTestMacroName() const;
+        bool isOk() const;
+        bool succeeded() const;
+        ResultWas::OfType getResultType() const;
+        bool hasExpression() const;
+        bool hasMessage() const;
+        std::string getExpression() const;
+        std::string getExpressionInMacro() const;
+        bool hasExpandedExpression() const;
+        std::string getExpandedExpression() const;
+        std::string getMessage() const;
+        SourceLineInfo getSourceInfo() const;
+        StringRef getTestMacroName() const;
 
     //protected:
-    AssertionInfo m_info;
-    AssertionResultData m_resultData;
-};
+        AssertionInfo m_info;
+        AssertionResultData m_resultData;
+    };
 
 } // end namespace Catch
 
@@ -5464,6 +5465,8 @@ namespace Catch {
 } // namespace Catch
 
 // end catch_outlier_classification.hpp
+
+#include <iterator>
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
 #include <string>
@@ -5475,140 +5478,140 @@ namespace Catch {
 
 namespace Catch {
 
-struct ReporterConfig {
-    explicit ReporterConfig( IConfigPtr const& _fullConfig );
+    struct ReporterConfig {
+        explicit ReporterConfig( IConfigPtr const& _fullConfig );
 
-    ReporterConfig( IConfigPtr const& _fullConfig, std::ostream& _stream );
+        ReporterConfig( IConfigPtr const& _fullConfig, std::ostream& _stream );
 
-    std::ostream& stream() const;
-    IConfigPtr fullConfig() const;
+        std::ostream& stream() const;
+        IConfigPtr fullConfig() const;
 
-private:
-    std::ostream* m_stream;
-    IConfigPtr m_fullConfig;
-};
+    private:
+        std::ostream* m_stream;
+        IConfigPtr m_fullConfig;
+    };
 
-struct ReporterPreferences {
-    bool shouldRedirectStdOut = false;
-    bool shouldReportAllAssertions = false;
-};
+    struct ReporterPreferences {
+        bool shouldRedirectStdOut = false;
+        bool shouldReportAllAssertions = false;
+    };
 
-template<typename T>
-struct LazyStat : Option<T> {
-    LazyStat& operator=( T const& _value ) {
-        Option<T>::operator=( _value );
-        used = false;
-        return *this;
-    }
-    void reset() {
-        Option<T>::reset();
-        used = false;
-    }
-    bool used = false;
-};
+    template<typename T>
+    struct LazyStat : Option<T> {
+        LazyStat& operator=( T const& _value ) {
+            Option<T>::operator=( _value );
+            used = false;
+            return *this;
+        }
+        void reset() {
+            Option<T>::reset();
+            used = false;
+        }
+        bool used = false;
+    };
 
-struct TestRunInfo {
-    TestRunInfo( std::string const& _name );
-    std::string name;
-};
-struct GroupInfo {
-    GroupInfo(  std::string const& _name,
-                std::size_t _groupIndex,
-                std::size_t _groupsCount );
+    struct TestRunInfo {
+        TestRunInfo( std::string const& _name );
+        std::string name;
+    };
+    struct GroupInfo {
+        GroupInfo(  std::string const& _name,
+                    std::size_t _groupIndex,
+                    std::size_t _groupsCount );
 
-    std::string name;
-    std::size_t groupIndex;
-    std::size_t groupsCounts;
-};
+        std::string name;
+        std::size_t groupIndex;
+        std::size_t groupsCounts;
+    };
 
-struct AssertionStats {
-    AssertionStats( AssertionResult const& _assertionResult,
-                    std::vector<MessageInfo> const& _infoMessages,
-                    Totals const& _totals );
+    struct AssertionStats {
+        AssertionStats( AssertionResult const& _assertionResult,
+                        std::vector<MessageInfo> const& _infoMessages,
+                        Totals const& _totals );
 
-    AssertionStats( AssertionStats const& )              = default;
-    AssertionStats( AssertionStats && )                  = default;
-    AssertionStats& operator = ( AssertionStats const& ) = delete;
-    AssertionStats& operator = ( AssertionStats && )     = delete;
-    virtual ~AssertionStats();
+        AssertionStats( AssertionStats const& )              = default;
+        AssertionStats( AssertionStats && )                  = default;
+        AssertionStats& operator = ( AssertionStats const& ) = delete;
+        AssertionStats& operator = ( AssertionStats && )     = delete;
+        virtual ~AssertionStats();
 
-    AssertionResult assertionResult;
-    std::vector<MessageInfo> infoMessages;
-    Totals totals;
-};
+        AssertionResult assertionResult;
+        std::vector<MessageInfo> infoMessages;
+        Totals totals;
+    };
 
-struct SectionStats {
-    SectionStats(   SectionInfo const& _sectionInfo,
-                    Counts const& _assertions,
-                    double _durationInSeconds,
-                    bool _missingAssertions );
-    SectionStats( SectionStats const& )              = default;
-    SectionStats( SectionStats && )                  = default;
-    SectionStats& operator = ( SectionStats const& ) = default;
-    SectionStats& operator = ( SectionStats && )     = default;
-    virtual ~SectionStats();
+    struct SectionStats {
+        SectionStats(   SectionInfo const& _sectionInfo,
+                        Counts const& _assertions,
+                        double _durationInSeconds,
+                        bool _missingAssertions );
+        SectionStats( SectionStats const& )              = default;
+        SectionStats( SectionStats && )                  = default;
+        SectionStats& operator = ( SectionStats const& ) = default;
+        SectionStats& operator = ( SectionStats && )     = default;
+        virtual ~SectionStats();
 
-    SectionInfo sectionInfo;
-    Counts assertions;
-    double durationInSeconds;
-    bool missingAssertions;
-};
+        SectionInfo sectionInfo;
+        Counts assertions;
+        double durationInSeconds;
+        bool missingAssertions;
+    };
 
-struct TestCaseStats {
-    TestCaseStats(  TestCaseInfo const& _testInfo,
-                    Totals const& _totals,
-                    std::string const& _stdOut,
-                    std::string const& _stdErr,
-                    bool _aborting );
+    struct TestCaseStats {
+        TestCaseStats(  TestCaseInfo const& _testInfo,
+                        Totals const& _totals,
+                        std::string const& _stdOut,
+                        std::string const& _stdErr,
+                        bool _aborting );
 
-    TestCaseStats( TestCaseStats const& )              = default;
-    TestCaseStats( TestCaseStats && )                  = default;
-    TestCaseStats& operator = ( TestCaseStats const& ) = default;
-    TestCaseStats& operator = ( TestCaseStats && )     = default;
-    virtual ~TestCaseStats();
+        TestCaseStats( TestCaseStats const& )              = default;
+        TestCaseStats( TestCaseStats && )                  = default;
+        TestCaseStats& operator = ( TestCaseStats const& ) = default;
+        TestCaseStats& operator = ( TestCaseStats && )     = default;
+        virtual ~TestCaseStats();
 
-    TestCaseInfo testInfo;
-    Totals totals;
-    std::string stdOut;
-    std::string stdErr;
-    bool aborting;
-};
+        TestCaseInfo testInfo;
+        Totals totals;
+        std::string stdOut;
+        std::string stdErr;
+        bool aborting;
+    };
 
-struct TestGroupStats {
-    TestGroupStats( GroupInfo const& _groupInfo,
-                    Totals const& _totals,
-                    bool _aborting );
-    TestGroupStats( GroupInfo const& _groupInfo );
+    struct TestGroupStats {
+        TestGroupStats( GroupInfo const& _groupInfo,
+                        Totals const& _totals,
+                        bool _aborting );
+        TestGroupStats( GroupInfo const& _groupInfo );
 
-    TestGroupStats( TestGroupStats const& )              = default;
-    TestGroupStats( TestGroupStats && )                  = default;
-    TestGroupStats& operator = ( TestGroupStats const& ) = default;
-    TestGroupStats& operator = ( TestGroupStats && )     = default;
-    virtual ~TestGroupStats();
+        TestGroupStats( TestGroupStats const& )              = default;
+        TestGroupStats( TestGroupStats && )                  = default;
+        TestGroupStats& operator = ( TestGroupStats const& ) = default;
+        TestGroupStats& operator = ( TestGroupStats && )     = default;
+        virtual ~TestGroupStats();
 
-    GroupInfo groupInfo;
-    Totals totals;
-    bool aborting;
-};
+        GroupInfo groupInfo;
+        Totals totals;
+        bool aborting;
+    };
 
-struct TestRunStats {
-    TestRunStats(   TestRunInfo const& _runInfo,
-                    Totals const& _totals,
-                    bool _aborting );
+    struct TestRunStats {
+        TestRunStats(   TestRunInfo const& _runInfo,
+                        Totals const& _totals,
+                        bool _aborting );
 
-    TestRunStats( TestRunStats const& )              = default;
-    TestRunStats( TestRunStats && )                  = default;
-    TestRunStats& operator = ( TestRunStats const& ) = default;
-    TestRunStats& operator = ( TestRunStats && )     = default;
-    virtual ~TestRunStats();
+        TestRunStats( TestRunStats const& )              = default;
+        TestRunStats( TestRunStats && )                  = default;
+        TestRunStats& operator = ( TestRunStats const& ) = default;
+        TestRunStats& operator = ( TestRunStats && )     = default;
+        virtual ~TestRunStats();
 
-    TestRunInfo runInfo;
-    Totals totals;
-    bool aborting;
-};
+        TestRunInfo runInfo;
+        Totals totals;
+        bool aborting;
+    };
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
-struct BenchmarkInfo {
+    struct BenchmarkInfo {
         std::string name;
         double estimatedDuration;
         int iterations;
@@ -5645,67 +5648,67 @@ struct BenchmarkInfo {
     };
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-struct IStreamingReporter {
-    virtual ~IStreamingReporter() = default;
+    struct IStreamingReporter {
+        virtual ~IStreamingReporter() = default;
 
-    // Implementing class must also provide the following static methods:
-    // static std::string getDescription();
-    // static std::set<Verbosity> getSupportedVerbosities()
+        // Implementing class must also provide the following static methods:
+        // static std::string getDescription();
+        // static std::set<Verbosity> getSupportedVerbosities()
 
-    virtual ReporterPreferences getPreferences() const = 0;
+        virtual ReporterPreferences getPreferences() const = 0;
 
-    virtual void noMatchingTestCases( std::string const& spec ) = 0;
+        virtual void noMatchingTestCases( std::string const& spec ) = 0;
 
-    virtual void reportInvalidArguments(std::string const&) {}
+        virtual void reportInvalidArguments(std::string const&) {}
 
-    virtual void testRunStarting( TestRunInfo const& testRunInfo ) = 0;
-    virtual void testGroupStarting( GroupInfo const& groupInfo ) = 0;
+        virtual void testRunStarting( TestRunInfo const& testRunInfo ) = 0;
+        virtual void testGroupStarting( GroupInfo const& groupInfo ) = 0;
 
-    virtual void testCaseStarting( TestCaseInfo const& testInfo ) = 0;
-    virtual void sectionStarting( SectionInfo const& sectionInfo ) = 0;
+        virtual void testCaseStarting( TestCaseInfo const& testInfo ) = 0;
+        virtual void sectionStarting( SectionInfo const& sectionInfo ) = 0;
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
-    virtual void benchmarkPreparing( std::string const& ) {}
+        virtual void benchmarkPreparing( std::string const& ) {}
         virtual void benchmarkStarting( BenchmarkInfo const& ) {}
         virtual void benchmarkEnded( BenchmarkStats<> const& ) {}
         virtual void benchmarkFailed( std::string const& ) {}
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-    virtual void assertionStarting( AssertionInfo const& assertionInfo ) = 0;
+        virtual void assertionStarting( AssertionInfo const& assertionInfo ) = 0;
 
-    // The return value indicates if the messages buffer should be cleared:
-    virtual bool assertionEnded( AssertionStats const& assertionStats ) = 0;
+        // The return value indicates if the messages buffer should be cleared:
+        virtual bool assertionEnded( AssertionStats const& assertionStats ) = 0;
 
-    virtual void sectionEnded( SectionStats const& sectionStats ) = 0;
-    virtual void testCaseEnded( TestCaseStats const& testCaseStats ) = 0;
-    virtual void testGroupEnded( TestGroupStats const& testGroupStats ) = 0;
-    virtual void testRunEnded( TestRunStats const& testRunStats ) = 0;
+        virtual void sectionEnded( SectionStats const& sectionStats ) = 0;
+        virtual void testCaseEnded( TestCaseStats const& testCaseStats ) = 0;
+        virtual void testGroupEnded( TestGroupStats const& testGroupStats ) = 0;
+        virtual void testRunEnded( TestRunStats const& testRunStats ) = 0;
 
-    virtual void skipTest( TestCaseInfo const& testInfo ) = 0;
+        virtual void skipTest( TestCaseInfo const& testInfo ) = 0;
 
-    // Default empty implementation provided
-    virtual void fatalErrorEncountered( StringRef name );
+        // Default empty implementation provided
+        virtual void fatalErrorEncountered( StringRef name );
 
-    virtual bool isMulti() const;
-};
-using IStreamingReporterPtr = std::unique_ptr<IStreamingReporter>;
+        virtual bool isMulti() const;
+    };
+    using IStreamingReporterPtr = std::unique_ptr<IStreamingReporter>;
 
-struct IReporterFactory {
-    virtual ~IReporterFactory();
-    virtual IStreamingReporterPtr create( ReporterConfig const& config ) const = 0;
-    virtual std::string getDescription() const = 0;
-};
-using IReporterFactoryPtr = std::shared_ptr<IReporterFactory>;
+    struct IReporterFactory {
+        virtual ~IReporterFactory();
+        virtual IStreamingReporterPtr create( ReporterConfig const& config ) const = 0;
+        virtual std::string getDescription() const = 0;
+    };
+    using IReporterFactoryPtr = std::shared_ptr<IReporterFactory>;
 
-struct IReporterRegistry {
-    using FactoryMap = std::map<std::string, IReporterFactoryPtr>;
-    using Listeners = std::vector<IReporterFactoryPtr>;
+    struct IReporterRegistry {
+        using FactoryMap = std::map<std::string, IReporterFactoryPtr>;
+        using Listeners = std::vector<IReporterFactoryPtr>;
 
-    virtual ~IReporterRegistry();
-    virtual IStreamingReporterPtr create( std::string const& name, IConfigPtr const& config ) const = 0;
-    virtual FactoryMap const& getFactories() const = 0;
-    virtual Listeners const& getListeners() const = 0;
-};
+        virtual ~IReporterRegistry();
+        virtual IStreamingReporterPtr create( std::string const& name, IConfigPtr const& config ) const = 0;
+        virtual FactoryMap const& getFactories() const = 0;
+        virtual Listeners const& getListeners() const = 0;
+    };
 
 } // end namespace Catch
 
@@ -5719,263 +5722,263 @@ struct IReporterRegistry {
 #include <ostream>
 
 namespace Catch {
-void prepareExpandedExpression(AssertionResult& result);
+    void prepareExpandedExpression(AssertionResult& result);
 
-// Returns double formatted as %.3f (format expected on output)
-std::string getFormattedDuration( double duration );
+    // Returns double formatted as %.3f (format expected on output)
+    std::string getFormattedDuration( double duration );
 
-//! Should the reporter show
-bool shouldShowDuration( IConfig const& config, double duration );
+    //! Should the reporter show
+    bool shouldShowDuration( IConfig const& config, double duration );
 
-std::string serializeFilters( std::vector<std::string> const& container );
+    std::string serializeFilters( std::vector<std::string> const& container );
 
-template<typename DerivedT>
-struct StreamingReporterBase : IStreamingReporter {
+    template<typename DerivedT>
+    struct StreamingReporterBase : IStreamingReporter {
 
-    StreamingReporterBase( ReporterConfig const& _config )
+        StreamingReporterBase( ReporterConfig const& _config )
         :   m_config( _config.fullConfig() ),
             stream( _config.stream() )
-    {
-        m_reporterPrefs.shouldRedirectStdOut = false;
-        if( !DerivedT::getSupportedVerbosities().count( m_config->verbosity() ) )
-            CATCH_ERROR( "Verbosity level not supported by this reporter" );
-    }
-
-    ReporterPreferences getPreferences() const override {
-        return m_reporterPrefs;
-    }
-
-    static std::set<Verbosity> getSupportedVerbosities() {
-        return { Verbosity::Normal };
-    }
-
-    ~StreamingReporterBase() override = default;
-
-    void noMatchingTestCases(std::string const&) override {}
-
-    void reportInvalidArguments(std::string const&) override {}
-
-    void testRunStarting(TestRunInfo const& _testRunInfo) override {
-        currentTestRunInfo = _testRunInfo;
-    }
-
-    void testGroupStarting(GroupInfo const& _groupInfo) override {
-        currentGroupInfo = _groupInfo;
-    }
-
-    void testCaseStarting(TestCaseInfo const& _testInfo) override  {
-        currentTestCaseInfo = _testInfo;
-    }
-    void sectionStarting(SectionInfo const& _sectionInfo) override {
-        m_sectionStack.push_back(_sectionInfo);
-    }
-
-    void sectionEnded(SectionStats const& /* _sectionStats */) override {
-        m_sectionStack.pop_back();
-    }
-    void testCaseEnded(TestCaseStats const& /* _testCaseStats */) override {
-        currentTestCaseInfo.reset();
-    }
-    void testGroupEnded(TestGroupStats const& /* _testGroupStats */) override {
-        currentGroupInfo.reset();
-    }
-    void testRunEnded(TestRunStats const& /* _testRunStats */) override {
-        currentTestCaseInfo.reset();
-        currentGroupInfo.reset();
-        currentTestRunInfo.reset();
-    }
-
-    void skipTest(TestCaseInfo const&) override {
-        // Don't do anything with this by default.
-        // It can optionally be overridden in the derived class.
-    }
-
-    IConfigPtr m_config;
-    std::ostream& stream;
-
-    LazyStat<TestRunInfo> currentTestRunInfo;
-    LazyStat<GroupInfo> currentGroupInfo;
-    LazyStat<TestCaseInfo> currentTestCaseInfo;
-
-    std::vector<SectionInfo> m_sectionStack;
-    ReporterPreferences m_reporterPrefs;
-};
-
-template<typename DerivedT>
-struct CumulativeReporterBase : IStreamingReporter {
-    template<typename T, typename ChildNodeT>
-    struct Node {
-        explicit Node( T const& _value ) : value( _value ) {}
-        virtual ~Node() {}
-
-        using ChildNodes = std::vector<std::shared_ptr<ChildNodeT>>;
-        T value;
-        ChildNodes children;
-    };
-    struct SectionNode {
-        explicit SectionNode(SectionStats const& _stats) : stats(_stats) {}
-        virtual ~SectionNode() = default;
-
-        bool operator == (SectionNode const& other) const {
-            return stats.sectionInfo.lineInfo == other.stats.sectionInfo.lineInfo;
-        }
-        bool operator == (std::shared_ptr<SectionNode> const& other) const {
-            return operator==(*other);
+        {
+            m_reporterPrefs.shouldRedirectStdOut = false;
+            if( !DerivedT::getSupportedVerbosities().count( m_config->verbosity() ) )
+                CATCH_ERROR( "Verbosity level not supported by this reporter" );
         }
 
-        SectionStats stats;
-        using ChildSections = std::vector<std::shared_ptr<SectionNode>>;
-        using Assertions = std::vector<AssertionStats>;
-        ChildSections childSections;
-        Assertions assertions;
-        std::string stdOut;
-        std::string stdErr;
+        ReporterPreferences getPreferences() const override {
+            return m_reporterPrefs;
+        }
+
+        static std::set<Verbosity> getSupportedVerbosities() {
+            return { Verbosity::Normal };
+        }
+
+        ~StreamingReporterBase() override = default;
+
+        void noMatchingTestCases(std::string const&) override {}
+
+        void reportInvalidArguments(std::string const&) override {}
+
+        void testRunStarting(TestRunInfo const& _testRunInfo) override {
+            currentTestRunInfo = _testRunInfo;
+        }
+
+        void testGroupStarting(GroupInfo const& _groupInfo) override {
+            currentGroupInfo = _groupInfo;
+        }
+
+        void testCaseStarting(TestCaseInfo const& _testInfo) override  {
+            currentTestCaseInfo = _testInfo;
+        }
+        void sectionStarting(SectionInfo const& _sectionInfo) override {
+            m_sectionStack.push_back(_sectionInfo);
+        }
+
+        void sectionEnded(SectionStats const& /* _sectionStats */) override {
+            m_sectionStack.pop_back();
+        }
+        void testCaseEnded(TestCaseStats const& /* _testCaseStats */) override {
+            currentTestCaseInfo.reset();
+        }
+        void testGroupEnded(TestGroupStats const& /* _testGroupStats */) override {
+            currentGroupInfo.reset();
+        }
+        void testRunEnded(TestRunStats const& /* _testRunStats */) override {
+            currentTestCaseInfo.reset();
+            currentGroupInfo.reset();
+            currentTestRunInfo.reset();
+        }
+
+        void skipTest(TestCaseInfo const&) override {
+            // Don't do anything with this by default.
+            // It can optionally be overridden in the derived class.
+        }
+
+        IConfigPtr m_config;
+        std::ostream& stream;
+
+        LazyStat<TestRunInfo> currentTestRunInfo;
+        LazyStat<GroupInfo> currentGroupInfo;
+        LazyStat<TestCaseInfo> currentTestCaseInfo;
+
+        std::vector<SectionInfo> m_sectionStack;
+        ReporterPreferences m_reporterPrefs;
     };
 
-    struct BySectionInfo {
-        BySectionInfo( SectionInfo const& other ) : m_other( other ) {}
-        BySectionInfo( BySectionInfo const& other ) : m_other( other.m_other ) {}
-        bool operator() (std::shared_ptr<SectionNode> const& node) const {
-            return ((node->stats.sectionInfo.name == m_other.name) &&
-                (node->stats.sectionInfo.lineInfo == m_other.lineInfo));
-        }
-        void operator=(BySectionInfo const&) = delete;
+    template<typename DerivedT>
+    struct CumulativeReporterBase : IStreamingReporter {
+        template<typename T, typename ChildNodeT>
+        struct Node {
+            explicit Node( T const& _value ) : value( _value ) {}
+            virtual ~Node() {}
 
-    private:
-        SectionInfo const& m_other;
-    };
+            using ChildNodes = std::vector<std::shared_ptr<ChildNodeT>>;
+            T value;
+            ChildNodes children;
+        };
+        struct SectionNode {
+            explicit SectionNode(SectionStats const& _stats) : stats(_stats) {}
+            virtual ~SectionNode() = default;
 
-    using TestCaseNode = Node<TestCaseStats, SectionNode>;
-    using TestGroupNode = Node<TestGroupStats, TestCaseNode>;
-    using TestRunNode = Node<TestRunStats, TestGroupNode>;
-
-    CumulativeReporterBase( ReporterConfig const& _config )
-        :   m_config( _config.fullConfig() ),
-            stream( _config.stream() )
-    {
-        m_reporterPrefs.shouldRedirectStdOut = false;
-        if( !DerivedT::getSupportedVerbosities().count( m_config->verbosity() ) )
-            CATCH_ERROR( "Verbosity level not supported by this reporter" );
-    }
-    ~CumulativeReporterBase() override = default;
-
-    ReporterPreferences getPreferences() const override {
-        return m_reporterPrefs;
-    }
-
-    static std::set<Verbosity> getSupportedVerbosities() {
-        return { Verbosity::Normal };
-    }
-
-    void testRunStarting( TestRunInfo const& ) override {}
-    void testGroupStarting( GroupInfo const& ) override {}
-
-    void testCaseStarting( TestCaseInfo const& ) override {}
-
-    void sectionStarting( SectionInfo const& sectionInfo ) override {
-        SectionStats incompleteStats( sectionInfo, Counts(), 0, false );
-        std::shared_ptr<SectionNode> node;
-        if( m_sectionStack.empty() ) {
-            if( !m_rootSection )
-                m_rootSection = std::make_shared<SectionNode>( incompleteStats );
-            node = m_rootSection;
-        }
-        else {
-            SectionNode& parentNode = *m_sectionStack.back();
-            auto it =
-                std::find_if(   parentNode.childSections.begin(),
-                                parentNode.childSections.end(),
-                                BySectionInfo( sectionInfo ) );
-            if( it == parentNode.childSections.end() ) {
-                node = std::make_shared<SectionNode>( incompleteStats );
-                parentNode.childSections.push_back( node );
+            bool operator == (SectionNode const& other) const {
+                return stats.sectionInfo.lineInfo == other.stats.sectionInfo.lineInfo;
             }
-            else
-                node = *it;
+            bool operator == (std::shared_ptr<SectionNode> const& other) const {
+                return operator==(*other);
+            }
+
+            SectionStats stats;
+            using ChildSections = std::vector<std::shared_ptr<SectionNode>>;
+            using Assertions = std::vector<AssertionStats>;
+            ChildSections childSections;
+            Assertions assertions;
+            std::string stdOut;
+            std::string stdErr;
+        };
+
+        struct BySectionInfo {
+            BySectionInfo( SectionInfo const& other ) : m_other( other ) {}
+            BySectionInfo( BySectionInfo const& other ) : m_other( other.m_other ) {}
+            bool operator() (std::shared_ptr<SectionNode> const& node) const {
+                return ((node->stats.sectionInfo.name == m_other.name) &&
+                        (node->stats.sectionInfo.lineInfo == m_other.lineInfo));
+            }
+            void operator=(BySectionInfo const&) = delete;
+
+        private:
+            SectionInfo const& m_other;
+        };
+
+        using TestCaseNode = Node<TestCaseStats, SectionNode>;
+        using TestGroupNode = Node<TestGroupStats, TestCaseNode>;
+        using TestRunNode = Node<TestRunStats, TestGroupNode>;
+
+        CumulativeReporterBase( ReporterConfig const& _config )
+        :   m_config( _config.fullConfig() ),
+            stream( _config.stream() )
+        {
+            m_reporterPrefs.shouldRedirectStdOut = false;
+            if( !DerivedT::getSupportedVerbosities().count( m_config->verbosity() ) )
+                CATCH_ERROR( "Verbosity level not supported by this reporter" );
         }
-        m_sectionStack.push_back( node );
-        m_deepestSection = std::move(node);
+        ~CumulativeReporterBase() override = default;
+
+        ReporterPreferences getPreferences() const override {
+            return m_reporterPrefs;
+        }
+
+        static std::set<Verbosity> getSupportedVerbosities() {
+            return { Verbosity::Normal };
+        }
+
+        void testRunStarting( TestRunInfo const& ) override {}
+        void testGroupStarting( GroupInfo const& ) override {}
+
+        void testCaseStarting( TestCaseInfo const& ) override {}
+
+        void sectionStarting( SectionInfo const& sectionInfo ) override {
+            SectionStats incompleteStats( sectionInfo, Counts(), 0, false );
+            std::shared_ptr<SectionNode> node;
+            if( m_sectionStack.empty() ) {
+                if( !m_rootSection )
+                    m_rootSection = std::make_shared<SectionNode>( incompleteStats );
+                node = m_rootSection;
+            }
+            else {
+                SectionNode& parentNode = *m_sectionStack.back();
+                auto it =
+                    std::find_if(   parentNode.childSections.begin(),
+                                    parentNode.childSections.end(),
+                                    BySectionInfo( sectionInfo ) );
+                if( it == parentNode.childSections.end() ) {
+                    node = std::make_shared<SectionNode>( incompleteStats );
+                    parentNode.childSections.push_back( node );
+                }
+                else
+                    node = *it;
+            }
+            m_sectionStack.push_back( node );
+            m_deepestSection = std::move(node);
+        }
+
+        void assertionStarting(AssertionInfo const&) override {}
+
+        bool assertionEnded(AssertionStats const& assertionStats) override {
+            assert(!m_sectionStack.empty());
+            // AssertionResult holds a pointer to a temporary DecomposedExpression,
+            // which getExpandedExpression() calls to build the expression string.
+            // Our section stack copy of the assertionResult will likely outlive the
+            // temporary, so it must be expanded or discarded now to avoid calling
+            // a destroyed object later.
+            prepareExpandedExpression(const_cast<AssertionResult&>( assertionStats.assertionResult ) );
+            SectionNode& sectionNode = *m_sectionStack.back();
+            sectionNode.assertions.push_back(assertionStats);
+            return true;
+        }
+        void sectionEnded(SectionStats const& sectionStats) override {
+            assert(!m_sectionStack.empty());
+            SectionNode& node = *m_sectionStack.back();
+            node.stats = sectionStats;
+            m_sectionStack.pop_back();
+        }
+        void testCaseEnded(TestCaseStats const& testCaseStats) override {
+            auto node = std::make_shared<TestCaseNode>(testCaseStats);
+            assert(m_sectionStack.size() == 0);
+            node->children.push_back(m_rootSection);
+            m_testCases.push_back(node);
+            m_rootSection.reset();
+
+            assert(m_deepestSection);
+            m_deepestSection->stdOut = testCaseStats.stdOut;
+            m_deepestSection->stdErr = testCaseStats.stdErr;
+        }
+        void testGroupEnded(TestGroupStats const& testGroupStats) override {
+            auto node = std::make_shared<TestGroupNode>(testGroupStats);
+            node->children.swap(m_testCases);
+            m_testGroups.push_back(node);
+        }
+        void testRunEnded(TestRunStats const& testRunStats) override {
+            auto node = std::make_shared<TestRunNode>(testRunStats);
+            node->children.swap(m_testGroups);
+            m_testRuns.push_back(node);
+            testRunEndedCumulative();
+        }
+        virtual void testRunEndedCumulative() = 0;
+
+        void skipTest(TestCaseInfo const&) override {}
+
+        IConfigPtr m_config;
+        std::ostream& stream;
+        std::vector<AssertionStats> m_assertions;
+        std::vector<std::vector<std::shared_ptr<SectionNode>>> m_sections;
+        std::vector<std::shared_ptr<TestCaseNode>> m_testCases;
+        std::vector<std::shared_ptr<TestGroupNode>> m_testGroups;
+
+        std::vector<std::shared_ptr<TestRunNode>> m_testRuns;
+
+        std::shared_ptr<SectionNode> m_rootSection;
+        std::shared_ptr<SectionNode> m_deepestSection;
+        std::vector<std::shared_ptr<SectionNode>> m_sectionStack;
+        ReporterPreferences m_reporterPrefs;
+    };
+
+    template<char C>
+    char const* getLineOfChars() {
+        static char line[CATCH_CONFIG_CONSOLE_WIDTH] = {0};
+        if( !*line ) {
+            std::memset( line, C, CATCH_CONFIG_CONSOLE_WIDTH-1 );
+            line[CATCH_CONFIG_CONSOLE_WIDTH-1] = 0;
+        }
+        return line;
     }
 
-    void assertionStarting(AssertionInfo const&) override {}
+    struct TestEventListenerBase : StreamingReporterBase<TestEventListenerBase> {
+        TestEventListenerBase( ReporterConfig const& _config );
 
-    bool assertionEnded(AssertionStats const& assertionStats) override {
-        assert(!m_sectionStack.empty());
-        // AssertionResult holds a pointer to a temporary DecomposedExpression,
-        // which getExpandedExpression() calls to build the expression string.
-        // Our section stack copy of the assertionResult will likely outlive the
-        // temporary, so it must be expanded or discarded now to avoid calling
-        // a destroyed object later.
-        prepareExpandedExpression(const_cast<AssertionResult&>( assertionStats.assertionResult ) );
-        SectionNode& sectionNode = *m_sectionStack.back();
-        sectionNode.assertions.push_back(assertionStats);
-        return true;
-    }
-    void sectionEnded(SectionStats const& sectionStats) override {
-        assert(!m_sectionStack.empty());
-        SectionNode& node = *m_sectionStack.back();
-        node.stats = sectionStats;
-        m_sectionStack.pop_back();
-    }
-    void testCaseEnded(TestCaseStats const& testCaseStats) override {
-        auto node = std::make_shared<TestCaseNode>(testCaseStats);
-        assert(m_sectionStack.size() == 0);
-        node->children.push_back(m_rootSection);
-        m_testCases.push_back(node);
-        m_rootSection.reset();
+        static std::set<Verbosity> getSupportedVerbosities();
 
-        assert(m_deepestSection);
-        m_deepestSection->stdOut = testCaseStats.stdOut;
-        m_deepestSection->stdErr = testCaseStats.stdErr;
-    }
-    void testGroupEnded(TestGroupStats const& testGroupStats) override {
-        auto node = std::make_shared<TestGroupNode>(testGroupStats);
-        node->children.swap(m_testCases);
-        m_testGroups.push_back(node);
-    }
-    void testRunEnded(TestRunStats const& testRunStats) override {
-        auto node = std::make_shared<TestRunNode>(testRunStats);
-        node->children.swap(m_testGroups);
-        m_testRuns.push_back(node);
-        testRunEndedCumulative();
-    }
-    virtual void testRunEndedCumulative() = 0;
-
-    void skipTest(TestCaseInfo const&) override {}
-
-    IConfigPtr m_config;
-    std::ostream& stream;
-    std::vector<AssertionStats> m_assertions;
-    std::vector<std::vector<std::shared_ptr<SectionNode>>> m_sections;
-    std::vector<std::shared_ptr<TestCaseNode>> m_testCases;
-    std::vector<std::shared_ptr<TestGroupNode>> m_testGroups;
-
-    std::vector<std::shared_ptr<TestRunNode>> m_testRuns;
-
-    std::shared_ptr<SectionNode> m_rootSection;
-    std::shared_ptr<SectionNode> m_deepestSection;
-    std::vector<std::shared_ptr<SectionNode>> m_sectionStack;
-    ReporterPreferences m_reporterPrefs;
-};
-
-template<char C>
-char const* getLineOfChars() {
-    static char line[CATCH_CONFIG_CONSOLE_WIDTH] = {0};
-    if( !*line ) {
-        std::memset( line, C, CATCH_CONFIG_CONSOLE_WIDTH-1 );
-        line[CATCH_CONFIG_CONSOLE_WIDTH-1] = 0;
-    }
-    return line;
-}
-
-struct TestEventListenerBase : StreamingReporterBase<TestEventListenerBase> {
-    TestEventListenerBase( ReporterConfig const& _config );
-
-    static std::set<Verbosity> getSupportedVerbosities();
-
-    void assertionStarting(AssertionInfo const&) override;
-    bool assertionEnded(AssertionStats const&) override;
-};
+        void assertionStarting(AssertionInfo const&) override;
+        bool assertionEnded(AssertionStats const&) override;
+    };
 
 } // end namespace Catch
 
@@ -5984,57 +5987,57 @@ struct TestEventListenerBase : StreamingReporterBase<TestEventListenerBase> {
 
 namespace Catch {
 
-struct Colour {
-    enum Code {
-        None = 0,
+    struct Colour {
+        enum Code {
+            None = 0,
 
-        White,
-        Red,
-        Green,
-        Blue,
-        Cyan,
-        Yellow,
-        Grey,
+            White,
+            Red,
+            Green,
+            Blue,
+            Cyan,
+            Yellow,
+            Grey,
 
-        Bright = 0x10,
+            Bright = 0x10,
 
-        BrightRed = Bright | Red,
-        BrightGreen = Bright | Green,
-        LightGrey = Bright | Grey,
-        BrightWhite = Bright | White,
-        BrightYellow = Bright | Yellow,
+            BrightRed = Bright | Red,
+            BrightGreen = Bright | Green,
+            LightGrey = Bright | Grey,
+            BrightWhite = Bright | White,
+            BrightYellow = Bright | Yellow,
 
-        // By intention
-        FileName = LightGrey,
-        Warning = BrightYellow,
-        ResultError = BrightRed,
-        ResultSuccess = BrightGreen,
-        ResultExpectedFailure = Warning,
+            // By intention
+            FileName = LightGrey,
+            Warning = BrightYellow,
+            ResultError = BrightRed,
+            ResultSuccess = BrightGreen,
+            ResultExpectedFailure = Warning,
 
-        Error = BrightRed,
-        Success = Green,
+            Error = BrightRed,
+            Success = Green,
 
-        OriginalExpression = Cyan,
-        ReconstructedExpression = BrightYellow,
+            OriginalExpression = Cyan,
+            ReconstructedExpression = BrightYellow,
 
-        SecondaryText = LightGrey,
-        Headers = White
+            SecondaryText = LightGrey,
+            Headers = White
+        };
+
+        // Use constructed object for RAII guard
+        Colour( Code _colourCode );
+        Colour( Colour&& other ) noexcept;
+        Colour& operator=( Colour&& other ) noexcept;
+        ~Colour();
+
+        // Use static method for one-shot changes
+        static void use( Code _colourCode );
+
+    private:
+        bool m_moved = false;
     };
 
-    // Use constructed object for RAII guard
-    Colour( Code _colourCode );
-    Colour( Colour&& other ) noexcept;
-    Colour& operator=( Colour&& other ) noexcept;
-    ~Colour();
-
-    // Use static method for one-shot changes
-    static void use( Code _colourCode );
-
-private:
-    bool m_moved = false;
-};
-
-std::ostream& operator << ( std::ostream& os, Colour const& );
+    std::ostream& operator << ( std::ostream& os, Colour const& );
 
 } // end namespace Catch
 
@@ -6044,46 +6047,46 @@ std::ostream& operator << ( std::ostream& os, Colour const& );
 
 namespace Catch {
 
-template<typename T>
-class ReporterRegistrar {
+    template<typename T>
+    class ReporterRegistrar {
 
-    class ReporterFactory : public IReporterFactory {
+        class ReporterFactory : public IReporterFactory {
 
-        IStreamingReporterPtr create( ReporterConfig const& config ) const override {
-            return std::unique_ptr<T>( new T( config ) );
-        }
+            IStreamingReporterPtr create( ReporterConfig const& config ) const override {
+                return std::unique_ptr<T>( new T( config ) );
+            }
 
-        std::string getDescription() const override {
-            return T::getDescription();
-        }
-    };
+            std::string getDescription() const override {
+                return T::getDescription();
+            }
+        };
 
-public:
+    public:
 
-    explicit ReporterRegistrar( std::string const& name ) {
-        getMutableRegistryHub().registerReporter( name, std::make_shared<ReporterFactory>() );
-    }
-};
-
-template<typename T>
-class ListenerRegistrar {
-
-    class ListenerFactory : public IReporterFactory {
-
-        IStreamingReporterPtr create( ReporterConfig const& config ) const override {
-            return std::unique_ptr<T>( new T( config ) );
-        }
-        std::string getDescription() const override {
-            return std::string();
+        explicit ReporterRegistrar( std::string const& name ) {
+            getMutableRegistryHub().registerReporter( name, std::make_shared<ReporterFactory>() );
         }
     };
 
-public:
+    template<typename T>
+    class ListenerRegistrar {
 
-    ListenerRegistrar() {
-        getMutableRegistryHub().registerListener( std::make_shared<ListenerFactory>() );
-    }
-};
+        class ListenerFactory : public IReporterFactory {
+
+            IStreamingReporterPtr create( ReporterConfig const& config ) const override {
+                return std::unique_ptr<T>( new T( config ) );
+            }
+            std::string getDescription() const override {
+                return std::string();
+            }
+        };
+
+    public:
+
+        ListenerRegistrar() {
+            getMutableRegistryHub().registerListener( std::make_shared<ListenerFactory>() );
+        }
+    };
 }
 
 #if !defined(CATCH_CONFIG_DISABLE)
@@ -6112,25 +6115,25 @@ public:
 
 namespace Catch {
 
-struct CompactReporter : StreamingReporterBase<CompactReporter> {
+    struct CompactReporter : StreamingReporterBase<CompactReporter> {
 
-    using StreamingReporterBase::StreamingReporterBase;
+        using StreamingReporterBase::StreamingReporterBase;
 
-    ~CompactReporter() override;
+        ~CompactReporter() override;
 
-    static std::string getDescription();
+        static std::string getDescription();
 
-    void noMatchingTestCases(std::string const& spec) override;
+        void noMatchingTestCases(std::string const& spec) override;
 
-    void assertionStarting(AssertionInfo const&) override;
+        void assertionStarting(AssertionInfo const&) override;
 
-    bool assertionEnded(AssertionStats const& _assertionStats) override;
+        bool assertionEnded(AssertionStats const& _assertionStats) override;
 
-    void sectionEnded(SectionStats const& _sectionStats) override;
+        void sectionEnded(SectionStats const& _sectionStats) override;
 
-    void testRunEnded(TestRunStats const& _testRunStats) override;
+        void testRunEnded(TestRunStats const& _testRunStats) override;
 
-};
+    };
 
 } // end namespace Catch
 
@@ -6145,65 +6148,65 @@ struct CompactReporter : StreamingReporterBase<CompactReporter> {
 #endif
 
 namespace Catch {
-// Fwd decls
-struct SummaryColumn;
-class TablePrinter;
+    // Fwd decls
+    struct SummaryColumn;
+    class TablePrinter;
 
-struct ConsoleReporter : StreamingReporterBase<ConsoleReporter> {
-    std::unique_ptr<TablePrinter> m_tablePrinter;
+    struct ConsoleReporter : StreamingReporterBase<ConsoleReporter> {
+        std::unique_ptr<TablePrinter> m_tablePrinter;
 
-    ConsoleReporter(ReporterConfig const& config);
-    ~ConsoleReporter() override;
-    static std::string getDescription();
+        ConsoleReporter(ReporterConfig const& config);
+        ~ConsoleReporter() override;
+        static std::string getDescription();
 
-    void noMatchingTestCases(std::string const& spec) override;
+        void noMatchingTestCases(std::string const& spec) override;
 
-    void reportInvalidArguments(std::string const&arg) override;
+        void reportInvalidArguments(std::string const&arg) override;
 
-    void assertionStarting(AssertionInfo const&) override;
+        void assertionStarting(AssertionInfo const&) override;
 
-    bool assertionEnded(AssertionStats const& _assertionStats) override;
+        bool assertionEnded(AssertionStats const& _assertionStats) override;
 
-    void sectionStarting(SectionInfo const& _sectionInfo) override;
-    void sectionEnded(SectionStats const& _sectionStats) override;
+        void sectionStarting(SectionInfo const& _sectionInfo) override;
+        void sectionEnded(SectionStats const& _sectionStats) override;
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
-    void benchmarkPreparing(std::string const& name) override;
+        void benchmarkPreparing(std::string const& name) override;
         void benchmarkStarting(BenchmarkInfo const& info) override;
         void benchmarkEnded(BenchmarkStats<> const& stats) override;
         void benchmarkFailed(std::string const& error) override;
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-    void testCaseEnded(TestCaseStats const& _testCaseStats) override;
-    void testGroupEnded(TestGroupStats const& _testGroupStats) override;
-    void testRunEnded(TestRunStats const& _testRunStats) override;
-    void testRunStarting(TestRunInfo const& _testRunInfo) override;
-private:
+        void testCaseEnded(TestCaseStats const& _testCaseStats) override;
+        void testGroupEnded(TestGroupStats const& _testGroupStats) override;
+        void testRunEnded(TestRunStats const& _testRunStats) override;
+        void testRunStarting(TestRunInfo const& _testRunInfo) override;
+    private:
 
-    void lazyPrint();
+        void lazyPrint();
 
-    void lazyPrintWithoutClosingBenchmarkTable();
-    void lazyPrintRunInfo();
-    void lazyPrintGroupInfo();
-    void printTestCaseAndSectionHeader();
+        void lazyPrintWithoutClosingBenchmarkTable();
+        void lazyPrintRunInfo();
+        void lazyPrintGroupInfo();
+        void printTestCaseAndSectionHeader();
 
-    void printClosedHeader(std::string const& _name);
-    void printOpenHeader(std::string const& _name);
+        void printClosedHeader(std::string const& _name);
+        void printOpenHeader(std::string const& _name);
 
-    // if string has a : in first line will set indent to follow it on
-    // subsequent lines
-    void printHeaderString(std::string const& _string, std::size_t indent = 0);
+        // if string has a : in first line will set indent to follow it on
+        // subsequent lines
+        void printHeaderString(std::string const& _string, std::size_t indent = 0);
 
-    void printTotals(Totals const& totals);
-    void printSummaryRow(std::string const& label, std::vector<SummaryColumn> const& cols, std::size_t row);
+        void printTotals(Totals const& totals);
+        void printSummaryRow(std::string const& label, std::vector<SummaryColumn> const& cols, std::size_t row);
 
-    void printTotalsDivider(Totals const& totals);
-    void printSummaryDivider();
-    void printTestFilters();
+        void printTotalsDivider(Totals const& totals);
+        void printSummaryDivider();
+        void printTestFilters();
 
-private:
-    bool m_headerPrinted = false;
-};
+    private:
+        bool m_headerPrinted = false;
+    };
 
 } // end namespace Catch
 
@@ -6219,149 +6222,150 @@ private:
 #include <vector>
 
 namespace Catch {
-enum class XmlFormatting {
-    None = 0x00,
-    Indent = 0x01,
-    Newline = 0x02,
-};
-
-XmlFormatting operator | (XmlFormatting lhs, XmlFormatting rhs);
-XmlFormatting operator & (XmlFormatting lhs, XmlFormatting rhs);
-
-class XmlEncode {
-public:
-    enum ForWhat { ForTextNodes, ForAttributes };
-
-    XmlEncode( std::string const& str, ForWhat forWhat = ForTextNodes );
-
-    void encodeTo( std::ostream& os ) const;
-
-    friend std::ostream& operator << ( std::ostream& os, XmlEncode const& xmlEncode );
-
-private:
-    std::string m_str;
-    ForWhat m_forWhat;
-};
-
-class XmlWriter {
-public:
-
-    class ScopedElement {
-    public:
-        ScopedElement( XmlWriter* writer, XmlFormatting fmt );
-
-        ScopedElement( ScopedElement&& other ) noexcept;
-        ScopedElement& operator=( ScopedElement&& other ) noexcept;
-
-        ~ScopedElement();
-
-        ScopedElement& writeText( std::string const& text, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent );
-
-        template<typename T>
-        ScopedElement& writeAttribute( std::string const& name, T const& attribute ) {
-            m_writer->writeAttribute( name, attribute );
-            return *this;
-        }
-
-    private:
-        mutable XmlWriter* m_writer = nullptr;
-        XmlFormatting m_fmt;
+    enum class XmlFormatting {
+        None = 0x00,
+        Indent = 0x01,
+        Newline = 0x02,
     };
 
-    XmlWriter( std::ostream& os = Catch::cout() );
-    ~XmlWriter();
+    XmlFormatting operator | (XmlFormatting lhs, XmlFormatting rhs);
+    XmlFormatting operator & (XmlFormatting lhs, XmlFormatting rhs);
 
-    XmlWriter( XmlWriter const& ) = delete;
-    XmlWriter& operator=( XmlWriter const& ) = delete;
+    class XmlEncode {
+    public:
+        enum ForWhat { ForTextNodes, ForAttributes };
 
-    XmlWriter& startElement( std::string const& name, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
+        XmlEncode( std::string const& str, ForWhat forWhat = ForTextNodes );
 
-    ScopedElement scopedElement( std::string const& name, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
+        void encodeTo( std::ostream& os ) const;
 
-    XmlWriter& endElement(XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
+        friend std::ostream& operator << ( std::ostream& os, XmlEncode const& xmlEncode );
 
-    XmlWriter& writeAttribute( std::string const& name, std::string const& attribute );
+    private:
+        std::string m_str;
+        ForWhat m_forWhat;
+    };
 
-    XmlWriter& writeAttribute( std::string const& name, bool attribute );
+    class XmlWriter {
+    public:
 
-    template<typename T>
-    XmlWriter& writeAttribute( std::string const& name, T const& attribute ) {
-        ReusableStringStream rss;
-        rss << attribute;
-        return writeAttribute( name, rss.str() );
-    }
+        class ScopedElement {
+        public:
+            ScopedElement( XmlWriter* writer, XmlFormatting fmt );
 
-    XmlWriter& writeText( std::string const& text, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
+            ScopedElement( ScopedElement&& other ) noexcept;
+            ScopedElement& operator=( ScopedElement&& other ) noexcept;
 
-    XmlWriter& writeComment(std::string const& text, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
+            ~ScopedElement();
 
-    void writeStylesheetRef( std::string const& url );
+            ScopedElement& writeText( std::string const& text, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent );
 
-    XmlWriter& writeBlankLine();
+            template<typename T>
+            ScopedElement& writeAttribute( std::string const& name, T const& attribute ) {
+                m_writer->writeAttribute( name, attribute );
+                return *this;
+            }
 
-    void ensureTagClosed();
+        private:
+            mutable XmlWriter* m_writer = nullptr;
+            XmlFormatting m_fmt;
+        };
 
-private:
+        XmlWriter( std::ostream& os = Catch::cout() );
+        ~XmlWriter();
 
-    void applyFormatting(XmlFormatting fmt);
+        XmlWriter( XmlWriter const& ) = delete;
+        XmlWriter& operator=( XmlWriter const& ) = delete;
 
-    void writeDeclaration();
+        XmlWriter& startElement( std::string const& name, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
 
-    void newlineIfNecessary();
+        ScopedElement scopedElement( std::string const& name, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
 
-    bool m_tagIsOpen = false;
-    bool m_needsNewline = false;
-    std::vector<std::string> m_tags;
-    std::string m_indent;
-    std::ostream& m_os;
-};
+        XmlWriter& endElement(XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
+
+        XmlWriter& writeAttribute( std::string const& name, std::string const& attribute );
+
+        XmlWriter& writeAttribute( std::string const& name, bool attribute );
+
+        template<typename T>
+        XmlWriter& writeAttribute( std::string const& name, T const& attribute ) {
+            ReusableStringStream rss;
+            rss << attribute;
+            return writeAttribute( name, rss.str() );
+        }
+
+        XmlWriter& writeText( std::string const& text, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
+
+        XmlWriter& writeComment(std::string const& text, XmlFormatting fmt = XmlFormatting::Newline | XmlFormatting::Indent);
+
+        void writeStylesheetRef( std::string const& url );
+
+        XmlWriter& writeBlankLine();
+
+        void ensureTagClosed();
+
+    private:
+
+        void applyFormatting(XmlFormatting fmt);
+
+        void writeDeclaration();
+
+        void newlineIfNecessary();
+
+        bool m_tagIsOpen = false;
+        bool m_needsNewline = false;
+        std::vector<std::string> m_tags;
+        std::string m_indent;
+        std::ostream& m_os;
+    };
 
 }
 
 // end catch_xmlwriter.h
 namespace Catch {
 
-class JunitReporter : public CumulativeReporterBase<JunitReporter> {
-public:
-    JunitReporter(ReporterConfig const& _config);
+    class JunitReporter : public CumulativeReporterBase<JunitReporter> {
+    public:
+        JunitReporter(ReporterConfig const& _config);
 
-    ~JunitReporter() override;
+        ~JunitReporter() override;
 
-    static std::string getDescription();
+        static std::string getDescription();
 
-    void noMatchingTestCases(std::string const& /*spec*/) override;
+        void noMatchingTestCases(std::string const& /*spec*/) override;
 
-    void testRunStarting(TestRunInfo const& runInfo) override;
+        void testRunStarting(TestRunInfo const& runInfo) override;
 
-    void testGroupStarting(GroupInfo const& groupInfo) override;
+        void testGroupStarting(GroupInfo const& groupInfo) override;
 
-    void testCaseStarting(TestCaseInfo const& testCaseInfo) override;
-    bool assertionEnded(AssertionStats const& assertionStats) override;
+        void testCaseStarting(TestCaseInfo const& testCaseInfo) override;
+        bool assertionEnded(AssertionStats const& assertionStats) override;
 
-    void testCaseEnded(TestCaseStats const& testCaseStats) override;
+        void testCaseEnded(TestCaseStats const& testCaseStats) override;
 
-    void testGroupEnded(TestGroupStats const& testGroupStats) override;
+        void testGroupEnded(TestGroupStats const& testGroupStats) override;
 
-    void testRunEndedCumulative() override;
+        void testRunEndedCumulative() override;
 
-    void writeGroup(TestGroupNode const& groupNode, double suiteTime);
+        void writeGroup(TestGroupNode const& groupNode, double suiteTime);
 
-    void writeTestCase(TestCaseNode const& testCaseNode);
+        void writeTestCase(TestCaseNode const& testCaseNode);
 
-    void writeSection(std::string const& className,
-                      std::string const& rootName,
-                      SectionNode const& sectionNode);
+        void writeSection( std::string const& className,
+                           std::string const& rootName,
+                           SectionNode const& sectionNode,
+                           bool testOkToFail );
 
-    void writeAssertions(SectionNode const& sectionNode);
-    void writeAssertion(AssertionStats const& stats);
+        void writeAssertions(SectionNode const& sectionNode);
+        void writeAssertion(AssertionStats const& stats);
 
-    XmlWriter xml;
-    Timer suiteTimer;
-    std::string stdOutForSuite;
-    std::string stdErrForSuite;
-    unsigned int unexpectedExceptions = 0;
-    bool m_okToFail = false;
-};
+        XmlWriter xml;
+        Timer suiteTimer;
+        std::string stdOutForSuite;
+        std::string stdErrForSuite;
+        unsigned int unexpectedExceptions = 0;
+        bool m_okToFail = false;
+    };
 
 } // end namespace Catch
 
@@ -6369,54 +6373,54 @@ public:
 // start catch_reporter_xml.h
 
 namespace Catch {
-class XmlReporter : public StreamingReporterBase<XmlReporter> {
-public:
-    XmlReporter(ReporterConfig const& _config);
+    class XmlReporter : public StreamingReporterBase<XmlReporter> {
+    public:
+        XmlReporter(ReporterConfig const& _config);
 
-    ~XmlReporter() override;
+        ~XmlReporter() override;
 
-    static std::string getDescription();
+        static std::string getDescription();
 
-    virtual std::string getStylesheetRef() const;
+        virtual std::string getStylesheetRef() const;
 
-    void writeSourceInfo(SourceLineInfo const& sourceInfo);
+        void writeSourceInfo(SourceLineInfo const& sourceInfo);
 
-public: // StreamingReporterBase
+    public: // StreamingReporterBase
 
-    void noMatchingTestCases(std::string const& s) override;
+        void noMatchingTestCases(std::string const& s) override;
 
-    void testRunStarting(TestRunInfo const& testInfo) override;
+        void testRunStarting(TestRunInfo const& testInfo) override;
 
-    void testGroupStarting(GroupInfo const& groupInfo) override;
+        void testGroupStarting(GroupInfo const& groupInfo) override;
 
-    void testCaseStarting(TestCaseInfo const& testInfo) override;
+        void testCaseStarting(TestCaseInfo const& testInfo) override;
 
-    void sectionStarting(SectionInfo const& sectionInfo) override;
+        void sectionStarting(SectionInfo const& sectionInfo) override;
 
-    void assertionStarting(AssertionInfo const&) override;
+        void assertionStarting(AssertionInfo const&) override;
 
-    bool assertionEnded(AssertionStats const& assertionStats) override;
+        bool assertionEnded(AssertionStats const& assertionStats) override;
 
-    void sectionEnded(SectionStats const& sectionStats) override;
+        void sectionEnded(SectionStats const& sectionStats) override;
 
-    void testCaseEnded(TestCaseStats const& testCaseStats) override;
+        void testCaseEnded(TestCaseStats const& testCaseStats) override;
 
-    void testGroupEnded(TestGroupStats const& testGroupStats) override;
+        void testGroupEnded(TestGroupStats const& testGroupStats) override;
 
-    void testRunEnded(TestRunStats const& testRunStats) override;
+        void testRunEnded(TestRunStats const& testRunStats) override;
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
-    void benchmarkPreparing(std::string const& name) override;
+        void benchmarkPreparing(std::string const& name) override;
         void benchmarkStarting(BenchmarkInfo const&) override;
         void benchmarkEnded(BenchmarkStats<> const&) override;
         void benchmarkFailed(std::string const&) override;
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-private:
-    Timer m_testCaseTimer;
-    XmlWriter m_xml;
-    int m_sectionDepth = 0;
-};
+    private:
+        Timer m_testCaseTimer;
+        XmlWriter m_xml;
+        int m_sectionDepth = 0;
+    };
 
 } // end namespace Catch
 
@@ -6885,7 +6889,7 @@ namespace Catch {
                     }
                     iters *= 2;
                 }
-                throw optimized_away_error{};
+                Catch::throw_exception(optimized_away_error{});
             }
         } // namespace Detail
     } // namespace Benchmark
@@ -6893,6 +6897,7 @@ namespace Catch {
 
 // end catch_run_for_at_least.hpp
 #include <algorithm>
+#include <iterator>
 
 namespace Catch {
     namespace Benchmark {
@@ -7063,8 +7068,8 @@ namespace Catch {
                 double b2 = bias - z1;
                 double a1 = a(b1);
                 double a2 = a(b2);
-                auto lo = std::max(cumn(a1), 0);
-                auto hi = std::min(cumn(a2), n - 1);
+                auto lo = (std::max)(cumn(a1), 0);
+                auto hi = (std::min)(cumn(a2), n - 1);
 
                 return { point, resample[lo], resample[hi], confidence_level };
             }
@@ -7133,7 +7138,9 @@ namespace Catch {
             }
             template <typename Clock>
             EnvironmentEstimate<FloatDuration<Clock>> estimate_clock_cost(FloatDuration<Clock> resolution) {
-                auto time_limit = std::min(resolution * clock_cost_estimation_tick_limit, FloatDuration<Clock>(clock_cost_estimation_time_limit));
+                auto time_limit = (std::min)(
+                    resolution * clock_cost_estimation_tick_limit,
+                    FloatDuration<Clock>(clock_cost_estimation_time_limit));
                 auto time_clock = [](int k) {
                     return Detail::measure<Clock>([k] {
                         for (int i = 0; i < k; ++i) {
@@ -7468,150 +7475,154 @@ namespace Catch {
 namespace Catch {
 namespace TestCaseTracking {
 
-struct NameAndLocation {
-    std::string name;
-    SourceLineInfo location;
+    struct NameAndLocation {
+        std::string name;
+        SourceLineInfo location;
 
-    NameAndLocation( std::string const& _name, SourceLineInfo const& _location );
-    friend bool operator==(NameAndLocation const& lhs, NameAndLocation const& rhs) {
-        return lhs.name == rhs.name
-            && lhs.location == rhs.location;
-    }
-};
-
-class ITracker;
-
-using ITrackerPtr = std::shared_ptr<ITracker>;
-
-class  ITracker {
-    NameAndLocation m_nameAndLocation;
-
-public:
-    ITracker(NameAndLocation const& nameAndLoc) :
-        m_nameAndLocation(nameAndLoc)
-    {}
-
-    // static queries
-    NameAndLocation const& nameAndLocation() const {
-        return m_nameAndLocation;
-    }
-
-    virtual ~ITracker();
-
-    // dynamic queries
-    virtual bool isComplete() const = 0; // Successfully completed or failed
-    virtual bool isSuccessfullyCompleted() const = 0;
-    virtual bool isOpen() const = 0; // Started but not complete
-    virtual bool hasChildren() const = 0;
-    virtual bool hasStarted() const = 0;
-
-    virtual ITracker& parent() = 0;
-
-    // actions
-    virtual void close() = 0; // Successfully complete
-    virtual void fail() = 0;
-    virtual void markAsNeedingAnotherRun() = 0;
-
-    virtual void addChild( ITrackerPtr const& child ) = 0;
-    virtual ITrackerPtr findChild( NameAndLocation const& nameAndLocation ) = 0;
-    virtual void openChild() = 0;
-
-    // Debug/ checking
-    virtual bool isSectionTracker() const = 0;
-    virtual bool isGeneratorTracker() const = 0;
-};
-
-class TrackerContext {
-
-    enum RunState {
-        NotStarted,
-        Executing,
-        CompletedCycle
+        NameAndLocation( std::string const& _name, SourceLineInfo const& _location );
+        friend bool operator==(NameAndLocation const& lhs, NameAndLocation const& rhs) {
+            return lhs.name == rhs.name
+                && lhs.location == rhs.location;
+        }
     };
 
-    ITrackerPtr m_rootTracker;
-    ITracker* m_currentTracker = nullptr;
-    RunState m_runState = NotStarted;
+    class ITracker;
 
-public:
+    using ITrackerPtr = std::shared_ptr<ITracker>;
 
-    ITracker& startRun();
-    void endRun();
+    class  ITracker {
+        NameAndLocation m_nameAndLocation;
 
-    void startCycle();
-    void completeCycle();
+    public:
+        ITracker(NameAndLocation const& nameAndLoc) :
+            m_nameAndLocation(nameAndLoc)
+        {}
 
-    bool completedCycle() const;
-    ITracker& currentTracker();
-    void setCurrentTracker( ITracker* tracker );
-};
+        // static queries
+        NameAndLocation const& nameAndLocation() const {
+            return m_nameAndLocation;
+        }
 
-class TrackerBase : public ITracker {
-protected:
-    enum CycleState {
-        NotStarted,
-        Executing,
-        ExecutingChildren,
-        NeedsAnotherRun,
-        CompletedSuccessfully,
-        Failed
+        virtual ~ITracker();
+
+        // dynamic queries
+        virtual bool isComplete() const = 0; // Successfully completed or failed
+        virtual bool isSuccessfullyCompleted() const = 0;
+        virtual bool isOpen() const = 0; // Started but not complete
+        virtual bool hasChildren() const = 0;
+        virtual bool hasStarted() const = 0;
+
+        virtual ITracker& parent() = 0;
+
+        // actions
+        virtual void close() = 0; // Successfully complete
+        virtual void fail() = 0;
+        virtual void markAsNeedingAnotherRun() = 0;
+
+        virtual void addChild( ITrackerPtr const& child ) = 0;
+        virtual ITrackerPtr findChild( NameAndLocation const& nameAndLocation ) = 0;
+        virtual void openChild() = 0;
+
+        // Debug/ checking
+        virtual bool isSectionTracker() const = 0;
+        virtual bool isGeneratorTracker() const = 0;
     };
 
-    using Children = std::vector<ITrackerPtr>;
-    TrackerContext& m_ctx;
-    ITracker* m_parent;
-    Children m_children;
-    CycleState m_runState = NotStarted;
+    class TrackerContext {
 
-public:
-    TrackerBase( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent );
+        enum RunState {
+            NotStarted,
+            Executing,
+            CompletedCycle
+        };
 
-    bool isComplete() const override;
-    bool isSuccessfullyCompleted() const override;
-    bool isOpen() const override;
-    bool hasChildren() const override;
-    bool hasStarted() const override {
-        return m_runState != NotStarted;
-    }
+        ITrackerPtr m_rootTracker;
+        ITracker* m_currentTracker = nullptr;
+        RunState m_runState = NotStarted;
 
-    void addChild( ITrackerPtr const& child ) override;
+    public:
 
-    ITrackerPtr findChild( NameAndLocation const& nameAndLocation ) override;
-    ITracker& parent() override;
+        ITracker& startRun();
+        void endRun();
 
-    void openChild() override;
+        void startCycle();
+        void completeCycle();
 
-    bool isSectionTracker() const override;
-    bool isGeneratorTracker() const override;
+        bool completedCycle() const;
+        ITracker& currentTracker();
+        void setCurrentTracker( ITracker* tracker );
+    };
 
-    void open();
+    class TrackerBase : public ITracker {
+    protected:
+        enum CycleState {
+            NotStarted,
+            Executing,
+            ExecutingChildren,
+            NeedsAnotherRun,
+            CompletedSuccessfully,
+            Failed
+        };
 
-    void close() override;
-    void fail() override;
-    void markAsNeedingAnotherRun() override;
+        using Children = std::vector<ITrackerPtr>;
+        TrackerContext& m_ctx;
+        ITracker* m_parent;
+        Children m_children;
+        CycleState m_runState = NotStarted;
 
-private:
-    void moveToParent();
-    void moveToThis();
-};
+    public:
+        TrackerBase( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent );
 
-class SectionTracker : public TrackerBase {
-    std::vector<std::string> m_filters;
-    std::string m_trimmed_name;
-public:
-    SectionTracker( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent );
+        bool isComplete() const override;
+        bool isSuccessfullyCompleted() const override;
+        bool isOpen() const override;
+        bool hasChildren() const override;
+        bool hasStarted() const override {
+            return m_runState != NotStarted;
+        }
 
-    bool isSectionTracker() const override;
+        void addChild( ITrackerPtr const& child ) override;
 
-    bool isComplete() const override;
+        ITrackerPtr findChild( NameAndLocation const& nameAndLocation ) override;
+        ITracker& parent() override;
 
-    static SectionTracker& acquire( TrackerContext& ctx, NameAndLocation const& nameAndLocation );
+        void openChild() override;
 
-    void tryOpen();
+        bool isSectionTracker() const override;
+        bool isGeneratorTracker() const override;
 
-    void addInitialFilters( std::vector<std::string> const& filters );
-    void addNextFilters( std::vector<std::string> const& filters );
-};
+        void open();
+
+        void close() override;
+        void fail() override;
+        void markAsNeedingAnotherRun() override;
+
+    private:
+        void moveToParent();
+        void moveToThis();
+    };
+
+    class SectionTracker : public TrackerBase {
+        std::vector<std::string> m_filters;
+        std::string m_trimmed_name;
+    public:
+        SectionTracker( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent );
+
+        bool isSectionTracker() const override;
+
+        bool isComplete() const override;
+
+        static SectionTracker& acquire( TrackerContext& ctx, NameAndLocation const& nameAndLocation );
+
+        void tryOpen();
+
+        void addInitialFilters( std::vector<std::string> const& filters );
+        void addNextFilters( std::vector<std::string> const& filters );
+        //! Returns filters active in this tracker
+        std::vector<std::string> const& getFilters() const;
+        //! Returns whitespace-trimmed name of the tracked section
+        std::string const& trimmedName() const;
+    };
 
 } // namespace TestCaseTracking
 
@@ -7627,10 +7638,10 @@ using TestCaseTracking::SectionTracker;
 
 namespace Catch {
 
-struct LeakDetector {
-    LeakDetector();
-    ~LeakDetector();
-};
+    struct LeakDetector {
+        LeakDetector();
+        ~LeakDetector();
+    };
 
 }
 // end catch_leak_detector.h
@@ -7776,7 +7787,7 @@ namespace Catch {
                 double sb = stddev.point;
                 double mn = mean.point / n;
                 double mg_min = mn / 2.;
-                double sg = std::min(mg_min / 4., sb / std::sqrt(n));
+                double sg = (std::min)(mg_min / 4., sb / std::sqrt(n));
                 double sg2 = sg * sg;
                 double sb2 = sb * sb;
 
@@ -7795,7 +7806,7 @@ namespace Catch {
                     return (nc / n) * (sb2 - nc * sg2);
                 };
 
-                return std::min(var_out(1), var_out(std::min(c_max(0.), c_max(mg_min)))) / sb2;
+                return (std::min)(var_out(1), var_out((std::min)(c_max(0.), c_max(mg_min)))) / sb2;
             }
 
             bootstrap_analysis analyse_samples(double confidence_level, int n_resamples, std::vector<double>::iterator first, std::vector<double>::iterator last) {
@@ -7864,59 +7875,59 @@ bool marginComparison(double lhs, double rhs, double margin) {
 namespace Catch {
 namespace Detail {
 
-Approx::Approx ( double value )
+    Approx::Approx ( double value )
     :   m_epsilon( std::numeric_limits<float>::epsilon()*100 ),
         m_margin( 0.0 ),
         m_scale( 0.0 ),
         m_value( value )
-{}
+    {}
 
-Approx Approx::custom() {
-    return Approx( 0 );
-}
+    Approx Approx::custom() {
+        return Approx( 0 );
+    }
 
-Approx Approx::operator-() const {
-    auto temp(*this);
-    temp.m_value = -temp.m_value;
-    return temp;
-}
+    Approx Approx::operator-() const {
+        auto temp(*this);
+        temp.m_value = -temp.m_value;
+        return temp;
+    }
 
-std::string Approx::toString() const {
-    ReusableStringStream rss;
-    rss << "Approx( " << ::Catch::Detail::stringify( m_value ) << " )";
-    return rss.str();
-}
+    std::string Approx::toString() const {
+        ReusableStringStream rss;
+        rss << "Approx( " << ::Catch::Detail::stringify( m_value ) << " )";
+        return rss.str();
+    }
 
-bool Approx::equalityComparisonImpl(const double other) const {
-    // First try with fixed margin, then compute margin based on epsilon, scale and Approx's value
-    // Thanks to Richard Harris for his help refining the scaled margin value
-    return marginComparison(m_value, other, m_margin)
-        || marginComparison(m_value, other, m_epsilon * (m_scale + std::fabs(std::isinf(m_value)? 0 : m_value)));
-}
+    bool Approx::equalityComparisonImpl(const double other) const {
+        // First try with fixed margin, then compute margin based on epsilon, scale and Approx's value
+        // Thanks to Richard Harris for his help refining the scaled margin value
+        return marginComparison(m_value, other, m_margin)
+            || marginComparison(m_value, other, m_epsilon * (m_scale + std::fabs(std::isinf(m_value)? 0 : m_value)));
+    }
 
-void Approx::setMargin(double newMargin) {
-    CATCH_ENFORCE(newMargin >= 0,
-                  "Invalid Approx::margin: " << newMargin << '.'
-                                             << " Approx::Margin has to be non-negative.");
-    m_margin = newMargin;
-}
+    void Approx::setMargin(double newMargin) {
+        CATCH_ENFORCE(newMargin >= 0,
+            "Invalid Approx::margin: " << newMargin << '.'
+            << " Approx::Margin has to be non-negative.");
+        m_margin = newMargin;
+    }
 
-void Approx::setEpsilon(double newEpsilon) {
-    CATCH_ENFORCE(newEpsilon >= 0 && newEpsilon <= 1.0,
-                  "Invalid Approx::epsilon: " << newEpsilon << '.'
-                                              << " Approx::epsilon has to be in [0, 1]");
-    m_epsilon = newEpsilon;
-}
+    void Approx::setEpsilon(double newEpsilon) {
+        CATCH_ENFORCE(newEpsilon >= 0 && newEpsilon <= 1.0,
+            "Invalid Approx::epsilon: " << newEpsilon << '.'
+            << " Approx::epsilon has to be in [0, 1]");
+        m_epsilon = newEpsilon;
+    }
 
 } // end namespace Detail
 
 namespace literals {
-Detail::Approx operator "" _a(long double val) {
-    return Detail::Approx(val);
-}
-Detail::Approx operator "" _a(unsigned long long val) {
-    return Detail::Approx(val);
-}
+    Detail::Approx operator "" _a(long double val) {
+        return Detail::Approx(val);
+    }
+    Detail::Approx operator "" _a(unsigned long long val) {
+        return Detail::Approx(val);
+    }
 } // end namespace literals
 
 std::string StringMaker<Catch::Detail::Approx>::convert(Catch::Detail::Approx const& value) {
@@ -7930,12 +7941,12 @@ std::string StringMaker<Catch::Detail::Approx>::convert(Catch::Detail::Approx co
 // start catch_debugger.h
 
 namespace Catch {
-bool isDebuggerActive();
+    bool isDebuggerActive();
 }
 
 #ifdef CATCH_PLATFORM_MAC
 
-#if defined(__i386__) || defined(__x86_64__)
+    #if defined(__i386__) || defined(__x86_64__)
         #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
     #elif defined(__aarch64__)
         #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
@@ -7943,7 +7954,7 @@ bool isDebuggerActive();
 
 #elif defined(CATCH_PLATFORM_IPHONE)
 
-// use inline assembler
+    // use inline assembler
     #if defined(__i386__) || defined(__x86_64__)
         #define CATCH_TRAP()  __asm__("int $3")
     #elif defined(__aarch64__)
@@ -7955,18 +7966,18 @@ bool isDebuggerActive();
     #endif
 
 #elif defined(CATCH_PLATFORM_LINUX)
-// If we can use inline assembler, do it because this allows us to break
-// directly at the location of the failing check instead of breaking inside
-// raise() called from it, i.e. one stack frame below.
+    // If we can use inline assembler, do it because this allows us to break
+    // directly at the location of the failing check instead of breaking inside
+    // raise() called from it, i.e. one stack frame below.
     #if defined(__GNUC__) && (defined(__i386) || defined(__x86_64))
         #define CATCH_TRAP() asm volatile ("int $3") /* NOLINT */
     #else // Fall back to the generic way.
-#include <signal.h>
+        #include <signal.h>
 
         #define CATCH_TRAP() raise(SIGTRAP)
     #endif
 #elif defined(_MSC_VER)
-#define CATCH_TRAP() __debugbreak()
+    #define CATCH_TRAP() __debugbreak()
 #elif defined(__MINGW32__)
     extern "C" __declspec(dllimport) void __stdcall DebugBreak();
     #define CATCH_TRAP() DebugBreak()
@@ -7985,419 +7996,392 @@ bool isDebuggerActive();
 
 // start catch_fatal_condition.h
 
-// start catch_windows_h_proxy.h
-
-
-#if defined(CATCH_PLATFORM_WINDOWS)
-
-#if !defined(NOMINMAX) && !defined(CATCH_CONFIG_NO_NOMINMAX)
-#  define CATCH_DEFINED_NOMINMAX
-#  define NOMINMAX
-#endif
-#if !defined(WIN32_LEAN_AND_MEAN) && !defined(CATCH_CONFIG_NO_WIN32_LEAN_AND_MEAN)
-#  define CATCH_DEFINED_WIN32_LEAN_AND_MEAN
-#  define WIN32_LEAN_AND_MEAN
-#endif
-
-#ifdef __AFXDLL
-#include <AfxWin.h>
-#else
-#include <windows.h>
-#endif
-
-#ifdef CATCH_DEFINED_NOMINMAX
-#  undef NOMINMAX
-#endif
-#ifdef CATCH_DEFINED_WIN32_LEAN_AND_MEAN
-#  undef WIN32_LEAN_AND_MEAN
-#endif
-
-#endif // defined(CATCH_PLATFORM_WINDOWS)
-
-// end catch_windows_h_proxy.h
-#if defined( CATCH_CONFIG_WINDOWS_SEH )
+#include <cassert>
 
 namespace Catch {
 
-    struct FatalConditionHandler {
+    // Wrapper for platform-specific fatal error (signals/SEH) handlers
+    //
+    // Tries to be cooperative with other handlers, and not step over
+    // other handlers. This means that unknown structured exceptions
+    // are passed on, previous signal handlers are called, and so on.
+    //
+    // Can only be instantiated once, and assumes that once a signal
+    // is caught, the binary will end up terminating. Thus, there
+    class FatalConditionHandler {
+        bool m_started = false;
 
-        static LONG CALLBACK handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo);
+        // Install/disengage implementation for specific platform.
+        // Should be if-defed to work on current platform, can assume
+        // engage-disengage 1:1 pairing.
+        void engage_platform();
+        void disengage_platform();
+    public:
+        // Should also have platform-specific implementations as needed
         FatalConditionHandler();
-        static void reset();
         ~FatalConditionHandler();
 
-    private:
-        static bool isSet;
-        static ULONG guaranteeSize;
-        static PVOID exceptionHandlerHandle;
+        void engage() {
+            assert(!m_started && "Handler cannot be installed twice.");
+            m_started = true;
+            engage_platform();
+        }
+
+        void disengage() {
+            assert(m_started && "Handler cannot be uninstalled without being installed first");
+            m_started = false;
+            disengage_platform();
+        }
     };
 
-} // namespace Catch
-
-#elif defined ( CATCH_CONFIG_POSIX_SIGNALS )
-
-#include <signal.h>
-
-namespace Catch {
-
-struct FatalConditionHandler {
-
-    static bool isSet;
-    static struct sigaction oldSigActions[];
-    static stack_t oldSigStack;
-    static char altStackMem[];
-
-    static void handleSignal( int sig );
-
-    FatalConditionHandler();
-    ~FatalConditionHandler();
-    static void reset();
-};
-
-} // namespace Catch
-
-#else
-
-namespace Catch {
-    struct FatalConditionHandler {
-        void reset();
+    //! Simple RAII guard for (dis)engaging the FatalConditionHandler
+    class FatalConditionHandlerGuard {
+        FatalConditionHandler* m_handler;
+    public:
+        FatalConditionHandlerGuard(FatalConditionHandler* handler):
+            m_handler(handler) {
+            m_handler->engage();
+        }
+        ~FatalConditionHandlerGuard() {
+            m_handler->disengage();
+        }
     };
-}
 
-#endif
+} // end namespace Catch
 
 // end catch_fatal_condition.h
 #include <string>
 
 namespace Catch {
 
-struct IMutableContext;
+    struct IMutableContext;
 
-///////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
 
-class RunContext : public IResultCapture, public IRunner {
+    class RunContext : public IResultCapture, public IRunner {
 
-public:
-    RunContext( RunContext const& ) = delete;
-    RunContext& operator =( RunContext const& ) = delete;
+    public:
+        RunContext( RunContext const& ) = delete;
+        RunContext& operator =( RunContext const& ) = delete;
 
-    explicit RunContext( IConfigPtr const& _config, IStreamingReporterPtr&& reporter );
+        explicit RunContext( IConfigPtr const& _config, IStreamingReporterPtr&& reporter );
 
-    ~RunContext() override;
+        ~RunContext() override;
 
-    void testGroupStarting( std::string const& testSpec, std::size_t groupIndex, std::size_t groupsCount );
-    void testGroupEnded( std::string const& testSpec, Totals const& totals, std::size_t groupIndex, std::size_t groupsCount );
+        void testGroupStarting( std::string const& testSpec, std::size_t groupIndex, std::size_t groupsCount );
+        void testGroupEnded( std::string const& testSpec, Totals const& totals, std::size_t groupIndex, std::size_t groupsCount );
 
-    Totals runTest(TestCase const& testCase);
+        Totals runTest(TestCase const& testCase);
 
-    IConfigPtr config() const;
-    IStreamingReporter& reporter() const;
+        IConfigPtr config() const;
+        IStreamingReporter& reporter() const;
 
-public: // IResultCapture
+    public: // IResultCapture
 
-    // Assertion handlers
-    void handleExpr
-        (   AssertionInfo const& info,
-            ITransientExpression const& expr,
-            AssertionReaction& reaction ) override;
-    void handleMessage
-        (   AssertionInfo const& info,
-            ResultWas::OfType resultType,
-            StringRef const& message,
-            AssertionReaction& reaction ) override;
-    void handleUnexpectedExceptionNotThrown
-        (   AssertionInfo const& info,
-            AssertionReaction& reaction ) override;
-    void handleUnexpectedInflightException
-        (   AssertionInfo const& info,
-            std::string const& message,
-            AssertionReaction& reaction ) override;
-    void handleIncomplete
-        (   AssertionInfo const& info ) override;
-    void handleNonExpr
-        (   AssertionInfo const &info,
-            ResultWas::OfType resultType,
-            AssertionReaction &reaction ) override;
+        // Assertion handlers
+        void handleExpr
+                (   AssertionInfo const& info,
+                    ITransientExpression const& expr,
+                    AssertionReaction& reaction ) override;
+        void handleMessage
+                (   AssertionInfo const& info,
+                    ResultWas::OfType resultType,
+                    StringRef const& message,
+                    AssertionReaction& reaction ) override;
+        void handleUnexpectedExceptionNotThrown
+                (   AssertionInfo const& info,
+                    AssertionReaction& reaction ) override;
+        void handleUnexpectedInflightException
+                (   AssertionInfo const& info,
+                    std::string const& message,
+                    AssertionReaction& reaction ) override;
+        void handleIncomplete
+                (   AssertionInfo const& info ) override;
+        void handleNonExpr
+                (   AssertionInfo const &info,
+                    ResultWas::OfType resultType,
+                    AssertionReaction &reaction ) override;
 
-    bool sectionStarted( SectionInfo const& sectionInfo, Counts& assertions ) override;
+        bool sectionStarted( SectionInfo const& sectionInfo, Counts& assertions ) override;
 
-    void sectionEnded( SectionEndInfo const& endInfo ) override;
-    void sectionEndedEarly( SectionEndInfo const& endInfo ) override;
+        void sectionEnded( SectionEndInfo const& endInfo ) override;
+        void sectionEndedEarly( SectionEndInfo const& endInfo ) override;
 
-    auto acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker& override;
+        auto acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker& override;
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
-    void benchmarkPreparing( std::string const& name ) override;
+        void benchmarkPreparing( std::string const& name ) override;
         void benchmarkStarting( BenchmarkInfo const& info ) override;
         void benchmarkEnded( BenchmarkStats<> const& stats ) override;
         void benchmarkFailed( std::string const& error ) override;
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-    void pushScopedMessage( MessageInfo const& message ) override;
-    void popScopedMessage( MessageInfo const& message ) override;
+        void pushScopedMessage( MessageInfo const& message ) override;
+        void popScopedMessage( MessageInfo const& message ) override;
 
-    void emplaceUnscopedMessage( MessageBuilder const& builder ) override;
+        void emplaceUnscopedMessage( MessageBuilder const& builder ) override;
 
-    std::string getCurrentTestName() const override;
+        std::string getCurrentTestName() const override;
 
-    const AssertionResult* getLastResult() const override;
+        const AssertionResult* getLastResult() const override;
 
-    void exceptionEarlyReported() override;
+        void exceptionEarlyReported() override;
 
-    void handleFatalErrorCondition( StringRef message ) override;
+        void handleFatalErrorCondition( StringRef message ) override;
 
-    bool lastAssertionPassed() override;
+        bool lastAssertionPassed() override;
 
-    void assertionPassed() override;
+        void assertionPassed() override;
 
-public:
-    // !TBD We need to do this another way!
-    bool aborting() const final;
+    public:
+        // !TBD We need to do this another way!
+        bool aborting() const final;
 
-private:
+    private:
 
-    void runCurrentTest( std::string& redirectedCout, std::string& redirectedCerr );
-    void invokeActiveTestCase();
+        void runCurrentTest( std::string& redirectedCout, std::string& redirectedCerr );
+        void invokeActiveTestCase();
 
-    void resetAssertionInfo();
-    bool testForMissingAssertions( Counts& assertions );
+        void resetAssertionInfo();
+        bool testForMissingAssertions( Counts& assertions );
 
-    void assertionEnded( AssertionResult const& result );
-    void reportExpr
-        (   AssertionInfo const &info,
-            ResultWas::OfType resultType,
-            ITransientExpression const *expr,
-            bool negated );
+        void assertionEnded( AssertionResult const& result );
+        void reportExpr
+                (   AssertionInfo const &info,
+                    ResultWas::OfType resultType,
+                    ITransientExpression const *expr,
+                    bool negated );
 
-    void populateReaction( AssertionReaction& reaction );
+        void populateReaction( AssertionReaction& reaction );
 
-private:
+    private:
 
-    void handleUnfinishedSections();
+        void handleUnfinishedSections();
 
-    TestRunInfo m_runInfo;
-    IMutableContext& m_context;
-    TestCase const* m_activeTestCase = nullptr;
-    ITracker* m_testCaseTracker = nullptr;
-    Option<AssertionResult> m_lastResult;
+        TestRunInfo m_runInfo;
+        IMutableContext& m_context;
+        TestCase const* m_activeTestCase = nullptr;
+        ITracker* m_testCaseTracker = nullptr;
+        Option<AssertionResult> m_lastResult;
 
-    IConfigPtr m_config;
-    Totals m_totals;
-    IStreamingReporterPtr m_reporter;
-    std::vector<MessageInfo> m_messages;
-    std::vector<ScopedMessage> m_messageScopes; /* Keeps owners of so-called unscoped messages. */
-    AssertionInfo m_lastAssertionInfo;
-    std::vector<SectionEndInfo> m_unfinishedSections;
-    std::vector<ITracker*> m_activeSections;
-    TrackerContext m_trackerContext;
-    bool m_lastAssertionPassed = false;
-    bool m_shouldReportUnexpected = true;
-    bool m_includeSuccessfulResults;
-};
+        IConfigPtr m_config;
+        Totals m_totals;
+        IStreamingReporterPtr m_reporter;
+        std::vector<MessageInfo> m_messages;
+        std::vector<ScopedMessage> m_messageScopes; /* Keeps owners of so-called unscoped messages. */
+        AssertionInfo m_lastAssertionInfo;
+        std::vector<SectionEndInfo> m_unfinishedSections;
+        std::vector<ITracker*> m_activeSections;
+        TrackerContext m_trackerContext;
+        FatalConditionHandler m_fatalConditionhandler;
+        bool m_lastAssertionPassed = false;
+        bool m_shouldReportUnexpected = true;
+        bool m_includeSuccessfulResults;
+    };
 
-void seedRng(IConfig const& config);
-unsigned int rngSeed();
+    void seedRng(IConfig const& config);
+    unsigned int rngSeed();
 } // end namespace Catch
 
 // end catch_run_context.h
 namespace Catch {
 
-namespace {
-auto operator <<( std::ostream& os, ITransientExpression const& expr ) -> std::ostream& {
-    expr.streamReconstructedExpression( os );
-    return os;
-}
-}
+    namespace {
+        auto operator <<( std::ostream& os, ITransientExpression const& expr ) -> std::ostream& {
+            expr.streamReconstructedExpression( os );
+            return os;
+        }
+    }
 
-LazyExpression::LazyExpression( bool isNegated )
+    LazyExpression::LazyExpression( bool isNegated )
     :   m_isNegated( isNegated )
-{}
+    {}
 
-LazyExpression::LazyExpression( LazyExpression const& other ) : m_isNegated( other.m_isNegated ) {}
+    LazyExpression::LazyExpression( LazyExpression const& other ) : m_isNegated( other.m_isNegated ) {}
 
-LazyExpression::operator bool() const {
-    return m_transientExpression != nullptr;
-}
-
-auto operator << ( std::ostream& os, LazyExpression const& lazyExpr ) -> std::ostream& {
-    if( lazyExpr.m_isNegated )
-        os << "!";
-
-    if( lazyExpr ) {
-        if( lazyExpr.m_isNegated && lazyExpr.m_transientExpression->isBinaryExpression() )
-            os << "(" << *lazyExpr.m_transientExpression << ")";
-        else
-            os << *lazyExpr.m_transientExpression;
+    LazyExpression::operator bool() const {
+        return m_transientExpression != nullptr;
     }
-    else {
-        os << "{** error - unchecked empty expression requested **}";
-    }
-    return os;
-}
 
-AssertionHandler::AssertionHandler
-    (   StringRef const& macroName,
-        SourceLineInfo const& lineInfo,
-        StringRef capturedExpression,
-        ResultDisposition::Flags resultDisposition )
+    auto operator << ( std::ostream& os, LazyExpression const& lazyExpr ) -> std::ostream& {
+        if( lazyExpr.m_isNegated )
+            os << "!";
+
+        if( lazyExpr ) {
+            if( lazyExpr.m_isNegated && lazyExpr.m_transientExpression->isBinaryExpression() )
+                os << "(" << *lazyExpr.m_transientExpression << ")";
+            else
+                os << *lazyExpr.m_transientExpression;
+        }
+        else {
+            os << "{** error - unchecked empty expression requested **}";
+        }
+        return os;
+    }
+
+    AssertionHandler::AssertionHandler
+        (   StringRef const& macroName,
+            SourceLineInfo const& lineInfo,
+            StringRef capturedExpression,
+            ResultDisposition::Flags resultDisposition )
     :   m_assertionInfo{ macroName, lineInfo, capturedExpression, resultDisposition },
         m_resultCapture( getResultCapture() )
-{}
+    {}
 
-void AssertionHandler::handleExpr( ITransientExpression const& expr ) {
-    m_resultCapture.handleExpr( m_assertionInfo, expr, m_reaction );
-}
-void AssertionHandler::handleMessage(ResultWas::OfType resultType, StringRef const& message) {
-    m_resultCapture.handleMessage( m_assertionInfo, resultType, message, m_reaction );
-}
-
-auto AssertionHandler::allowThrows() const -> bool {
-    return getCurrentContext().getConfig()->allowThrows();
-}
-
-void AssertionHandler::complete() {
-    setCompleted();
-    if( m_reaction.shouldDebugBreak ) {
-
-        // If you find your debugger stopping you here then go one level up on the
-        // call-stack for the code that caused it (typically a failed assertion)
-
-        // (To go back to the test and change execution, jump over the throw, next)
-        CATCH_BREAK_INTO_DEBUGGER();
+    void AssertionHandler::handleExpr( ITransientExpression const& expr ) {
+        m_resultCapture.handleExpr( m_assertionInfo, expr, m_reaction );
     }
-    if (m_reaction.shouldThrow) {
+    void AssertionHandler::handleMessage(ResultWas::OfType resultType, StringRef const& message) {
+        m_resultCapture.handleMessage( m_assertionInfo, resultType, message, m_reaction );
+    }
+
+    auto AssertionHandler::allowThrows() const -> bool {
+        return getCurrentContext().getConfig()->allowThrows();
+    }
+
+    void AssertionHandler::complete() {
+        setCompleted();
+        if( m_reaction.shouldDebugBreak ) {
+
+            // If you find your debugger stopping you here then go one level up on the
+            // call-stack for the code that caused it (typically a failed assertion)
+
+            // (To go back to the test and change execution, jump over the throw, next)
+            CATCH_BREAK_INTO_DEBUGGER();
+        }
+        if (m_reaction.shouldThrow) {
 #if !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
-        throw Catch::TestFailureException();
+            throw Catch::TestFailureException();
 #else
-        CATCH_ERROR( "Test failure requires aborting test!" );
+            CATCH_ERROR( "Test failure requires aborting test!" );
 #endif
+        }
     }
-}
-void AssertionHandler::setCompleted() {
-    m_completed = true;
-}
+    void AssertionHandler::setCompleted() {
+        m_completed = true;
+    }
 
-void AssertionHandler::handleUnexpectedInflightException() {
-    m_resultCapture.handleUnexpectedInflightException( m_assertionInfo, Catch::translateActiveException(), m_reaction );
-}
+    void AssertionHandler::handleUnexpectedInflightException() {
+        m_resultCapture.handleUnexpectedInflightException( m_assertionInfo, Catch::translateActiveException(), m_reaction );
+    }
 
-void AssertionHandler::handleExceptionThrownAsExpected() {
-    m_resultCapture.handleNonExpr(m_assertionInfo, ResultWas::Ok, m_reaction);
-}
-void AssertionHandler::handleExceptionNotThrownAsExpected() {
-    m_resultCapture.handleNonExpr(m_assertionInfo, ResultWas::Ok, m_reaction);
-}
+    void AssertionHandler::handleExceptionThrownAsExpected() {
+        m_resultCapture.handleNonExpr(m_assertionInfo, ResultWas::Ok, m_reaction);
+    }
+    void AssertionHandler::handleExceptionNotThrownAsExpected() {
+        m_resultCapture.handleNonExpr(m_assertionInfo, ResultWas::Ok, m_reaction);
+    }
 
-void AssertionHandler::handleUnexpectedExceptionNotThrown() {
-    m_resultCapture.handleUnexpectedExceptionNotThrown( m_assertionInfo, m_reaction );
-}
+    void AssertionHandler::handleUnexpectedExceptionNotThrown() {
+        m_resultCapture.handleUnexpectedExceptionNotThrown( m_assertionInfo, m_reaction );
+    }
 
-void AssertionHandler::handleThrowingCallSkipped() {
-    m_resultCapture.handleNonExpr(m_assertionInfo, ResultWas::Ok, m_reaction);
-}
+    void AssertionHandler::handleThrowingCallSkipped() {
+        m_resultCapture.handleNonExpr(m_assertionInfo, ResultWas::Ok, m_reaction);
+    }
 
-// This is the overload that takes a string and infers the Equals matcher from it
-// The more general overload, that takes any string matcher, is in catch_capture_matchers.cpp
-void handleExceptionMatchExpr( AssertionHandler& handler, std::string const& str, StringRef const& matcherString  ) {
-    handleExceptionMatchExpr( handler, Matchers::Equals( str ), matcherString );
-}
+    // This is the overload that takes a string and infers the Equals matcher from it
+    // The more general overload, that takes any string matcher, is in catch_capture_matchers.cpp
+    void handleExceptionMatchExpr( AssertionHandler& handler, std::string const& str, StringRef const& matcherString  ) {
+        handleExceptionMatchExpr( handler, Matchers::Equals( str ), matcherString );
+    }
 
 } // namespace Catch
 // end catch_assertionhandler.cpp
 // start catch_assertionresult.cpp
 
 namespace Catch {
-AssertionResultData::AssertionResultData(ResultWas::OfType _resultType, LazyExpression const & _lazyExpression):
-    lazyExpression(_lazyExpression),
-    resultType(_resultType) {}
+    AssertionResultData::AssertionResultData(ResultWas::OfType _resultType, LazyExpression const & _lazyExpression):
+        lazyExpression(_lazyExpression),
+        resultType(_resultType) {}
 
-std::string AssertionResultData::reconstructExpression() const {
+    std::string AssertionResultData::reconstructExpression() const {
 
-    if( reconstructedExpression.empty() ) {
-        if( lazyExpression ) {
-            ReusableStringStream rss;
-            rss << lazyExpression;
-            reconstructedExpression = rss.str();
+        if( reconstructedExpression.empty() ) {
+            if( lazyExpression ) {
+                ReusableStringStream rss;
+                rss << lazyExpression;
+                reconstructedExpression = rss.str();
+            }
         }
+        return reconstructedExpression;
     }
-    return reconstructedExpression;
-}
 
-AssertionResult::AssertionResult( AssertionInfo const& info, AssertionResultData const& data )
+    AssertionResult::AssertionResult( AssertionInfo const& info, AssertionResultData const& data )
     :   m_info( info ),
         m_resultData( data )
-{}
+    {}
 
-// Result was a success
-bool AssertionResult::succeeded() const {
-    return Catch::isOk( m_resultData.resultType );
-}
-
-// Result was a success, or failure is suppressed
-bool AssertionResult::isOk() const {
-    return Catch::isOk( m_resultData.resultType ) || shouldSuppressFailure( m_info.resultDisposition );
-}
-
-ResultWas::OfType AssertionResult::getResultType() const {
-    return m_resultData.resultType;
-}
-
-bool AssertionResult::hasExpression() const {
-    return !m_info.capturedExpression.empty();
-}
-
-bool AssertionResult::hasMessage() const {
-    return !m_resultData.message.empty();
-}
-
-std::string AssertionResult::getExpression() const {
-    // Possibly overallocating by 3 characters should be basically free
-    std::string expr; expr.reserve(m_info.capturedExpression.size() + 3);
-    if (isFalseTest(m_info.resultDisposition)) {
-        expr += "!(";
+    // Result was a success
+    bool AssertionResult::succeeded() const {
+        return Catch::isOk( m_resultData.resultType );
     }
-    expr += m_info.capturedExpression;
-    if (isFalseTest(m_info.resultDisposition)) {
-        expr += ')';
-    }
-    return expr;
-}
 
-std::string AssertionResult::getExpressionInMacro() const {
-    std::string expr;
-    if( m_info.macroName.empty() )
-        expr = static_cast<std::string>(m_info.capturedExpression);
-    else {
-        expr.reserve( m_info.macroName.size() + m_info.capturedExpression.size() + 4 );
-        expr += m_info.macroName;
-        expr += "( ";
+    // Result was a success, or failure is suppressed
+    bool AssertionResult::isOk() const {
+        return Catch::isOk( m_resultData.resultType ) || shouldSuppressFailure( m_info.resultDisposition );
+    }
+
+    ResultWas::OfType AssertionResult::getResultType() const {
+        return m_resultData.resultType;
+    }
+
+    bool AssertionResult::hasExpression() const {
+        return !m_info.capturedExpression.empty();
+    }
+
+    bool AssertionResult::hasMessage() const {
+        return !m_resultData.message.empty();
+    }
+
+    std::string AssertionResult::getExpression() const {
+        // Possibly overallocating by 3 characters should be basically free
+        std::string expr; expr.reserve(m_info.capturedExpression.size() + 3);
+        if (isFalseTest(m_info.resultDisposition)) {
+            expr += "!(";
+        }
         expr += m_info.capturedExpression;
-        expr += " )";
+        if (isFalseTest(m_info.resultDisposition)) {
+            expr += ')';
+        }
+        return expr;
     }
-    return expr;
-}
 
-bool AssertionResult::hasExpandedExpression() const {
-    return hasExpression() && getExpandedExpression() != getExpression();
-}
+    std::string AssertionResult::getExpressionInMacro() const {
+        std::string expr;
+        if( m_info.macroName.empty() )
+            expr = static_cast<std::string>(m_info.capturedExpression);
+        else {
+            expr.reserve( m_info.macroName.size() + m_info.capturedExpression.size() + 4 );
+            expr += m_info.macroName;
+            expr += "( ";
+            expr += m_info.capturedExpression;
+            expr += " )";
+        }
+        return expr;
+    }
 
-std::string AssertionResult::getExpandedExpression() const {
-    std::string expr = m_resultData.reconstructExpression();
-    return expr.empty()
-           ? getExpression()
-           : expr;
-}
+    bool AssertionResult::hasExpandedExpression() const {
+        return hasExpression() && getExpandedExpression() != getExpression();
+    }
 
-std::string AssertionResult::getMessage() const {
-    return m_resultData.message;
-}
-SourceLineInfo AssertionResult::getSourceInfo() const {
-    return m_info.lineInfo;
-}
+    std::string AssertionResult::getExpandedExpression() const {
+        std::string expr = m_resultData.reconstructExpression();
+        return expr.empty()
+                ? getExpression()
+                : expr;
+    }
 
-StringRef AssertionResult::getTestMacroName() const {
-    return m_info.macroName;
-}
+    std::string AssertionResult::getMessage() const {
+        return m_resultData.message;
+    }
+    SourceLineInfo AssertionResult::getSourceInfo() const {
+        return m_info.lineInfo;
+    }
+
+    StringRef AssertionResult::getTestMacroName() const {
+        return m_info.macroName;
+    }
 
 } // end namespace Catch
 // end catch_assertionresult.cpp
@@ -8405,16 +8389,16 @@ StringRef AssertionResult::getTestMacroName() const {
 
 namespace Catch {
 
-using StringMatcher = Matchers::Impl::MatcherBase<std::string>;
+    using StringMatcher = Matchers::Impl::MatcherBase<std::string>;
 
-// This is the general overload that takes a any string matcher
-// There is another overload, in catch_assertionhandler.h/.cpp, that only takes a string and infers
-// the Equals matcher (so the header does not mention matchers)
-void handleExceptionMatchExpr( AssertionHandler& handler, StringMatcher const& matcher, StringRef const& matcherString  ) {
-    std::string exceptionMessage = Catch::translateActiveException();
-    MatchExpr<std::string, StringMatcher const&> expr( exceptionMessage, matcher, matcherString );
-    handler.handleExpr( expr );
-}
+    // This is the general overload that takes a any string matcher
+    // There is another overload, in catch_assertionhandler.h/.cpp, that only takes a string and infers
+    // the Equals matcher (so the header does not mention matchers)
+    void handleExceptionMatchExpr( AssertionHandler& handler, StringMatcher const& matcher, StringRef const& matcherString  ) {
+        std::string exceptionMessage = Catch::translateActiveException();
+        MatchExpr<std::string, StringMatcher const&> expr( exceptionMessage, matcher, matcherString );
+        handler.handleExpr( expr );
+    }
 
 } // namespace Catch
 // end catch_capture_matchers.cpp
@@ -8492,312 +8476,312 @@ namespace clara {
 namespace TextFlow {
 
 inline auto isWhitespace(char c) -> bool {
-    static std::string chars = " \t\n\r";
-    return chars.find(c) != std::string::npos;
+	static std::string chars = " \t\n\r";
+	return chars.find(c) != std::string::npos;
 }
 inline auto isBreakableBefore(char c) -> bool {
-    static std::string chars = "[({<|";
-    return chars.find(c) != std::string::npos;
+	static std::string chars = "[({<|";
+	return chars.find(c) != std::string::npos;
 }
 inline auto isBreakableAfter(char c) -> bool {
-    static std::string chars = "])}>.,:;*+-=&/\\";
-    return chars.find(c) != std::string::npos;
+	static std::string chars = "])}>.,:;*+-=&/\\";
+	return chars.find(c) != std::string::npos;
 }
 
 class Columns;
 
 class Column {
-    std::vector<std::string> m_strings;
-    size_t m_width = CATCH_CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH;
-    size_t m_indent = 0;
-    size_t m_initialIndent = std::string::npos;
+	std::vector<std::string> m_strings;
+	size_t m_width = CATCH_CLARA_TEXTFLOW_CONFIG_CONSOLE_WIDTH;
+	size_t m_indent = 0;
+	size_t m_initialIndent = std::string::npos;
 
 public:
-    class iterator {
-        friend Column;
+	class iterator {
+		friend Column;
 
-        Column const& m_column;
-        size_t m_stringIndex = 0;
-        size_t m_pos = 0;
+		Column const& m_column;
+		size_t m_stringIndex = 0;
+		size_t m_pos = 0;
 
-        size_t m_len = 0;
-        size_t m_end = 0;
-        bool m_suffix = false;
+		size_t m_len = 0;
+		size_t m_end = 0;
+		bool m_suffix = false;
 
-        iterator(Column const& column, size_t stringIndex)
-            : m_column(column),
-              m_stringIndex(stringIndex) {}
+		iterator(Column const& column, size_t stringIndex)
+			: m_column(column),
+			m_stringIndex(stringIndex) {}
 
-        auto line() const -> std::string const& { return m_column.m_strings[m_stringIndex]; }
+		auto line() const -> std::string const& { return m_column.m_strings[m_stringIndex]; }
 
-        auto isBoundary(size_t at) const -> bool {
-            assert(at > 0);
-            assert(at <= line().size());
+		auto isBoundary(size_t at) const -> bool {
+			assert(at > 0);
+			assert(at <= line().size());
 
-            return at == line().size() ||
-                (isWhitespace(line()[at]) && !isWhitespace(line()[at - 1])) ||
-                isBreakableBefore(line()[at]) ||
-                isBreakableAfter(line()[at - 1]);
-        }
+			return at == line().size() ||
+				(isWhitespace(line()[at]) && !isWhitespace(line()[at - 1])) ||
+				isBreakableBefore(line()[at]) ||
+				isBreakableAfter(line()[at - 1]);
+		}
 
-        void calcLength() {
-            assert(m_stringIndex < m_column.m_strings.size());
+		void calcLength() {
+			assert(m_stringIndex < m_column.m_strings.size());
 
-            m_suffix = false;
-            auto width = m_column.m_width - indent();
-            m_end = m_pos;
-            if (line()[m_pos] == '\n') {
-                ++m_end;
-            }
-            while (m_end < line().size() && line()[m_end] != '\n')
-                ++m_end;
+			m_suffix = false;
+			auto width = m_column.m_width - indent();
+			m_end = m_pos;
+			if (line()[m_pos] == '\n') {
+				++m_end;
+			}
+			while (m_end < line().size() && line()[m_end] != '\n')
+				++m_end;
 
-            if (m_end < m_pos + width) {
-                m_len = m_end - m_pos;
-            } else {
-                size_t len = width;
-                while (len > 0 && !isBoundary(m_pos + len))
-                    --len;
-                while (len > 0 && isWhitespace(line()[m_pos + len - 1]))
-                    --len;
+			if (m_end < m_pos + width) {
+				m_len = m_end - m_pos;
+			} else {
+				size_t len = width;
+				while (len > 0 && !isBoundary(m_pos + len))
+					--len;
+				while (len > 0 && isWhitespace(line()[m_pos + len - 1]))
+					--len;
 
-                if (len > 0) {
-                    m_len = len;
-                } else {
-                    m_suffix = true;
-                    m_len = width - 1;
-                }
-            }
-        }
+				if (len > 0) {
+					m_len = len;
+				} else {
+					m_suffix = true;
+					m_len = width - 1;
+				}
+			}
+		}
 
-        auto indent() const -> size_t {
-            auto initial = m_pos == 0 && m_stringIndex == 0 ? m_column.m_initialIndent : std::string::npos;
-            return initial == std::string::npos ? m_column.m_indent : initial;
-        }
+		auto indent() const -> size_t {
+			auto initial = m_pos == 0 && m_stringIndex == 0 ? m_column.m_initialIndent : std::string::npos;
+			return initial == std::string::npos ? m_column.m_indent : initial;
+		}
 
-        auto addIndentAndSuffix(std::string const &plain) const -> std::string {
-            return std::string(indent(), ' ') + (m_suffix ? plain + "-" : plain);
-        }
+		auto addIndentAndSuffix(std::string const &plain) const -> std::string {
+			return std::string(indent(), ' ') + (m_suffix ? plain + "-" : plain);
+		}
 
-    public:
-        using difference_type = std::ptrdiff_t;
-        using value_type = std::string;
-        using pointer = value_type * ;
-        using reference = value_type & ;
-        using iterator_category = std::forward_iterator_tag;
+	public:
+		using difference_type = std::ptrdiff_t;
+		using value_type = std::string;
+		using pointer = value_type * ;
+		using reference = value_type & ;
+		using iterator_category = std::forward_iterator_tag;
 
-        explicit iterator(Column const& column) : m_column(column) {
-            assert(m_column.m_width > m_column.m_indent);
-            assert(m_column.m_initialIndent == std::string::npos || m_column.m_width > m_column.m_initialIndent);
-            calcLength();
-            if (m_len == 0)
-                m_stringIndex++; // Empty string
-        }
+		explicit iterator(Column const& column) : m_column(column) {
+			assert(m_column.m_width > m_column.m_indent);
+			assert(m_column.m_initialIndent == std::string::npos || m_column.m_width > m_column.m_initialIndent);
+			calcLength();
+			if (m_len == 0)
+				m_stringIndex++; // Empty string
+		}
 
-        auto operator *() const -> std::string {
-            assert(m_stringIndex < m_column.m_strings.size());
-            assert(m_pos <= m_end);
-            return addIndentAndSuffix(line().substr(m_pos, m_len));
-        }
+		auto operator *() const -> std::string {
+			assert(m_stringIndex < m_column.m_strings.size());
+			assert(m_pos <= m_end);
+			return addIndentAndSuffix(line().substr(m_pos, m_len));
+		}
 
-        auto operator ++() -> iterator& {
-            m_pos += m_len;
-            if (m_pos < line().size() && line()[m_pos] == '\n')
-                m_pos += 1;
-            else
-                while (m_pos < line().size() && isWhitespace(line()[m_pos]))
-                    ++m_pos;
+		auto operator ++() -> iterator& {
+			m_pos += m_len;
+			if (m_pos < line().size() && line()[m_pos] == '\n')
+				m_pos += 1;
+			else
+				while (m_pos < line().size() && isWhitespace(line()[m_pos]))
+					++m_pos;
 
-            if (m_pos == line().size()) {
-                m_pos = 0;
-                ++m_stringIndex;
-            }
-            if (m_stringIndex < m_column.m_strings.size())
-                calcLength();
-            return *this;
-        }
-        auto operator ++(int) -> iterator {
-            iterator prev(*this);
-            operator++();
-            return prev;
-        }
+			if (m_pos == line().size()) {
+				m_pos = 0;
+				++m_stringIndex;
+			}
+			if (m_stringIndex < m_column.m_strings.size())
+				calcLength();
+			return *this;
+		}
+		auto operator ++(int) -> iterator {
+			iterator prev(*this);
+			operator++();
+			return prev;
+		}
 
-        auto operator ==(iterator const& other) const -> bool {
-            return
-                m_pos == other.m_pos &&
-                    m_stringIndex == other.m_stringIndex &&
-                    &m_column == &other.m_column;
-        }
-        auto operator !=(iterator const& other) const -> bool {
-            return !operator==(other);
-        }
-    };
-    using const_iterator = iterator;
+		auto operator ==(iterator const& other) const -> bool {
+			return
+				m_pos == other.m_pos &&
+				m_stringIndex == other.m_stringIndex &&
+				&m_column == &other.m_column;
+		}
+		auto operator !=(iterator const& other) const -> bool {
+			return !operator==(other);
+		}
+	};
+	using const_iterator = iterator;
 
-    explicit Column(std::string const& text) { m_strings.push_back(text); }
+	explicit Column(std::string const& text) { m_strings.push_back(text); }
 
-    auto width(size_t newWidth) -> Column& {
-        assert(newWidth > 0);
-        m_width = newWidth;
-        return *this;
-    }
-    auto indent(size_t newIndent) -> Column& {
-        m_indent = newIndent;
-        return *this;
-    }
-    auto initialIndent(size_t newIndent) -> Column& {
-        m_initialIndent = newIndent;
-        return *this;
-    }
+	auto width(size_t newWidth) -> Column& {
+		assert(newWidth > 0);
+		m_width = newWidth;
+		return *this;
+	}
+	auto indent(size_t newIndent) -> Column& {
+		m_indent = newIndent;
+		return *this;
+	}
+	auto initialIndent(size_t newIndent) -> Column& {
+		m_initialIndent = newIndent;
+		return *this;
+	}
 
-    auto width() const -> size_t { return m_width; }
-    auto begin() const -> iterator { return iterator(*this); }
-    auto end() const -> iterator { return { *this, m_strings.size() }; }
+	auto width() const -> size_t { return m_width; }
+	auto begin() const -> iterator { return iterator(*this); }
+	auto end() const -> iterator { return { *this, m_strings.size() }; }
 
-    inline friend std::ostream& operator << (std::ostream& os, Column const& col) {
-        bool first = true;
-        for (auto line : col) {
-            if (first)
-                first = false;
-            else
-                os << "\n";
-            os << line;
-        }
-        return os;
-    }
+	inline friend std::ostream& operator << (std::ostream& os, Column const& col) {
+		bool first = true;
+		for (auto line : col) {
+			if (first)
+				first = false;
+			else
+				os << "\n";
+			os << line;
+		}
+		return os;
+	}
 
-    auto operator + (Column const& other)->Columns;
+	auto operator + (Column const& other)->Columns;
 
-    auto toString() const -> std::string {
-        std::ostringstream oss;
-        oss << *this;
-        return oss.str();
-    }
+	auto toString() const -> std::string {
+		std::ostringstream oss;
+		oss << *this;
+		return oss.str();
+	}
 };
 
 class Spacer : public Column {
 
 public:
-    explicit Spacer(size_t spaceWidth) : Column("") {
-        width(spaceWidth);
-    }
+	explicit Spacer(size_t spaceWidth) : Column("") {
+		width(spaceWidth);
+	}
 };
 
 class Columns {
-    std::vector<Column> m_columns;
+	std::vector<Column> m_columns;
 
 public:
 
-    class iterator {
-        friend Columns;
-        struct EndTag {};
+	class iterator {
+		friend Columns;
+		struct EndTag {};
 
-        std::vector<Column> const& m_columns;
-        std::vector<Column::iterator> m_iterators;
-        size_t m_activeIterators;
+		std::vector<Column> const& m_columns;
+		std::vector<Column::iterator> m_iterators;
+		size_t m_activeIterators;
 
-        iterator(Columns const& columns, EndTag)
-            : m_columns(columns.m_columns),
-              m_activeIterators(0) {
-            m_iterators.reserve(m_columns.size());
+		iterator(Columns const& columns, EndTag)
+			: m_columns(columns.m_columns),
+			m_activeIterators(0) {
+			m_iterators.reserve(m_columns.size());
 
-            for (auto const& col : m_columns)
-                m_iterators.push_back(col.end());
-        }
+			for (auto const& col : m_columns)
+				m_iterators.push_back(col.end());
+		}
 
-    public:
-        using difference_type = std::ptrdiff_t;
-        using value_type = std::string;
-        using pointer = value_type * ;
-        using reference = value_type & ;
-        using iterator_category = std::forward_iterator_tag;
+	public:
+		using difference_type = std::ptrdiff_t;
+		using value_type = std::string;
+		using pointer = value_type * ;
+		using reference = value_type & ;
+		using iterator_category = std::forward_iterator_tag;
 
-        explicit iterator(Columns const& columns)
-            : m_columns(columns.m_columns),
-              m_activeIterators(m_columns.size()) {
-            m_iterators.reserve(m_columns.size());
+		explicit iterator(Columns const& columns)
+			: m_columns(columns.m_columns),
+			m_activeIterators(m_columns.size()) {
+			m_iterators.reserve(m_columns.size());
 
-            for (auto const& col : m_columns)
-                m_iterators.push_back(col.begin());
-        }
+			for (auto const& col : m_columns)
+				m_iterators.push_back(col.begin());
+		}
 
-        auto operator ==(iterator const& other) const -> bool {
-            return m_iterators == other.m_iterators;
-        }
-        auto operator !=(iterator const& other) const -> bool {
-            return m_iterators != other.m_iterators;
-        }
-        auto operator *() const -> std::string {
-            std::string row, padding;
+		auto operator ==(iterator const& other) const -> bool {
+			return m_iterators == other.m_iterators;
+		}
+		auto operator !=(iterator const& other) const -> bool {
+			return m_iterators != other.m_iterators;
+		}
+		auto operator *() const -> std::string {
+			std::string row, padding;
 
-            for (size_t i = 0; i < m_columns.size(); ++i) {
-                auto width = m_columns[i].width();
-                if (m_iterators[i] != m_columns[i].end()) {
-                    std::string col = *m_iterators[i];
-                    row += padding + col;
-                    if (col.size() < width)
-                        padding = std::string(width - col.size(), ' ');
-                    else
-                        padding = "";
-                } else {
-                    padding += std::string(width, ' ');
-                }
-            }
-            return row;
-        }
-        auto operator ++() -> iterator& {
-            for (size_t i = 0; i < m_columns.size(); ++i) {
-                if (m_iterators[i] != m_columns[i].end())
-                    ++m_iterators[i];
-            }
-            return *this;
-        }
-        auto operator ++(int) -> iterator {
-            iterator prev(*this);
-            operator++();
-            return prev;
-        }
-    };
-    using const_iterator = iterator;
+			for (size_t i = 0; i < m_columns.size(); ++i) {
+				auto width = m_columns[i].width();
+				if (m_iterators[i] != m_columns[i].end()) {
+					std::string col = *m_iterators[i];
+					row += padding + col;
+					if (col.size() < width)
+						padding = std::string(width - col.size(), ' ');
+					else
+						padding = "";
+				} else {
+					padding += std::string(width, ' ');
+				}
+			}
+			return row;
+		}
+		auto operator ++() -> iterator& {
+			for (size_t i = 0; i < m_columns.size(); ++i) {
+				if (m_iterators[i] != m_columns[i].end())
+					++m_iterators[i];
+			}
+			return *this;
+		}
+		auto operator ++(int) -> iterator {
+			iterator prev(*this);
+			operator++();
+			return prev;
+		}
+	};
+	using const_iterator = iterator;
 
-    auto begin() const -> iterator { return iterator(*this); }
-    auto end() const -> iterator { return { *this, iterator::EndTag() }; }
+	auto begin() const -> iterator { return iterator(*this); }
+	auto end() const -> iterator { return { *this, iterator::EndTag() }; }
 
-    auto operator += (Column const& col) -> Columns& {
-        m_columns.push_back(col);
-        return *this;
-    }
-    auto operator + (Column const& col) -> Columns {
-        Columns combined = *this;
-        combined += col;
-        return combined;
-    }
+	auto operator += (Column const& col) -> Columns& {
+		m_columns.push_back(col);
+		return *this;
+	}
+	auto operator + (Column const& col) -> Columns {
+		Columns combined = *this;
+		combined += col;
+		return combined;
+	}
 
-    inline friend std::ostream& operator << (std::ostream& os, Columns const& cols) {
+	inline friend std::ostream& operator << (std::ostream& os, Columns const& cols) {
 
-        bool first = true;
-        for (auto line : cols) {
-            if (first)
-                first = false;
-            else
-                os << "\n";
-            os << line;
-        }
-        return os;
-    }
+		bool first = true;
+		for (auto line : cols) {
+			if (first)
+				first = false;
+			else
+				os << "\n";
+			os << line;
+		}
+		return os;
+	}
 
-    auto toString() const -> std::string {
-        std::ostringstream oss;
-        oss << *this;
-        return oss.str();
-    }
+	auto toString() const -> std::string {
+		std::ostringstream oss;
+		oss << *this;
+		return oss.str();
+	}
 };
 
 inline auto Column::operator + (Column const& other) -> Columns {
-    Columns cols;
-    cols += *this;
-    cols += other;
-    return cols;
+	Columns cols;
+	cols += *this;
+	cols += other;
+	return cols;
 }
 }
 
@@ -8820,851 +8804,851 @@ inline auto Column::operator + (Column const& other) -> Columns {
 namespace Catch { namespace clara {
 namespace detail {
 
-// Traits for extracting arg and return type of lambdas (for single argument lambdas)
-template<typename L>
-struct UnaryLambdaTraits : UnaryLambdaTraits<decltype( &L::operator() )> {};
+    // Traits for extracting arg and return type of lambdas (for single argument lambdas)
+    template<typename L>
+    struct UnaryLambdaTraits : UnaryLambdaTraits<decltype( &L::operator() )> {};
 
-template<typename ClassT, typename ReturnT, typename... Args>
-struct UnaryLambdaTraits<ReturnT( ClassT::* )( Args... ) const> {
-    static const bool isValid = false;
-};
+    template<typename ClassT, typename ReturnT, typename... Args>
+    struct UnaryLambdaTraits<ReturnT( ClassT::* )( Args... ) const> {
+        static const bool isValid = false;
+    };
 
-template<typename ClassT, typename ReturnT, typename ArgT>
-struct UnaryLambdaTraits<ReturnT( ClassT::* )( ArgT ) const> {
-    static const bool isValid = true;
-    using ArgType = typename std::remove_const<typename std::remove_reference<ArgT>::type>::type;
-    using ReturnType = ReturnT;
-};
+    template<typename ClassT, typename ReturnT, typename ArgT>
+    struct UnaryLambdaTraits<ReturnT( ClassT::* )( ArgT ) const> {
+        static const bool isValid = true;
+        using ArgType = typename std::remove_const<typename std::remove_reference<ArgT>::type>::type;
+        using ReturnType = ReturnT;
+    };
 
-class TokenStream;
+    class TokenStream;
 
-// Transport for raw args (copied from main args, or supplied via init list for testing)
-class Args {
-    friend TokenStream;
-    std::string m_exeName;
-    std::vector<std::string> m_args;
+    // Transport for raw args (copied from main args, or supplied via init list for testing)
+    class Args {
+        friend TokenStream;
+        std::string m_exeName;
+        std::vector<std::string> m_args;
 
-public:
-    Args( int argc, char const* const* argv )
-        : m_exeName(argv[0]),
-          m_args(argv + 1, argv + argc) {}
+    public:
+        Args( int argc, char const* const* argv )
+            : m_exeName(argv[0]),
+              m_args(argv + 1, argv + argc) {}
 
-    Args( std::initializer_list<std::string> args )
+        Args( std::initializer_list<std::string> args )
         :   m_exeName( *args.begin() ),
             m_args( args.begin()+1, args.end() )
-    {}
+        {}
 
-    auto exeName() const -> std::string {
-        return m_exeName;
-    }
-};
+        auto exeName() const -> std::string {
+            return m_exeName;
+        }
+    };
 
-// Wraps a token coming from a token stream. These may not directly correspond to strings as a single string
-// may encode an option + its argument if the : or = form is used
-enum class TokenType {
-    Option, Argument
-};
-struct Token {
-    TokenType type;
-    std::string token;
-};
+    // Wraps a token coming from a token stream. These may not directly correspond to strings as a single string
+    // may encode an option + its argument if the : or = form is used
+    enum class TokenType {
+        Option, Argument
+    };
+    struct Token {
+        TokenType type;
+        std::string token;
+    };
 
-inline auto isOptPrefix( char c ) -> bool {
-    return c == '-'
+    inline auto isOptPrefix( char c ) -> bool {
+        return c == '-'
 #ifdef CATCH_PLATFORM_WINDOWS
-        || c == '/'
+            || c == '/'
 #endif
         ;
-}
+    }
 
-// Abstracts iterators into args as a stream of tokens, with option arguments uniformly handled
-class TokenStream {
-    using Iterator = std::vector<std::string>::const_iterator;
-    Iterator it;
-    Iterator itEnd;
-    std::vector<Token> m_tokenBuffer;
+    // Abstracts iterators into args as a stream of tokens, with option arguments uniformly handled
+    class TokenStream {
+        using Iterator = std::vector<std::string>::const_iterator;
+        Iterator it;
+        Iterator itEnd;
+        std::vector<Token> m_tokenBuffer;
 
-    void loadBuffer() {
-        m_tokenBuffer.resize( 0 );
+        void loadBuffer() {
+            m_tokenBuffer.resize( 0 );
 
-        // Skip any empty strings
-        while( it != itEnd && it->empty() )
-            ++it;
+            // Skip any empty strings
+            while( it != itEnd && it->empty() )
+                ++it;
 
-        if( it != itEnd ) {
-            auto const &next = *it;
-            if( isOptPrefix( next[0] ) ) {
-                auto delimiterPos = next.find_first_of( " :=" );
-                if( delimiterPos != std::string::npos ) {
-                    m_tokenBuffer.push_back( { TokenType::Option, next.substr( 0, delimiterPos ) } );
-                    m_tokenBuffer.push_back( { TokenType::Argument, next.substr( delimiterPos + 1 ) } );
-                } else {
-                    if( next[1] != '-' && next.size() > 2 ) {
-                        std::string opt = "- ";
-                        for( size_t i = 1; i < next.size(); ++i ) {
-                            opt[1] = next[i];
-                            m_tokenBuffer.push_back( { TokenType::Option, opt } );
-                        }
+            if( it != itEnd ) {
+                auto const &next = *it;
+                if( isOptPrefix( next[0] ) ) {
+                    auto delimiterPos = next.find_first_of( " :=" );
+                    if( delimiterPos != std::string::npos ) {
+                        m_tokenBuffer.push_back( { TokenType::Option, next.substr( 0, delimiterPos ) } );
+                        m_tokenBuffer.push_back( { TokenType::Argument, next.substr( delimiterPos + 1 ) } );
                     } else {
-                        m_tokenBuffer.push_back( { TokenType::Option, next } );
+                        if( next[1] != '-' && next.size() > 2 ) {
+                            std::string opt = "- ";
+                            for( size_t i = 1; i < next.size(); ++i ) {
+                                opt[1] = next[i];
+                                m_tokenBuffer.push_back( { TokenType::Option, opt } );
+                            }
+                        } else {
+                            m_tokenBuffer.push_back( { TokenType::Option, next } );
+                        }
                     }
+                } else {
+                    m_tokenBuffer.push_back( { TokenType::Argument, next } );
                 }
-            } else {
-                m_tokenBuffer.push_back( { TokenType::Argument, next } );
             }
         }
-    }
 
-public:
-    explicit TokenStream( Args const &args ) : TokenStream( args.m_args.begin(), args.m_args.end() ) {}
+    public:
+        explicit TokenStream( Args const &args ) : TokenStream( args.m_args.begin(), args.m_args.end() ) {}
 
-    TokenStream( Iterator it, Iterator itEnd ) : it( it ), itEnd( itEnd ) {
-        loadBuffer();
-    }
-
-    explicit operator bool() const {
-        return !m_tokenBuffer.empty() || it != itEnd;
-    }
-
-    auto count() const -> size_t { return m_tokenBuffer.size() + (itEnd - it); }
-
-    auto operator*() const -> Token {
-        assert( !m_tokenBuffer.empty() );
-        return m_tokenBuffer.front();
-    }
-
-    auto operator->() const -> Token const * {
-        assert( !m_tokenBuffer.empty() );
-        return &m_tokenBuffer.front();
-    }
-
-    auto operator++() -> TokenStream & {
-        if( m_tokenBuffer.size() >= 2 ) {
-            m_tokenBuffer.erase( m_tokenBuffer.begin() );
-        } else {
-            if( it != itEnd )
-                ++it;
+        TokenStream( Iterator it, Iterator itEnd ) : it( it ), itEnd( itEnd ) {
             loadBuffer();
         }
-        return *this;
-    }
-};
 
-class ResultBase {
-public:
-    enum Type {
-        Ok, LogicError, RuntimeError
+        explicit operator bool() const {
+            return !m_tokenBuffer.empty() || it != itEnd;
+        }
+
+        auto count() const -> size_t { return m_tokenBuffer.size() + (itEnd - it); }
+
+        auto operator*() const -> Token {
+            assert( !m_tokenBuffer.empty() );
+            return m_tokenBuffer.front();
+        }
+
+        auto operator->() const -> Token const * {
+            assert( !m_tokenBuffer.empty() );
+            return &m_tokenBuffer.front();
+        }
+
+        auto operator++() -> TokenStream & {
+            if( m_tokenBuffer.size() >= 2 ) {
+                m_tokenBuffer.erase( m_tokenBuffer.begin() );
+            } else {
+                if( it != itEnd )
+                    ++it;
+                loadBuffer();
+            }
+            return *this;
+        }
     };
 
-protected:
-    ResultBase( Type type ) : m_type( type ) {}
-    virtual ~ResultBase() = default;
+    class ResultBase {
+    public:
+        enum Type {
+            Ok, LogicError, RuntimeError
+        };
 
-    virtual void enforceOk() const = 0;
+    protected:
+        ResultBase( Type type ) : m_type( type ) {}
+        virtual ~ResultBase() = default;
 
-    Type m_type;
-};
+        virtual void enforceOk() const = 0;
 
-template<typename T>
-class ResultValueBase : public ResultBase {
-public:
-    auto value() const -> T const & {
-        enforceOk();
-        return m_value;
-    }
-
-protected:
-    ResultValueBase( Type type ) : ResultBase( type ) {}
-
-    ResultValueBase( ResultValueBase const &other ) : ResultBase( other ) {
-        if( m_type == ResultBase::Ok )
-            new( &m_value ) T( other.m_value );
-    }
-
-    ResultValueBase( Type, T const &value ) : ResultBase( Ok ) {
-        new( &m_value ) T( value );
-    }
-
-    auto operator=( ResultValueBase const &other ) -> ResultValueBase & {
-        if( m_type == ResultBase::Ok )
-            m_value.~T();
-        ResultBase::operator=(other);
-        if( m_type == ResultBase::Ok )
-            new( &m_value ) T( other.m_value );
-        return *this;
-    }
-
-    ~ResultValueBase() override {
-        if( m_type == Ok )
-            m_value.~T();
-    }
-
-    union {
-        T m_value;
+        Type m_type;
     };
-};
 
-template<>
-class ResultValueBase<void> : public ResultBase {
-protected:
-    using ResultBase::ResultBase;
-};
+    template<typename T>
+    class ResultValueBase : public ResultBase {
+    public:
+        auto value() const -> T const & {
+            enforceOk();
+            return m_value;
+        }
 
-template<typename T = void>
-class BasicResult : public ResultValueBase<T> {
-public:
-    template<typename U>
-    explicit BasicResult( BasicResult<U> const &other )
+    protected:
+        ResultValueBase( Type type ) : ResultBase( type ) {}
+
+        ResultValueBase( ResultValueBase const &other ) : ResultBase( other ) {
+            if( m_type == ResultBase::Ok )
+                new( &m_value ) T( other.m_value );
+        }
+
+        ResultValueBase( Type, T const &value ) : ResultBase( Ok ) {
+            new( &m_value ) T( value );
+        }
+
+        auto operator=( ResultValueBase const &other ) -> ResultValueBase & {
+            if( m_type == ResultBase::Ok )
+                m_value.~T();
+            ResultBase::operator=(other);
+            if( m_type == ResultBase::Ok )
+                new( &m_value ) T( other.m_value );
+            return *this;
+        }
+
+        ~ResultValueBase() override {
+            if( m_type == Ok )
+                m_value.~T();
+        }
+
+        union {
+            T m_value;
+        };
+    };
+
+    template<>
+    class ResultValueBase<void> : public ResultBase {
+    protected:
+        using ResultBase::ResultBase;
+    };
+
+    template<typename T = void>
+    class BasicResult : public ResultValueBase<T> {
+    public:
+        template<typename U>
+        explicit BasicResult( BasicResult<U> const &other )
         :   ResultValueBase<T>( other.type() ),
             m_errorMessage( other.errorMessage() )
-    {
-        assert( type() != ResultBase::Ok );
-    }
+        {
+            assert( type() != ResultBase::Ok );
+        }
 
-    template<typename U>
-    static auto ok( U const &value ) -> BasicResult { return { ResultBase::Ok, value }; }
-    static auto ok() -> BasicResult { return { ResultBase::Ok }; }
-    static auto logicError( std::string const &message ) -> BasicResult { return { ResultBase::LogicError, message }; }
-    static auto runtimeError( std::string const &message ) -> BasicResult { return { ResultBase::RuntimeError, message }; }
+        template<typename U>
+        static auto ok( U const &value ) -> BasicResult { return { ResultBase::Ok, value }; }
+        static auto ok() -> BasicResult { return { ResultBase::Ok }; }
+        static auto logicError( std::string const &message ) -> BasicResult { return { ResultBase::LogicError, message }; }
+        static auto runtimeError( std::string const &message ) -> BasicResult { return { ResultBase::RuntimeError, message }; }
 
-    explicit operator bool() const { return m_type == ResultBase::Ok; }
-    auto type() const -> ResultBase::Type { return m_type; }
-    auto errorMessage() const -> std::string { return m_errorMessage; }
+        explicit operator bool() const { return m_type == ResultBase::Ok; }
+        auto type() const -> ResultBase::Type { return m_type; }
+        auto errorMessage() const -> std::string { return m_errorMessage; }
 
-protected:
-    void enforceOk() const override {
+    protected:
+        void enforceOk() const override {
 
-        // Errors shouldn't reach this point, but if they do
-        // the actual error message will be in m_errorMessage
-        assert( m_type != ResultBase::LogicError );
-        assert( m_type != ResultBase::RuntimeError );
-        if( m_type != ResultBase::Ok )
-            std::abort();
-    }
+            // Errors shouldn't reach this point, but if they do
+            // the actual error message will be in m_errorMessage
+            assert( m_type != ResultBase::LogicError );
+            assert( m_type != ResultBase::RuntimeError );
+            if( m_type != ResultBase::Ok )
+                std::abort();
+        }
 
-    std::string m_errorMessage; // Only populated if resultType is an error
+        std::string m_errorMessage; // Only populated if resultType is an error
 
-    BasicResult( ResultBase::Type type, std::string const &message )
+        BasicResult( ResultBase::Type type, std::string const &message )
         :   ResultValueBase<T>(type),
             m_errorMessage(message)
-    {
-        assert( m_type != ResultBase::Ok );
-    }
+        {
+            assert( m_type != ResultBase::Ok );
+        }
 
-    using ResultValueBase<T>::ResultValueBase;
-    using ResultBase::m_type;
-};
+        using ResultValueBase<T>::ResultValueBase;
+        using ResultBase::m_type;
+    };
 
-enum class ParseResultType {
-    Matched, NoMatch, ShortCircuitAll, ShortCircuitSame
-};
+    enum class ParseResultType {
+        Matched, NoMatch, ShortCircuitAll, ShortCircuitSame
+    };
 
-class ParseState {
-public:
+    class ParseState {
+    public:
 
-    ParseState( ParseResultType type, TokenStream const &remainingTokens )
+        ParseState( ParseResultType type, TokenStream const &remainingTokens )
         : m_type(type),
           m_remainingTokens( remainingTokens )
-    {}
+        {}
 
-    auto type() const -> ParseResultType { return m_type; }
-    auto remainingTokens() const -> TokenStream { return m_remainingTokens; }
+        auto type() const -> ParseResultType { return m_type; }
+        auto remainingTokens() const -> TokenStream { return m_remainingTokens; }
 
-private:
-    ParseResultType m_type;
-    TokenStream m_remainingTokens;
-};
-
-using Result = BasicResult<void>;
-using ParserResult = BasicResult<ParseResultType>;
-using InternalParseResult = BasicResult<ParseState>;
-
-struct HelpColumns {
-    std::string left;
-    std::string right;
-};
-
-template<typename T>
-inline auto convertInto( std::string const &source, T& target ) -> ParserResult {
-    std::stringstream ss;
-    ss << source;
-    ss >> target;
-    if( ss.fail() )
-        return ParserResult::runtimeError( "Unable to convert '" + source + "' to destination type" );
-    else
-        return ParserResult::ok( ParseResultType::Matched );
-}
-inline auto convertInto( std::string const &source, std::string& target ) -> ParserResult {
-    target = source;
-    return ParserResult::ok( ParseResultType::Matched );
-}
-inline auto convertInto( std::string const &source, bool &target ) -> ParserResult {
-    std::string srcLC = source;
-    std::transform( srcLC.begin(), srcLC.end(), srcLC.begin(), []( unsigned char c ) { return static_cast<char>( std::tolower(c) ); } );
-    if (srcLC == "y" || srcLC == "1" || srcLC == "true" || srcLC == "yes" || srcLC == "on")
-        target = true;
-    else if (srcLC == "n" || srcLC == "0" || srcLC == "false" || srcLC == "no" || srcLC == "off")
-        target = false;
-    else
-        return ParserResult::runtimeError( "Expected a boolean value but did not recognise: '" + source + "'" );
-    return ParserResult::ok( ParseResultType::Matched );
-}
-#ifdef CLARA_CONFIG_OPTIONAL_TYPE
-template<typename T>
-inline auto convertInto( std::string const &source, CLARA_CONFIG_OPTIONAL_TYPE<T>& target ) -> ParserResult {
-    T temp;
-    auto result = convertInto( source, temp );
-    if( result )
-        target = std::move(temp);
-    return result;
-}
-#endif // CLARA_CONFIG_OPTIONAL_TYPE
-
-struct NonCopyable {
-    NonCopyable() = default;
-    NonCopyable( NonCopyable const & ) = delete;
-    NonCopyable( NonCopyable && ) = delete;
-    NonCopyable &operator=( NonCopyable const & ) = delete;
-    NonCopyable &operator=( NonCopyable && ) = delete;
-};
-
-struct BoundRef : NonCopyable {
-    virtual ~BoundRef() = default;
-    virtual auto isContainer() const -> bool { return false; }
-    virtual auto isFlag() const -> bool { return false; }
-};
-struct BoundValueRefBase : BoundRef {
-    virtual auto setValue( std::string const &arg ) -> ParserResult = 0;
-};
-struct BoundFlagRefBase : BoundRef {
-    virtual auto setFlag( bool flag ) -> ParserResult = 0;
-    virtual auto isFlag() const -> bool { return true; }
-};
-
-template<typename T>
-struct BoundValueRef : BoundValueRefBase {
-    T &m_ref;
-
-    explicit BoundValueRef( T &ref ) : m_ref( ref ) {}
-
-    auto setValue( std::string const &arg ) -> ParserResult override {
-        return convertInto( arg, m_ref );
-    }
-};
-
-template<typename T>
-struct BoundValueRef<std::vector<T>> : BoundValueRefBase {
-    std::vector<T> &m_ref;
-
-    explicit BoundValueRef( std::vector<T> &ref ) : m_ref( ref ) {}
-
-    auto isContainer() const -> bool override { return true; }
-
-    auto setValue( std::string const &arg ) -> ParserResult override {
-        T temp;
-        auto result = convertInto( arg, temp );
-        if( result )
-            m_ref.push_back( temp );
-        return result;
-    }
-};
-
-struct BoundFlagRef : BoundFlagRefBase {
-    bool &m_ref;
-
-    explicit BoundFlagRef( bool &ref ) : m_ref( ref ) {}
-
-    auto setFlag( bool flag ) -> ParserResult override {
-        m_ref = flag;
-        return ParserResult::ok( ParseResultType::Matched );
-    }
-};
-
-template<typename ReturnType>
-struct LambdaInvoker {
-    static_assert( std::is_same<ReturnType, ParserResult>::value, "Lambda must return void or clara::ParserResult" );
-
-    template<typename L, typename ArgType>
-    static auto invoke( L const &lambda, ArgType const &arg ) -> ParserResult {
-        return lambda( arg );
-    }
-};
-
-template<>
-struct LambdaInvoker<void> {
-    template<typename L, typename ArgType>
-    static auto invoke( L const &lambda, ArgType const &arg ) -> ParserResult {
-        lambda( arg );
-        return ParserResult::ok( ParseResultType::Matched );
-    }
-};
-
-template<typename ArgType, typename L>
-inline auto invokeLambda( L const &lambda, std::string const &arg ) -> ParserResult {
-    ArgType temp{};
-    auto result = convertInto( arg, temp );
-    return !result
-           ? result
-           : LambdaInvoker<typename UnaryLambdaTraits<L>::ReturnType>::invoke( lambda, temp );
-}
-
-template<typename L>
-struct BoundLambda : BoundValueRefBase {
-    L m_lambda;
-
-    static_assert( UnaryLambdaTraits<L>::isValid, "Supplied lambda must take exactly one argument" );
-    explicit BoundLambda( L const &lambda ) : m_lambda( lambda ) {}
-
-    auto setValue( std::string const &arg ) -> ParserResult override {
-        return invokeLambda<typename UnaryLambdaTraits<L>::ArgType>( m_lambda, arg );
-    }
-};
-
-template<typename L>
-struct BoundFlagLambda : BoundFlagRefBase {
-    L m_lambda;
-
-    static_assert( UnaryLambdaTraits<L>::isValid, "Supplied lambda must take exactly one argument" );
-    static_assert( std::is_same<typename UnaryLambdaTraits<L>::ArgType, bool>::value, "flags must be boolean" );
-
-    explicit BoundFlagLambda( L const &lambda ) : m_lambda( lambda ) {}
-
-    auto setFlag( bool flag ) -> ParserResult override {
-        return LambdaInvoker<typename UnaryLambdaTraits<L>::ReturnType>::invoke( m_lambda, flag );
-    }
-};
-
-enum class Optionality { Optional, Required };
-
-struct Parser;
-
-class ParserBase {
-public:
-    virtual ~ParserBase() = default;
-    virtual auto validate() const -> Result { return Result::ok(); }
-    virtual auto parse( std::string const& exeName, TokenStream const &tokens) const -> InternalParseResult  = 0;
-    virtual auto cardinality() const -> size_t { return 1; }
-
-    auto parse( Args const &args ) const -> InternalParseResult {
-        return parse( args.exeName(), TokenStream( args ) );
-    }
-};
-
-template<typename DerivedT>
-class ComposableParserImpl : public ParserBase {
-public:
-    template<typename T>
-    auto operator|( T const &other ) const -> Parser;
-
-    template<typename T>
-    auto operator+( T const &other ) const -> Parser;
-};
-
-// Common code and state for Args and Opts
-template<typename DerivedT>
-class ParserRefImpl : public ComposableParserImpl<DerivedT> {
-protected:
-    Optionality m_optionality = Optionality::Optional;
-    std::shared_ptr<BoundRef> m_ref;
-    std::string m_hint;
-    std::string m_description;
-
-    explicit ParserRefImpl( std::shared_ptr<BoundRef> const &ref ) : m_ref( ref ) {}
-
-public:
-    template<typename T>
-    ParserRefImpl( T &ref, std::string const &hint )
-        :   m_ref( std::make_shared<BoundValueRef<T>>( ref ) ),
-            m_hint( hint )
-    {}
-
-    template<typename LambdaT>
-    ParserRefImpl( LambdaT const &ref, std::string const &hint )
-        :   m_ref( std::make_shared<BoundLambda<LambdaT>>( ref ) ),
-            m_hint(hint)
-    {}
-
-    auto operator()( std::string const &description ) -> DerivedT & {
-        m_description = description;
-        return static_cast<DerivedT &>( *this );
-    }
-
-    auto optional() -> DerivedT & {
-        m_optionality = Optionality::Optional;
-        return static_cast<DerivedT &>( *this );
+    private:
+        ParseResultType m_type;
+        TokenStream m_remainingTokens;
     };
 
-    auto required() -> DerivedT & {
-        m_optionality = Optionality::Required;
-        return static_cast<DerivedT &>( *this );
+    using Result = BasicResult<void>;
+    using ParserResult = BasicResult<ParseResultType>;
+    using InternalParseResult = BasicResult<ParseState>;
+
+    struct HelpColumns {
+        std::string left;
+        std::string right;
     };
 
-    auto isOptional() const -> bool {
-        return m_optionality == Optionality::Optional;
-    }
-
-    auto cardinality() const -> size_t override {
-        if( m_ref->isContainer() )
-            return 0;
-        else
-            return 1;
-    }
-
-    auto hint() const -> std::string { return m_hint; }
-};
-
-class ExeName : public ComposableParserImpl<ExeName> {
-    std::shared_ptr<std::string> m_name;
-    std::shared_ptr<BoundValueRefBase> m_ref;
-
-    template<typename LambdaT>
-    static auto makeRef(LambdaT const &lambda) -> std::shared_ptr<BoundValueRefBase> {
-        return std::make_shared<BoundLambda<LambdaT>>( lambda) ;
-    }
-
-public:
-    ExeName() : m_name( std::make_shared<std::string>( "<executable>" ) ) {}
-
-    explicit ExeName( std::string &ref ) : ExeName() {
-        m_ref = std::make_shared<BoundValueRef<std::string>>( ref );
-    }
-
-    template<typename LambdaT>
-    explicit ExeName( LambdaT const& lambda ) : ExeName() {
-        m_ref = std::make_shared<BoundLambda<LambdaT>>( lambda );
-    }
-
-    // The exe name is not parsed out of the normal tokens, but is handled specially
-    auto parse( std::string const&, TokenStream const &tokens ) const -> InternalParseResult override {
-        return InternalParseResult::ok( ParseState( ParseResultType::NoMatch, tokens ) );
-    }
-
-    auto name() const -> std::string { return *m_name; }
-    auto set( std::string const& newName ) -> ParserResult {
-
-        auto lastSlash = newName.find_last_of( "\\/" );
-        auto filename = ( lastSlash == std::string::npos )
-                        ? newName
-                        : newName.substr( lastSlash+1 );
-
-        *m_name = filename;
-        if( m_ref )
-            return m_ref->setValue( filename );
+    template<typename T>
+    inline auto convertInto( std::string const &source, T& target ) -> ParserResult {
+        std::stringstream ss;
+        ss << source;
+        ss >> target;
+        if( ss.fail() )
+            return ParserResult::runtimeError( "Unable to convert '" + source + "' to destination type" );
         else
             return ParserResult::ok( ParseResultType::Matched );
     }
-};
-
-class Arg : public ParserRefImpl<Arg> {
-public:
-    using ParserRefImpl::ParserRefImpl;
-
-    auto parse( std::string const &, TokenStream const &tokens ) const -> InternalParseResult override {
-        auto validationResult = validate();
-        if( !validationResult )
-            return InternalParseResult( validationResult );
-
-        auto remainingTokens = tokens;
-        auto const &token = *remainingTokens;
-        if( token.type != TokenType::Argument )
-            return InternalParseResult::ok( ParseState( ParseResultType::NoMatch, remainingTokens ) );
-
-        assert( !m_ref->isFlag() );
-        auto valueRef = static_cast<detail::BoundValueRefBase*>( m_ref.get() );
-
-        auto result = valueRef->setValue( remainingTokens->token );
-        if( !result )
-            return InternalParseResult( result );
-        else
-            return InternalParseResult::ok( ParseState( ParseResultType::Matched, ++remainingTokens ) );
+    inline auto convertInto( std::string const &source, std::string& target ) -> ParserResult {
+        target = source;
+        return ParserResult::ok( ParseResultType::Matched );
     }
-};
+    inline auto convertInto( std::string const &source, bool &target ) -> ParserResult {
+        std::string srcLC = source;
+        std::transform( srcLC.begin(), srcLC.end(), srcLC.begin(), []( unsigned char c ) { return static_cast<char>( std::tolower(c) ); } );
+        if (srcLC == "y" || srcLC == "1" || srcLC == "true" || srcLC == "yes" || srcLC == "on")
+            target = true;
+        else if (srcLC == "n" || srcLC == "0" || srcLC == "false" || srcLC == "no" || srcLC == "off")
+            target = false;
+        else
+            return ParserResult::runtimeError( "Expected a boolean value but did not recognise: '" + source + "'" );
+        return ParserResult::ok( ParseResultType::Matched );
+    }
+#ifdef CLARA_CONFIG_OPTIONAL_TYPE
+    template<typename T>
+    inline auto convertInto( std::string const &source, CLARA_CONFIG_OPTIONAL_TYPE<T>& target ) -> ParserResult {
+        T temp;
+        auto result = convertInto( source, temp );
+        if( result )
+            target = std::move(temp);
+        return result;
+    }
+#endif // CLARA_CONFIG_OPTIONAL_TYPE
 
-inline auto normaliseOpt( std::string const &optName ) -> std::string {
+    struct NonCopyable {
+        NonCopyable() = default;
+        NonCopyable( NonCopyable const & ) = delete;
+        NonCopyable( NonCopyable && ) = delete;
+        NonCopyable &operator=( NonCopyable const & ) = delete;
+        NonCopyable &operator=( NonCopyable && ) = delete;
+    };
+
+    struct BoundRef : NonCopyable {
+        virtual ~BoundRef() = default;
+        virtual auto isContainer() const -> bool { return false; }
+        virtual auto isFlag() const -> bool { return false; }
+    };
+    struct BoundValueRefBase : BoundRef {
+        virtual auto setValue( std::string const &arg ) -> ParserResult = 0;
+    };
+    struct BoundFlagRefBase : BoundRef {
+        virtual auto setFlag( bool flag ) -> ParserResult = 0;
+        virtual auto isFlag() const -> bool { return true; }
+    };
+
+    template<typename T>
+    struct BoundValueRef : BoundValueRefBase {
+        T &m_ref;
+
+        explicit BoundValueRef( T &ref ) : m_ref( ref ) {}
+
+        auto setValue( std::string const &arg ) -> ParserResult override {
+            return convertInto( arg, m_ref );
+        }
+    };
+
+    template<typename T>
+    struct BoundValueRef<std::vector<T>> : BoundValueRefBase {
+        std::vector<T> &m_ref;
+
+        explicit BoundValueRef( std::vector<T> &ref ) : m_ref( ref ) {}
+
+        auto isContainer() const -> bool override { return true; }
+
+        auto setValue( std::string const &arg ) -> ParserResult override {
+            T temp;
+            auto result = convertInto( arg, temp );
+            if( result )
+                m_ref.push_back( temp );
+            return result;
+        }
+    };
+
+    struct BoundFlagRef : BoundFlagRefBase {
+        bool &m_ref;
+
+        explicit BoundFlagRef( bool &ref ) : m_ref( ref ) {}
+
+        auto setFlag( bool flag ) -> ParserResult override {
+            m_ref = flag;
+            return ParserResult::ok( ParseResultType::Matched );
+        }
+    };
+
+    template<typename ReturnType>
+    struct LambdaInvoker {
+        static_assert( std::is_same<ReturnType, ParserResult>::value, "Lambda must return void or clara::ParserResult" );
+
+        template<typename L, typename ArgType>
+        static auto invoke( L const &lambda, ArgType const &arg ) -> ParserResult {
+            return lambda( arg );
+        }
+    };
+
+    template<>
+    struct LambdaInvoker<void> {
+        template<typename L, typename ArgType>
+        static auto invoke( L const &lambda, ArgType const &arg ) -> ParserResult {
+            lambda( arg );
+            return ParserResult::ok( ParseResultType::Matched );
+        }
+    };
+
+    template<typename ArgType, typename L>
+    inline auto invokeLambda( L const &lambda, std::string const &arg ) -> ParserResult {
+        ArgType temp{};
+        auto result = convertInto( arg, temp );
+        return !result
+           ? result
+           : LambdaInvoker<typename UnaryLambdaTraits<L>::ReturnType>::invoke( lambda, temp );
+    }
+
+    template<typename L>
+    struct BoundLambda : BoundValueRefBase {
+        L m_lambda;
+
+        static_assert( UnaryLambdaTraits<L>::isValid, "Supplied lambda must take exactly one argument" );
+        explicit BoundLambda( L const &lambda ) : m_lambda( lambda ) {}
+
+        auto setValue( std::string const &arg ) -> ParserResult override {
+            return invokeLambda<typename UnaryLambdaTraits<L>::ArgType>( m_lambda, arg );
+        }
+    };
+
+    template<typename L>
+    struct BoundFlagLambda : BoundFlagRefBase {
+        L m_lambda;
+
+        static_assert( UnaryLambdaTraits<L>::isValid, "Supplied lambda must take exactly one argument" );
+        static_assert( std::is_same<typename UnaryLambdaTraits<L>::ArgType, bool>::value, "flags must be boolean" );
+
+        explicit BoundFlagLambda( L const &lambda ) : m_lambda( lambda ) {}
+
+        auto setFlag( bool flag ) -> ParserResult override {
+            return LambdaInvoker<typename UnaryLambdaTraits<L>::ReturnType>::invoke( m_lambda, flag );
+        }
+    };
+
+    enum class Optionality { Optional, Required };
+
+    struct Parser;
+
+    class ParserBase {
+    public:
+        virtual ~ParserBase() = default;
+        virtual auto validate() const -> Result { return Result::ok(); }
+        virtual auto parse( std::string const& exeName, TokenStream const &tokens) const -> InternalParseResult  = 0;
+        virtual auto cardinality() const -> size_t { return 1; }
+
+        auto parse( Args const &args ) const -> InternalParseResult {
+            return parse( args.exeName(), TokenStream( args ) );
+        }
+    };
+
+    template<typename DerivedT>
+    class ComposableParserImpl : public ParserBase {
+    public:
+        template<typename T>
+        auto operator|( T const &other ) const -> Parser;
+
+		template<typename T>
+        auto operator+( T const &other ) const -> Parser;
+    };
+
+    // Common code and state for Args and Opts
+    template<typename DerivedT>
+    class ParserRefImpl : public ComposableParserImpl<DerivedT> {
+    protected:
+        Optionality m_optionality = Optionality::Optional;
+        std::shared_ptr<BoundRef> m_ref;
+        std::string m_hint;
+        std::string m_description;
+
+        explicit ParserRefImpl( std::shared_ptr<BoundRef> const &ref ) : m_ref( ref ) {}
+
+    public:
+        template<typename T>
+        ParserRefImpl( T &ref, std::string const &hint )
+        :   m_ref( std::make_shared<BoundValueRef<T>>( ref ) ),
+            m_hint( hint )
+        {}
+
+        template<typename LambdaT>
+        ParserRefImpl( LambdaT const &ref, std::string const &hint )
+        :   m_ref( std::make_shared<BoundLambda<LambdaT>>( ref ) ),
+            m_hint(hint)
+        {}
+
+        auto operator()( std::string const &description ) -> DerivedT & {
+            m_description = description;
+            return static_cast<DerivedT &>( *this );
+        }
+
+        auto optional() -> DerivedT & {
+            m_optionality = Optionality::Optional;
+            return static_cast<DerivedT &>( *this );
+        };
+
+        auto required() -> DerivedT & {
+            m_optionality = Optionality::Required;
+            return static_cast<DerivedT &>( *this );
+        };
+
+        auto isOptional() const -> bool {
+            return m_optionality == Optionality::Optional;
+        }
+
+        auto cardinality() const -> size_t override {
+            if( m_ref->isContainer() )
+                return 0;
+            else
+                return 1;
+        }
+
+        auto hint() const -> std::string { return m_hint; }
+    };
+
+    class ExeName : public ComposableParserImpl<ExeName> {
+        std::shared_ptr<std::string> m_name;
+        std::shared_ptr<BoundValueRefBase> m_ref;
+
+        template<typename LambdaT>
+        static auto makeRef(LambdaT const &lambda) -> std::shared_ptr<BoundValueRefBase> {
+            return std::make_shared<BoundLambda<LambdaT>>( lambda) ;
+        }
+
+    public:
+        ExeName() : m_name( std::make_shared<std::string>( "<executable>" ) ) {}
+
+        explicit ExeName( std::string &ref ) : ExeName() {
+            m_ref = std::make_shared<BoundValueRef<std::string>>( ref );
+        }
+
+        template<typename LambdaT>
+        explicit ExeName( LambdaT const& lambda ) : ExeName() {
+            m_ref = std::make_shared<BoundLambda<LambdaT>>( lambda );
+        }
+
+        // The exe name is not parsed out of the normal tokens, but is handled specially
+        auto parse( std::string const&, TokenStream const &tokens ) const -> InternalParseResult override {
+            return InternalParseResult::ok( ParseState( ParseResultType::NoMatch, tokens ) );
+        }
+
+        auto name() const -> std::string { return *m_name; }
+        auto set( std::string const& newName ) -> ParserResult {
+
+            auto lastSlash = newName.find_last_of( "\\/" );
+            auto filename = ( lastSlash == std::string::npos )
+                    ? newName
+                    : newName.substr( lastSlash+1 );
+
+            *m_name = filename;
+            if( m_ref )
+                return m_ref->setValue( filename );
+            else
+                return ParserResult::ok( ParseResultType::Matched );
+        }
+    };
+
+    class Arg : public ParserRefImpl<Arg> {
+    public:
+        using ParserRefImpl::ParserRefImpl;
+
+        auto parse( std::string const &, TokenStream const &tokens ) const -> InternalParseResult override {
+            auto validationResult = validate();
+            if( !validationResult )
+                return InternalParseResult( validationResult );
+
+            auto remainingTokens = tokens;
+            auto const &token = *remainingTokens;
+            if( token.type != TokenType::Argument )
+                return InternalParseResult::ok( ParseState( ParseResultType::NoMatch, remainingTokens ) );
+
+            assert( !m_ref->isFlag() );
+            auto valueRef = static_cast<detail::BoundValueRefBase*>( m_ref.get() );
+
+            auto result = valueRef->setValue( remainingTokens->token );
+            if( !result )
+                return InternalParseResult( result );
+            else
+                return InternalParseResult::ok( ParseState( ParseResultType::Matched, ++remainingTokens ) );
+        }
+    };
+
+    inline auto normaliseOpt( std::string const &optName ) -> std::string {
 #ifdef CATCH_PLATFORM_WINDOWS
-    if( optName[0] == '/' )
+        if( optName[0] == '/' )
             return "-" + optName.substr( 1 );
         else
 #endif
-    return optName;
-}
-
-class Opt : public ParserRefImpl<Opt> {
-protected:
-    std::vector<std::string> m_optNames;
-
-public:
-    template<typename LambdaT>
-    explicit Opt( LambdaT const &ref ) : ParserRefImpl( std::make_shared<BoundFlagLambda<LambdaT>>( ref ) ) {}
-
-    explicit Opt( bool &ref ) : ParserRefImpl( std::make_shared<BoundFlagRef>( ref ) ) {}
-
-    template<typename LambdaT>
-    Opt( LambdaT const &ref, std::string const &hint ) : ParserRefImpl( ref, hint ) {}
-
-    template<typename T>
-    Opt( T &ref, std::string const &hint ) : ParserRefImpl( ref, hint ) {}
-
-    auto operator[]( std::string const &optName ) -> Opt & {
-        m_optNames.push_back( optName );
-        return *this;
+            return optName;
     }
 
-    auto getHelpColumns() const -> std::vector<HelpColumns> {
-        std::ostringstream oss;
-        bool first = true;
-        for( auto const &opt : m_optNames ) {
-            if (first)
-                first = false;
-            else
-                oss << ", ";
-            oss << opt;
+    class Opt : public ParserRefImpl<Opt> {
+    protected:
+        std::vector<std::string> m_optNames;
+
+    public:
+        template<typename LambdaT>
+        explicit Opt( LambdaT const &ref ) : ParserRefImpl( std::make_shared<BoundFlagLambda<LambdaT>>( ref ) ) {}
+
+        explicit Opt( bool &ref ) : ParserRefImpl( std::make_shared<BoundFlagRef>( ref ) ) {}
+
+        template<typename LambdaT>
+        Opt( LambdaT const &ref, std::string const &hint ) : ParserRefImpl( ref, hint ) {}
+
+        template<typename T>
+        Opt( T &ref, std::string const &hint ) : ParserRefImpl( ref, hint ) {}
+
+        auto operator[]( std::string const &optName ) -> Opt & {
+            m_optNames.push_back( optName );
+            return *this;
         }
-        if( !m_hint.empty() )
-            oss << " <" << m_hint << ">";
-        return { { oss.str(), m_description } };
-    }
 
-    auto isMatch( std::string const &optToken ) const -> bool {
-        auto normalisedToken = normaliseOpt( optToken );
-        for( auto const &name : m_optNames ) {
-            if( normaliseOpt( name ) == normalisedToken )
-                return true;
-        }
-        return false;
-    }
-
-    using ParserBase::parse;
-
-    auto parse( std::string const&, TokenStream const &tokens ) const -> InternalParseResult override {
-        auto validationResult = validate();
-        if( !validationResult )
-            return InternalParseResult( validationResult );
-
-        auto remainingTokens = tokens;
-        if( remainingTokens && remainingTokens->type == TokenType::Option ) {
-            auto const &token = *remainingTokens;
-            if( isMatch(token.token ) ) {
-                if( m_ref->isFlag() ) {
-                    auto flagRef = static_cast<detail::BoundFlagRefBase*>( m_ref.get() );
-                    auto result = flagRef->setFlag( true );
-                    if( !result )
-                        return InternalParseResult( result );
-                    if( result.value() == ParseResultType::ShortCircuitAll )
-                        return InternalParseResult::ok( ParseState( result.value(), remainingTokens ) );
-                } else {
-                    auto valueRef = static_cast<detail::BoundValueRefBase*>( m_ref.get() );
-                    ++remainingTokens;
-                    if( !remainingTokens )
-                        return InternalParseResult::runtimeError( "Expected argument following " + token.token );
-                    auto const &argToken = *remainingTokens;
-                    if( argToken.type != TokenType::Argument )
-                        return InternalParseResult::runtimeError( "Expected argument following " + token.token );
-                    auto result = valueRef->setValue( argToken.token );
-                    if( !result )
-                        return InternalParseResult( result );
-                    if( result.value() == ParseResultType::ShortCircuitAll )
-                        return InternalParseResult::ok( ParseState( result.value(), remainingTokens ) );
-                }
-                return InternalParseResult::ok( ParseState( ParseResultType::Matched, ++remainingTokens ) );
-            }
-        }
-        return InternalParseResult::ok( ParseState( ParseResultType::NoMatch, remainingTokens ) );
-    }
-
-    auto validate() const -> Result override {
-        if( m_optNames.empty() )
-            return Result::logicError( "No options supplied to Opt" );
-        for( auto const &name : m_optNames ) {
-            if( name.empty() )
-                return Result::logicError( "Option name cannot be empty" );
-#ifdef CATCH_PLATFORM_WINDOWS
-            if( name[0] != '-' && name[0] != '/' )
-                    return Result::logicError( "Option name must begin with '-' or '/'" );
-#else
-            if( name[0] != '-' )
-                return Result::logicError( "Option name must begin with '-'" );
-#endif
-        }
-        return ParserRefImpl::validate();
-    }
-};
-
-struct Help : Opt {
-    Help( bool &showHelpFlag )
-        :   Opt([&]( bool flag ) {
-        showHelpFlag = flag;
-        return ParserResult::ok( ParseResultType::ShortCircuitAll );
-    })
-    {
-        static_cast<Opt &>( *this )
-            ("display usage information")
-        ["-?"]["-h"]["--help"]
-            .optional();
-    }
-};
-
-struct Parser : ParserBase {
-
-    mutable ExeName m_exeName;
-    std::vector<Opt> m_options;
-    std::vector<Arg> m_args;
-
-    auto operator|=( ExeName const &exeName ) -> Parser & {
-        m_exeName = exeName;
-        return *this;
-    }
-
-    auto operator|=( Arg const &arg ) -> Parser & {
-        m_args.push_back(arg);
-        return *this;
-    }
-
-    auto operator|=( Opt const &opt ) -> Parser & {
-        m_options.push_back(opt);
-        return *this;
-    }
-
-    auto operator|=( Parser const &other ) -> Parser & {
-        m_options.insert(m_options.end(), other.m_options.begin(), other.m_options.end());
-        m_args.insert(m_args.end(), other.m_args.begin(), other.m_args.end());
-        return *this;
-    }
-
-    template<typename T>
-    auto operator|( T const &other ) const -> Parser {
-        return Parser( *this ) |= other;
-    }
-
-    // Forward deprecated interface with '+' instead of '|'
-    template<typename T>
-    auto operator+=( T const &other ) -> Parser & { return operator|=( other ); }
-    template<typename T>
-    auto operator+( T const &other ) const -> Parser { return operator|( other ); }
-
-    auto getHelpColumns() const -> std::vector<HelpColumns> {
-        std::vector<HelpColumns> cols;
-        for (auto const &o : m_options) {
-            auto childCols = o.getHelpColumns();
-            cols.insert( cols.end(), childCols.begin(), childCols.end() );
-        }
-        return cols;
-    }
-
-    void writeToStream( std::ostream &os ) const {
-        if (!m_exeName.name().empty()) {
-            os << "usage:\n" << "  " << m_exeName.name() << " ";
-            bool required = true, first = true;
-            for( auto const &arg : m_args ) {
+        auto getHelpColumns() const -> std::vector<HelpColumns> {
+            std::ostringstream oss;
+            bool first = true;
+            for( auto const &opt : m_optNames ) {
                 if (first)
                     first = false;
                 else
-                    os << " ";
-                if( arg.isOptional() && required ) {
-                    os << "[";
-                    required = false;
-                }
-                os << "<" << arg.hint() << ">";
-                if( arg.cardinality() == 0 )
-                    os << " ... ";
+                    oss << ", ";
+                oss << opt;
             }
-            if( !required )
-                os << "]";
-            if( !m_options.empty() )
-                os << " options";
-            os << "\n\nwhere options are:" << std::endl;
+            if( !m_hint.empty() )
+                oss << " <" << m_hint << ">";
+            return { { oss.str(), m_description } };
         }
 
-        auto rows = getHelpColumns();
-        size_t consoleWidth = CATCH_CLARA_CONFIG_CONSOLE_WIDTH;
-        size_t optWidth = 0;
-        for( auto const &cols : rows )
-            optWidth = (std::max)(optWidth, cols.left.size() + 2);
-
-        optWidth = (std::min)(optWidth, consoleWidth/2);
-
-        for( auto const &cols : rows ) {
-            auto row =
-                TextFlow::Column( cols.left ).width( optWidth ).indent( 2 ) +
-                    TextFlow::Spacer(4) +
-                    TextFlow::Column( cols.right ).width( consoleWidth - 7 - optWidth );
-            os << row << std::endl;
+        auto isMatch( std::string const &optToken ) const -> bool {
+            auto normalisedToken = normaliseOpt( optToken );
+            for( auto const &name : m_optNames ) {
+                if( normaliseOpt( name ) == normalisedToken )
+                    return true;
+            }
+            return false;
         }
-    }
 
-    friend auto operator<<( std::ostream &os, Parser const &parser ) -> std::ostream& {
-        parser.writeToStream( os );
-        return os;
-    }
+        using ParserBase::parse;
 
-    auto validate() const -> Result override {
-        for( auto const &opt : m_options ) {
-            auto result = opt.validate();
-            if( !result )
-                return result;
+        auto parse( std::string const&, TokenStream const &tokens ) const -> InternalParseResult override {
+            auto validationResult = validate();
+            if( !validationResult )
+                return InternalParseResult( validationResult );
+
+            auto remainingTokens = tokens;
+            if( remainingTokens && remainingTokens->type == TokenType::Option ) {
+                auto const &token = *remainingTokens;
+                if( isMatch(token.token ) ) {
+                    if( m_ref->isFlag() ) {
+                        auto flagRef = static_cast<detail::BoundFlagRefBase*>( m_ref.get() );
+                        auto result = flagRef->setFlag( true );
+                        if( !result )
+                            return InternalParseResult( result );
+                        if( result.value() == ParseResultType::ShortCircuitAll )
+                            return InternalParseResult::ok( ParseState( result.value(), remainingTokens ) );
+                    } else {
+                        auto valueRef = static_cast<detail::BoundValueRefBase*>( m_ref.get() );
+                        ++remainingTokens;
+                        if( !remainingTokens )
+                            return InternalParseResult::runtimeError( "Expected argument following " + token.token );
+                        auto const &argToken = *remainingTokens;
+                        if( argToken.type != TokenType::Argument )
+                            return InternalParseResult::runtimeError( "Expected argument following " + token.token );
+                        auto result = valueRef->setValue( argToken.token );
+                        if( !result )
+                            return InternalParseResult( result );
+                        if( result.value() == ParseResultType::ShortCircuitAll )
+                            return InternalParseResult::ok( ParseState( result.value(), remainingTokens ) );
+                    }
+                    return InternalParseResult::ok( ParseState( ParseResultType::Matched, ++remainingTokens ) );
+                }
+            }
+            return InternalParseResult::ok( ParseState( ParseResultType::NoMatch, remainingTokens ) );
         }
-        for( auto const &arg : m_args ) {
-            auto result = arg.validate();
-            if( !result )
-                return result;
+
+        auto validate() const -> Result override {
+            if( m_optNames.empty() )
+                return Result::logicError( "No options supplied to Opt" );
+            for( auto const &name : m_optNames ) {
+                if( name.empty() )
+                    return Result::logicError( "Option name cannot be empty" );
+#ifdef CATCH_PLATFORM_WINDOWS
+                if( name[0] != '-' && name[0] != '/' )
+                    return Result::logicError( "Option name must begin with '-' or '/'" );
+#else
+                if( name[0] != '-' )
+                    return Result::logicError( "Option name must begin with '-'" );
+#endif
+            }
+            return ParserRefImpl::validate();
         }
-        return Result::ok();
-    }
+    };
 
-    using ParserBase::parse;
-
-    auto parse( std::string const& exeName, TokenStream const &tokens ) const -> InternalParseResult override {
-
-        struct ParserInfo {
-            ParserBase const* parser = nullptr;
-            size_t count = 0;
-        };
-        const size_t totalParsers = m_options.size() + m_args.size();
-        assert( totalParsers < 512 );
-        // ParserInfo parseInfos[totalParsers]; // <-- this is what we really want to do
-        ParserInfo parseInfos[512];
-
+    struct Help : Opt {
+        Help( bool &showHelpFlag )
+        :   Opt([&]( bool flag ) {
+                showHelpFlag = flag;
+                return ParserResult::ok( ParseResultType::ShortCircuitAll );
+            })
         {
-            size_t i = 0;
-            for (auto const &opt : m_options) parseInfos[i++].parser = &opt;
-            for (auto const &arg : m_args) parseInfos[i++].parser = &arg;
+            static_cast<Opt &>( *this )
+                    ("display usage information")
+                    ["-?"]["-h"]["--help"]
+                    .optional();
+        }
+    };
+
+    struct Parser : ParserBase {
+
+        mutable ExeName m_exeName;
+        std::vector<Opt> m_options;
+        std::vector<Arg> m_args;
+
+        auto operator|=( ExeName const &exeName ) -> Parser & {
+            m_exeName = exeName;
+            return *this;
         }
 
-        m_exeName.set( exeName );
+        auto operator|=( Arg const &arg ) -> Parser & {
+            m_args.push_back(arg);
+            return *this;
+        }
 
-        auto result = InternalParseResult::ok( ParseState( ParseResultType::NoMatch, tokens ) );
-        while( result.value().remainingTokens() ) {
-            bool tokenParsed = false;
+        auto operator|=( Opt const &opt ) -> Parser & {
+            m_options.push_back(opt);
+            return *this;
+        }
 
-            for( size_t i = 0; i < totalParsers; ++i ) {
-                auto&  parseInfo = parseInfos[i];
-                if( parseInfo.parser->cardinality() == 0 || parseInfo.count < parseInfo.parser->cardinality() ) {
-                    result = parseInfo.parser->parse(exeName, result.value().remainingTokens());
-                    if (!result)
-                        return result;
-                    if (result.value().type() != ParseResultType::NoMatch) {
-                        tokenParsed = true;
-                        ++parseInfo.count;
-                        break;
+        auto operator|=( Parser const &other ) -> Parser & {
+            m_options.insert(m_options.end(), other.m_options.begin(), other.m_options.end());
+            m_args.insert(m_args.end(), other.m_args.begin(), other.m_args.end());
+            return *this;
+        }
+
+        template<typename T>
+        auto operator|( T const &other ) const -> Parser {
+            return Parser( *this ) |= other;
+        }
+
+        // Forward deprecated interface with '+' instead of '|'
+        template<typename T>
+        auto operator+=( T const &other ) -> Parser & { return operator|=( other ); }
+        template<typename T>
+        auto operator+( T const &other ) const -> Parser { return operator|( other ); }
+
+        auto getHelpColumns() const -> std::vector<HelpColumns> {
+            std::vector<HelpColumns> cols;
+            for (auto const &o : m_options) {
+                auto childCols = o.getHelpColumns();
+                cols.insert( cols.end(), childCols.begin(), childCols.end() );
+            }
+            return cols;
+        }
+
+        void writeToStream( std::ostream &os ) const {
+            if (!m_exeName.name().empty()) {
+                os << "usage:\n" << "  " << m_exeName.name() << " ";
+                bool required = true, first = true;
+                for( auto const &arg : m_args ) {
+                    if (first)
+                        first = false;
+                    else
+                        os << " ";
+                    if( arg.isOptional() && required ) {
+                        os << "[";
+                        required = false;
+                    }
+                    os << "<" << arg.hint() << ">";
+                    if( arg.cardinality() == 0 )
+                        os << " ... ";
+                }
+                if( !required )
+                    os << "]";
+                if( !m_options.empty() )
+                    os << " options";
+                os << "\n\nwhere options are:" << std::endl;
+            }
+
+            auto rows = getHelpColumns();
+            size_t consoleWidth = CATCH_CLARA_CONFIG_CONSOLE_WIDTH;
+            size_t optWidth = 0;
+            for( auto const &cols : rows )
+                optWidth = (std::max)(optWidth, cols.left.size() + 2);
+
+            optWidth = (std::min)(optWidth, consoleWidth/2);
+
+            for( auto const &cols : rows ) {
+                auto row =
+                        TextFlow::Column( cols.left ).width( optWidth ).indent( 2 ) +
+                        TextFlow::Spacer(4) +
+                        TextFlow::Column( cols.right ).width( consoleWidth - 7 - optWidth );
+                os << row << std::endl;
+            }
+        }
+
+        friend auto operator<<( std::ostream &os, Parser const &parser ) -> std::ostream& {
+            parser.writeToStream( os );
+            return os;
+        }
+
+        auto validate() const -> Result override {
+            for( auto const &opt : m_options ) {
+                auto result = opt.validate();
+                if( !result )
+                    return result;
+            }
+            for( auto const &arg : m_args ) {
+                auto result = arg.validate();
+                if( !result )
+                    return result;
+            }
+            return Result::ok();
+        }
+
+        using ParserBase::parse;
+
+        auto parse( std::string const& exeName, TokenStream const &tokens ) const -> InternalParseResult override {
+
+            struct ParserInfo {
+                ParserBase const* parser = nullptr;
+                size_t count = 0;
+            };
+            const size_t totalParsers = m_options.size() + m_args.size();
+            assert( totalParsers < 512 );
+            // ParserInfo parseInfos[totalParsers]; // <-- this is what we really want to do
+            ParserInfo parseInfos[512];
+
+            {
+                size_t i = 0;
+                for (auto const &opt : m_options) parseInfos[i++].parser = &opt;
+                for (auto const &arg : m_args) parseInfos[i++].parser = &arg;
+            }
+
+            m_exeName.set( exeName );
+
+            auto result = InternalParseResult::ok( ParseState( ParseResultType::NoMatch, tokens ) );
+            while( result.value().remainingTokens() ) {
+                bool tokenParsed = false;
+
+                for( size_t i = 0; i < totalParsers; ++i ) {
+                    auto&  parseInfo = parseInfos[i];
+                    if( parseInfo.parser->cardinality() == 0 || parseInfo.count < parseInfo.parser->cardinality() ) {
+                        result = parseInfo.parser->parse(exeName, result.value().remainingTokens());
+                        if (!result)
+                            return result;
+                        if (result.value().type() != ParseResultType::NoMatch) {
+                            tokenParsed = true;
+                            ++parseInfo.count;
+                            break;
+                        }
                     }
                 }
+
+                if( result.value().type() == ParseResultType::ShortCircuitAll )
+                    return result;
+                if( !tokenParsed )
+                    return InternalParseResult::runtimeError( "Unrecognised token: " + result.value().remainingTokens()->token );
             }
-
-            if( result.value().type() == ParseResultType::ShortCircuitAll )
-                return result;
-            if( !tokenParsed )
-                return InternalParseResult::runtimeError( "Unrecognised token: " + result.value().remainingTokens()->token );
+            // !TBD Check missing required options
+            return result;
         }
-        // !TBD Check missing required options
-        return result;
-    }
-};
+    };
 
-template<typename DerivedT>
-template<typename T>
-auto ComposableParserImpl<DerivedT>::operator|( T const &other ) const -> Parser {
-    return Parser() | static_cast<DerivedT const &>( *this ) | other;
-}
+    template<typename DerivedT>
+    template<typename T>
+    auto ComposableParserImpl<DerivedT>::operator|( T const &other ) const -> Parser {
+        return Parser() | static_cast<DerivedT const &>( *this ) | other;
+    }
 } // namespace detail
 
 // A Combined parser
@@ -9707,7 +9691,7 @@ using detail::ParserResult;
 // end catch_clara.h
 namespace Catch {
 
-clara::Parser makeCommandLineParser( ConfigData& config );
+    clara::Parser makeCommandLineParser( ConfigData& config );
 
 } // end namespace Catch
 
@@ -9717,214 +9701,214 @@ clara::Parser makeCommandLineParser( ConfigData& config );
 
 namespace Catch {
 
-clara::Parser makeCommandLineParser( ConfigData& config ) {
+    clara::Parser makeCommandLineParser( ConfigData& config ) {
 
-    using namespace clara;
+        using namespace clara;
 
-    auto const setWarning = [&]( std::string const& warning ) {
-        auto warningSet = [&]() {
-            if( warning == "NoAssertions" )
-                return WarnAbout::NoAssertions;
+        auto const setWarning = [&]( std::string const& warning ) {
+                auto warningSet = [&]() {
+                    if( warning == "NoAssertions" )
+                        return WarnAbout::NoAssertions;
 
-            if ( warning == "NoTests" )
-                return WarnAbout::NoTests;
+                    if ( warning == "NoTests" )
+                        return WarnAbout::NoTests;
 
-            return WarnAbout::Nothing;
-        }();
+                    return WarnAbout::Nothing;
+                }();
 
-        if (warningSet == WarnAbout::Nothing)
-            return ParserResult::runtimeError( "Unrecognised warning: '" + warning + "'" );
-        config.warnings = static_cast<WarnAbout::What>( config.warnings | warningSet );
-        return ParserResult::ok( ParseResultType::Matched );
-    };
-    auto const loadTestNamesFromFile = [&]( std::string const& filename ) {
-        std::ifstream f( filename.c_str() );
-        if( !f.is_open() )
-            return ParserResult::runtimeError( "Unable to load input file: '" + filename + "'" );
+                if (warningSet == WarnAbout::Nothing)
+                    return ParserResult::runtimeError( "Unrecognised warning: '" + warning + "'" );
+                config.warnings = static_cast<WarnAbout::What>( config.warnings | warningSet );
+                return ParserResult::ok( ParseResultType::Matched );
+            };
+        auto const loadTestNamesFromFile = [&]( std::string const& filename ) {
+                std::ifstream f( filename.c_str() );
+                if( !f.is_open() )
+                    return ParserResult::runtimeError( "Unable to load input file: '" + filename + "'" );
 
-        std::string line;
-        while( std::getline( f, line ) ) {
-            line = trim(line);
-            if( !line.empty() && !startsWith( line, '#' ) ) {
-                if( !startsWith( line, '"' ) )
-                    line = '"' + line + '"';
-                config.testsOrTags.push_back( line );
-                config.testsOrTags.emplace_back( "," );
-            }
-        }
-        //Remove comma in the end
-        if(!config.testsOrTags.empty())
-            config.testsOrTags.erase( config.testsOrTags.end()-1 );
+                std::string line;
+                while( std::getline( f, line ) ) {
+                    line = trim(line);
+                    if( !line.empty() && !startsWith( line, '#' ) ) {
+                        if( !startsWith( line, '"' ) )
+                            line = '"' + line + '"';
+                        config.testsOrTags.push_back( line );
+                        config.testsOrTags.emplace_back( "," );
+                    }
+                }
+                //Remove comma in the end
+                if(!config.testsOrTags.empty())
+                    config.testsOrTags.erase( config.testsOrTags.end()-1 );
 
-        return ParserResult::ok( ParseResultType::Matched );
-    };
-    auto const setTestOrder = [&]( std::string const& order ) {
-        if( startsWith( "declared", order ) )
-            config.runOrder = RunTests::InDeclarationOrder;
-        else if( startsWith( "lexical", order ) )
-            config.runOrder = RunTests::InLexicographicalOrder;
-        else if( startsWith( "random", order ) )
-            config.runOrder = RunTests::InRandomOrder;
-        else
-            return clara::ParserResult::runtimeError( "Unrecognised ordering: '" + order + "'" );
-        return ParserResult::ok( ParseResultType::Matched );
-    };
-    auto const setRngSeed = [&]( std::string const& seed ) {
-        if( seed != "time" )
-            return clara::detail::convertInto( seed, config.rngSeed );
-        config.rngSeed = static_cast<unsigned int>( std::time(nullptr) );
-        return ParserResult::ok( ParseResultType::Matched );
-    };
-    auto const setColourUsage = [&]( std::string const& useColour ) {
-        auto mode = toLower( useColour );
+                return ParserResult::ok( ParseResultType::Matched );
+            };
+        auto const setTestOrder = [&]( std::string const& order ) {
+                if( startsWith( "declared", order ) )
+                    config.runOrder = RunTests::InDeclarationOrder;
+                else if( startsWith( "lexical", order ) )
+                    config.runOrder = RunTests::InLexicographicalOrder;
+                else if( startsWith( "random", order ) )
+                    config.runOrder = RunTests::InRandomOrder;
+                else
+                    return clara::ParserResult::runtimeError( "Unrecognised ordering: '" + order + "'" );
+                return ParserResult::ok( ParseResultType::Matched );
+            };
+        auto const setRngSeed = [&]( std::string const& seed ) {
+                if( seed != "time" )
+                    return clara::detail::convertInto( seed, config.rngSeed );
+                config.rngSeed = static_cast<unsigned int>( std::time(nullptr) );
+                return ParserResult::ok( ParseResultType::Matched );
+            };
+        auto const setColourUsage = [&]( std::string const& useColour ) {
+                    auto mode = toLower( useColour );
 
-        if( mode == "yes" )
-            config.useColour = UseColour::Yes;
-        else if( mode == "no" )
-            config.useColour = UseColour::No;
-        else if( mode == "auto" )
-            config.useColour = UseColour::Auto;
-        else
-            return ParserResult::runtimeError( "colour mode must be one of: auto, yes or no. '" + useColour + "' not recognised" );
-        return ParserResult::ok( ParseResultType::Matched );
-    };
-    auto const setWaitForKeypress = [&]( std::string const& keypress ) {
-        auto keypressLc = toLower( keypress );
-        if (keypressLc == "never")
-            config.waitForKeypress = WaitForKeypress::Never;
-        else if( keypressLc == "start" )
-            config.waitForKeypress = WaitForKeypress::BeforeStart;
-        else if( keypressLc == "exit" )
-            config.waitForKeypress = WaitForKeypress::BeforeExit;
-        else if( keypressLc == "both" )
-            config.waitForKeypress = WaitForKeypress::BeforeStartAndExit;
-        else
-            return ParserResult::runtimeError( "keypress argument must be one of: never, start, exit or both. '" + keypress + "' not recognised" );
-        return ParserResult::ok( ParseResultType::Matched );
-    };
-    auto const setVerbosity = [&]( std::string const& verbosity ) {
-        auto lcVerbosity = toLower( verbosity );
-        if( lcVerbosity == "quiet" )
-            config.verbosity = Verbosity::Quiet;
-        else if( lcVerbosity == "normal" )
-            config.verbosity = Verbosity::Normal;
-        else if( lcVerbosity == "high" )
-            config.verbosity = Verbosity::High;
-        else
-            return ParserResult::runtimeError( "Unrecognised verbosity, '" + verbosity + "'" );
-        return ParserResult::ok( ParseResultType::Matched );
-    };
-    auto const setReporter = [&]( std::string const& reporter ) {
-        IReporterRegistry::FactoryMap const& factories = getRegistryHub().getReporterRegistry().getFactories();
+                    if( mode == "yes" )
+                        config.useColour = UseColour::Yes;
+                    else if( mode == "no" )
+                        config.useColour = UseColour::No;
+                    else if( mode == "auto" )
+                        config.useColour = UseColour::Auto;
+                    else
+                        return ParserResult::runtimeError( "colour mode must be one of: auto, yes or no. '" + useColour + "' not recognised" );
+                return ParserResult::ok( ParseResultType::Matched );
+            };
+        auto const setWaitForKeypress = [&]( std::string const& keypress ) {
+                auto keypressLc = toLower( keypress );
+                if (keypressLc == "never")
+                    config.waitForKeypress = WaitForKeypress::Never;
+                else if( keypressLc == "start" )
+                    config.waitForKeypress = WaitForKeypress::BeforeStart;
+                else if( keypressLc == "exit" )
+                    config.waitForKeypress = WaitForKeypress::BeforeExit;
+                else if( keypressLc == "both" )
+                    config.waitForKeypress = WaitForKeypress::BeforeStartAndExit;
+                else
+                    return ParserResult::runtimeError( "keypress argument must be one of: never, start, exit or both. '" + keypress + "' not recognised" );
+            return ParserResult::ok( ParseResultType::Matched );
+            };
+        auto const setVerbosity = [&]( std::string const& verbosity ) {
+            auto lcVerbosity = toLower( verbosity );
+            if( lcVerbosity == "quiet" )
+                config.verbosity = Verbosity::Quiet;
+            else if( lcVerbosity == "normal" )
+                config.verbosity = Verbosity::Normal;
+            else if( lcVerbosity == "high" )
+                config.verbosity = Verbosity::High;
+            else
+                return ParserResult::runtimeError( "Unrecognised verbosity, '" + verbosity + "'" );
+            return ParserResult::ok( ParseResultType::Matched );
+        };
+        auto const setReporter = [&]( std::string const& reporter ) {
+            IReporterRegistry::FactoryMap const& factories = getRegistryHub().getReporterRegistry().getFactories();
 
-        auto lcReporter = toLower( reporter );
-        auto result = factories.find( lcReporter );
+            auto lcReporter = toLower( reporter );
+            auto result = factories.find( lcReporter );
 
-        if( factories.end() != result )
-            config.reporterName = lcReporter;
-        else
-            return ParserResult::runtimeError( "Unrecognized reporter, '" + reporter + "'. Check available with --list-reporters" );
-        return ParserResult::ok( ParseResultType::Matched );
-    };
+            if( factories.end() != result )
+                config.reporterName = lcReporter;
+            else
+                return ParserResult::runtimeError( "Unrecognized reporter, '" + reporter + "'. Check available with --list-reporters" );
+            return ParserResult::ok( ParseResultType::Matched );
+        };
 
-    auto cli
-        = ExeName( config.processName )
+        auto cli
+            = ExeName( config.processName )
             | Help( config.showHelp )
             | Opt( config.listTests )
-            ["-l"]["--list-tests"]
+                ["-l"]["--list-tests"]
                 ( "list all/matching test cases" )
             | Opt( config.listTags )
-            ["-t"]["--list-tags"]
+                ["-t"]["--list-tags"]
                 ( "list all/matching tags" )
             | Opt( config.showSuccessfulTests )
-            ["-s"]["--success"]
+                ["-s"]["--success"]
                 ( "include successful tests in output" )
             | Opt( config.shouldDebugBreak )
-            ["-b"]["--break"]
+                ["-b"]["--break"]
                 ( "break into debugger on failure" )
             | Opt( config.noThrow )
-            ["-e"]["--nothrow"]
+                ["-e"]["--nothrow"]
                 ( "skip exception tests" )
             | Opt( config.showInvisibles )
-            ["-i"]["--invisibles"]
+                ["-i"]["--invisibles"]
                 ( "show invisibles (tabs, newlines)" )
             | Opt( config.outputFilename, "filename" )
-            ["-o"]["--out"]
+                ["-o"]["--out"]
                 ( "output filename" )
             | Opt( setReporter, "name" )
-            ["-r"]["--reporter"]
+                ["-r"]["--reporter"]
                 ( "reporter to use (defaults to console)" )
             | Opt( config.name, "name" )
-            ["-n"]["--name"]
+                ["-n"]["--name"]
                 ( "suite name" )
             | Opt( [&]( bool ){ config.abortAfter = 1; } )
-            ["-a"]["--abort"]
+                ["-a"]["--abort"]
                 ( "abort at first failure" )
             | Opt( [&]( int x ){ config.abortAfter = x; }, "no. failures" )
-            ["-x"]["--abortx"]
+                ["-x"]["--abortx"]
                 ( "abort after x failures" )
             | Opt( setWarning, "warning name" )
-            ["-w"]["--warn"]
+                ["-w"]["--warn"]
                 ( "enable warnings" )
             | Opt( [&]( bool flag ) { config.showDurations = flag ? ShowDurations::Always : ShowDurations::Never; }, "yes|no" )
-            ["-d"]["--durations"]
+                ["-d"]["--durations"]
                 ( "show test durations" )
             | Opt( config.minDuration, "seconds" )
-            ["-D"]["--min-duration"]
+                ["-D"]["--min-duration"]
                 ( "show test durations for tests taking at least the given number of seconds" )
             | Opt( loadTestNamesFromFile, "filename" )
-            ["-f"]["--input-file"]
+                ["-f"]["--input-file"]
                 ( "load test names to run from a file" )
             | Opt( config.filenamesAsTags )
-            ["-#"]["--filenames-as-tags"]
+                ["-#"]["--filenames-as-tags"]
                 ( "adds a tag for the filename" )
             | Opt( config.sectionsToRun, "section name" )
-            ["-c"]["--section"]
+                ["-c"]["--section"]
                 ( "specify section to run" )
             | Opt( setVerbosity, "quiet|normal|high" )
-            ["-v"]["--verbosity"]
+                ["-v"]["--verbosity"]
                 ( "set output verbosity" )
             | Opt( config.listTestNamesOnly )
-            ["--list-test-names-only"]
+                ["--list-test-names-only"]
                 ( "list all/matching test cases names only" )
             | Opt( config.listReporters )
-            ["--list-reporters"]
+                ["--list-reporters"]
                 ( "list all reporters" )
             | Opt( setTestOrder, "decl|lex|rand" )
-            ["--order"]
+                ["--order"]
                 ( "test case order (defaults to decl)" )
             | Opt( setRngSeed, "'time'|number" )
-            ["--rng-seed"]
+                ["--rng-seed"]
                 ( "set a specific seed for random numbers" )
             | Opt( setColourUsage, "yes|no" )
-            ["--use-colour"]
+                ["--use-colour"]
                 ( "should output be colourised" )
             | Opt( config.libIdentify )
-            ["--libidentify"]
+                ["--libidentify"]
                 ( "report name and version according to libidentify standard" )
             | Opt( setWaitForKeypress, "never|start|exit|both" )
-            ["--wait-for-keypress"]
+                ["--wait-for-keypress"]
                 ( "waits for a keypress before exiting" )
             | Opt( config.benchmarkSamples, "samples" )
-            ["--benchmark-samples"]
+                ["--benchmark-samples"]
                 ( "number of samples to collect (default: 100)" )
             | Opt( config.benchmarkResamples, "resamples" )
-            ["--benchmark-resamples"]
+                ["--benchmark-resamples"]
                 ( "number of resamples for the bootstrap (default: 100000)" )
             | Opt( config.benchmarkConfidenceInterval, "confidence interval" )
-            ["--benchmark-confidence-interval"]
+                ["--benchmark-confidence-interval"]
                 ( "confidence interval for the bootstrap (between 0 and 1, default: 0.95)" )
             | Opt( config.benchmarkNoAnalysis )
-            ["--benchmark-no-analysis"]
+                ["--benchmark-no-analysis"]
                 ( "perform only measurements; do not perform any analysis" )
             | Opt( config.benchmarkWarmupTime, "benchmarkWarmupTime" )
-            ["--benchmark-warmup-time"]
+                ["--benchmark-warmup-time"]
                 ( "amount of time in milliseconds spent on warming up each test (default: 100)" )
             | Arg( config.testsOrTags, "test name|pattern|tags" )
                 ( "which test or tests to use" );
 
-    return cli;
-}
+        return cli;
+    }
 
 } // end namespace Catch
 // end catch_commandline.cpp
@@ -9935,30 +9919,30 @@ clara::Parser makeCommandLineParser( ConfigData& config ) {
 
 namespace Catch {
 
-bool SourceLineInfo::operator == ( SourceLineInfo const& other ) const noexcept {
-    return line == other.line && (file == other.file || std::strcmp(file, other.file) == 0);
-}
-bool SourceLineInfo::operator < ( SourceLineInfo const& other ) const noexcept {
-    // We can assume that the same file will usually have the same pointer.
-    // Thus, if the pointers are the same, there is no point in calling the strcmp
-    return line < other.line || ( line == other.line && file != other.file && (std::strcmp(file, other.file) < 0));
-}
+    bool SourceLineInfo::operator == ( SourceLineInfo const& other ) const noexcept {
+        return line == other.line && (file == other.file || std::strcmp(file, other.file) == 0);
+    }
+    bool SourceLineInfo::operator < ( SourceLineInfo const& other ) const noexcept {
+        // We can assume that the same file will usually have the same pointer.
+        // Thus, if the pointers are the same, there is no point in calling the strcmp
+        return line < other.line || ( line == other.line && file != other.file && (std::strcmp(file, other.file) < 0));
+    }
 
-std::ostream& operator << ( std::ostream& os, SourceLineInfo const& info ) {
+    std::ostream& operator << ( std::ostream& os, SourceLineInfo const& info ) {
 #ifndef __GNUG__
-    os << info.file << '(' << info.line << ')';
+        os << info.file << '(' << info.line << ')';
 #else
-    os << info.file << ':' << info.line;
+        os << info.file << ':' << info.line;
 #endif
-    return os;
-}
+        return os;
+    }
 
-std::string StreamEndStop::operator+() const {
-    return std::string();
-}
+    std::string StreamEndStop::operator+() const {
+        return std::string();
+    }
 
-NonCopyable::NonCopyable() = default;
-NonCopyable::~NonCopyable() = default;
+    NonCopyable::NonCopyable() = default;
+    NonCopyable::~NonCopyable() = default;
 
 }
 // end catch_common.cpp
@@ -9966,77 +9950,77 @@ NonCopyable::~NonCopyable() = default;
 
 namespace Catch {
 
-Config::Config( ConfigData const& data )
+    Config::Config( ConfigData const& data )
     :   m_data( data ),
         m_stream( openStream() )
-{
-    // We need to trim filter specs to avoid trouble with superfluous
-    // whitespace (esp. important for bdd macros, as those are manually
-    // aligned with whitespace).
+    {
+        // We need to trim filter specs to avoid trouble with superfluous
+        // whitespace (esp. important for bdd macros, as those are manually
+        // aligned with whitespace).
 
-    for (auto& elem : m_data.testsOrTags) {
-        elem = trim(elem);
-    }
-    for (auto& elem : m_data.sectionsToRun) {
-        elem = trim(elem);
-    }
-
-    TestSpecParser parser(ITagAliasRegistry::get());
-    if (!m_data.testsOrTags.empty()) {
-        m_hasTestFilters = true;
-        for (auto const& testOrTags : m_data.testsOrTags) {
-            parser.parse(testOrTags);
+        for (auto& elem : m_data.testsOrTags) {
+            elem = trim(elem);
         }
+        for (auto& elem : m_data.sectionsToRun) {
+            elem = trim(elem);
+        }
+
+        TestSpecParser parser(ITagAliasRegistry::get());
+        if (!m_data.testsOrTags.empty()) {
+            m_hasTestFilters = true;
+            for (auto const& testOrTags : m_data.testsOrTags) {
+                parser.parse(testOrTags);
+            }
+        }
+        m_testSpec = parser.testSpec();
     }
-    m_testSpec = parser.testSpec();
-}
 
-std::string const& Config::getFilename() const {
-    return m_data.outputFilename ;
-}
+    std::string const& Config::getFilename() const {
+        return m_data.outputFilename ;
+    }
 
-bool Config::listTests() const          { return m_data.listTests; }
-bool Config::listTestNamesOnly() const  { return m_data.listTestNamesOnly; }
-bool Config::listTags() const           { return m_data.listTags; }
-bool Config::listReporters() const      { return m_data.listReporters; }
+    bool Config::listTests() const          { return m_data.listTests; }
+    bool Config::listTestNamesOnly() const  { return m_data.listTestNamesOnly; }
+    bool Config::listTags() const           { return m_data.listTags; }
+    bool Config::listReporters() const      { return m_data.listReporters; }
 
-std::string Config::getProcessName() const { return m_data.processName; }
-std::string const& Config::getReporterName() const { return m_data.reporterName; }
+    std::string Config::getProcessName() const { return m_data.processName; }
+    std::string const& Config::getReporterName() const { return m_data.reporterName; }
 
-std::vector<std::string> const& Config::getTestsOrTags() const { return m_data.testsOrTags; }
-std::vector<std::string> const& Config::getSectionsToRun() const { return m_data.sectionsToRun; }
+    std::vector<std::string> const& Config::getTestsOrTags() const { return m_data.testsOrTags; }
+    std::vector<std::string> const& Config::getSectionsToRun() const { return m_data.sectionsToRun; }
 
-TestSpec const& Config::testSpec() const { return m_testSpec; }
-bool Config::hasTestFilters() const { return m_hasTestFilters; }
+    TestSpec const& Config::testSpec() const { return m_testSpec; }
+    bool Config::hasTestFilters() const { return m_hasTestFilters; }
 
-bool Config::showHelp() const { return m_data.showHelp; }
+    bool Config::showHelp() const { return m_data.showHelp; }
 
-// IConfig interface
-bool Config::allowThrows() const                   { return !m_data.noThrow; }
-std::ostream& Config::stream() const               { return m_stream->stream(); }
-std::string Config::name() const                   { return m_data.name.empty() ? m_data.processName : m_data.name; }
-bool Config::includeSuccessfulResults() const      { return m_data.showSuccessfulTests; }
-bool Config::warnAboutMissingAssertions() const    { return !!(m_data.warnings & WarnAbout::NoAssertions); }
-bool Config::warnAboutNoTests() const              { return !!(m_data.warnings & WarnAbout::NoTests); }
-ShowDurations::OrNot Config::showDurations() const { return m_data.showDurations; }
-double Config::minDuration() const                 { return m_data.minDuration; }
-RunTests::InWhatOrder Config::runOrder() const     { return m_data.runOrder; }
-unsigned int Config::rngSeed() const               { return m_data.rngSeed; }
-UseColour::YesOrNo Config::useColour() const       { return m_data.useColour; }
-bool Config::shouldDebugBreak() const              { return m_data.shouldDebugBreak; }
-int Config::abortAfter() const                     { return m_data.abortAfter; }
-bool Config::showInvisibles() const                { return m_data.showInvisibles; }
-Verbosity Config::verbosity() const                { return m_data.verbosity; }
+    // IConfig interface
+    bool Config::allowThrows() const                   { return !m_data.noThrow; }
+    std::ostream& Config::stream() const               { return m_stream->stream(); }
+    std::string Config::name() const                   { return m_data.name.empty() ? m_data.processName : m_data.name; }
+    bool Config::includeSuccessfulResults() const      { return m_data.showSuccessfulTests; }
+    bool Config::warnAboutMissingAssertions() const    { return !!(m_data.warnings & WarnAbout::NoAssertions); }
+    bool Config::warnAboutNoTests() const              { return !!(m_data.warnings & WarnAbout::NoTests); }
+    ShowDurations::OrNot Config::showDurations() const { return m_data.showDurations; }
+    double Config::minDuration() const                 { return m_data.minDuration; }
+    RunTests::InWhatOrder Config::runOrder() const     { return m_data.runOrder; }
+    unsigned int Config::rngSeed() const               { return m_data.rngSeed; }
+    UseColour::YesOrNo Config::useColour() const       { return m_data.useColour; }
+    bool Config::shouldDebugBreak() const              { return m_data.shouldDebugBreak; }
+    int Config::abortAfter() const                     { return m_data.abortAfter; }
+    bool Config::showInvisibles() const                { return m_data.showInvisibles; }
+    Verbosity Config::verbosity() const                { return m_data.verbosity; }
 
-bool Config::benchmarkNoAnalysis() const                      { return m_data.benchmarkNoAnalysis; }
-int Config::benchmarkSamples() const                          { return m_data.benchmarkSamples; }
-double Config::benchmarkConfidenceInterval() const            { return m_data.benchmarkConfidenceInterval; }
-unsigned int Config::benchmarkResamples() const               { return m_data.benchmarkResamples; }
-std::chrono::milliseconds Config::benchmarkWarmupTime() const { return std::chrono::milliseconds(m_data.benchmarkWarmupTime); }
+    bool Config::benchmarkNoAnalysis() const                      { return m_data.benchmarkNoAnalysis; }
+    int Config::benchmarkSamples() const                          { return m_data.benchmarkSamples; }
+    double Config::benchmarkConfidenceInterval() const            { return m_data.benchmarkConfidenceInterval; }
+    unsigned int Config::benchmarkResamples() const               { return m_data.benchmarkResamples; }
+    std::chrono::milliseconds Config::benchmarkWarmupTime() const { return std::chrono::milliseconds(m_data.benchmarkWarmupTime); }
 
-IStream const* Config::openStream() {
-    return Catch::makeStream(m_data.outputFilename);
-}
+    IStream const* Config::openStream() {
+        return Catch::makeStream(m_data.outputFilename);
+    }
 
 } // end namespace Catch
 // end catch_config.cpp
@@ -10051,37 +10035,67 @@ IStream const* Config::openStream() {
 
 namespace Catch {
 
-class ErrnoGuard {
-public:
-    ErrnoGuard();
-    ~ErrnoGuard();
-private:
-    int m_oldErrno;
-};
+    class ErrnoGuard {
+    public:
+        ErrnoGuard();
+        ~ErrnoGuard();
+    private:
+        int m_oldErrno;
+    };
 
 }
 
 // end catch_errno_guard.h
+// start catch_windows_h_proxy.h
+
+
+#if defined(CATCH_PLATFORM_WINDOWS)
+
+#if !defined(NOMINMAX) && !defined(CATCH_CONFIG_NO_NOMINMAX)
+#  define CATCH_DEFINED_NOMINMAX
+#  define NOMINMAX
+#endif
+#if !defined(WIN32_LEAN_AND_MEAN) && !defined(CATCH_CONFIG_NO_WIN32_LEAN_AND_MEAN)
+#  define CATCH_DEFINED_WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifdef __AFXDLL
+#include <AfxWin.h>
+#else
+#include <windows.h>
+#endif
+
+#ifdef CATCH_DEFINED_NOMINMAX
+#  undef NOMINMAX
+#endif
+#ifdef CATCH_DEFINED_WIN32_LEAN_AND_MEAN
+#  undef WIN32_LEAN_AND_MEAN
+#endif
+
+#endif // defined(CATCH_PLATFORM_WINDOWS)
+
+// end catch_windows_h_proxy.h
 #include <sstream>
 
 namespace Catch {
-namespace {
+    namespace {
 
-struct IColourImpl {
-    virtual ~IColourImpl() = default;
-    virtual void use( Colour::Code _colourCode ) = 0;
-};
+        struct IColourImpl {
+            virtual ~IColourImpl() = default;
+            virtual void use( Colour::Code _colourCode ) = 0;
+        };
 
-struct NoColourImpl : IColourImpl {
-    void use( Colour::Code ) override {}
+        struct NoColourImpl : IColourImpl {
+            void use( Colour::Code ) override {}
 
-    static IColourImpl* instance() {
-        static NoColourImpl s_instance;
-        return &s_instance;
-    }
-};
+            static IColourImpl* instance() {
+                static NoColourImpl s_instance;
+                return &s_instance;
+            }
+        };
 
-} // anon namespace
+    } // anon namespace
 } // namespace Catch
 
 #if !defined( CATCH_CONFIG_COLOUR_NONE ) && !defined( CATCH_CONFIG_COLOUR_WINDOWS ) && !defined( CATCH_CONFIG_COLOUR_ANSI )
@@ -10164,71 +10178,71 @@ namespace {
 namespace Catch {
 namespace {
 
-// use POSIX/ ANSI console terminal codes
-// Thanks to Adam Strzelecki for original contribution
-// (http://github.com/nanoant)
-// https://github.com/philsquared/Catch/pull/131
-class PosixColourImpl : public IColourImpl {
-public:
-    void use( Colour::Code _colourCode ) override {
-        switch( _colourCode ) {
-            case Colour::None:
-            case Colour::White:     return setColour( "[0m" );
-            case Colour::Red:       return setColour( "[0;31m" );
-            case Colour::Green:     return setColour( "[0;32m" );
-            case Colour::Blue:      return setColour( "[0;34m" );
-            case Colour::Cyan:      return setColour( "[0;36m" );
-            case Colour::Yellow:    return setColour( "[0;33m" );
-            case Colour::Grey:      return setColour( "[1;30m" );
+    // use POSIX/ ANSI console terminal codes
+    // Thanks to Adam Strzelecki for original contribution
+    // (http://github.com/nanoant)
+    // https://github.com/philsquared/Catch/pull/131
+    class PosixColourImpl : public IColourImpl {
+    public:
+        void use( Colour::Code _colourCode ) override {
+            switch( _colourCode ) {
+                case Colour::None:
+                case Colour::White:     return setColour( "[0m" );
+                case Colour::Red:       return setColour( "[0;31m" );
+                case Colour::Green:     return setColour( "[0;32m" );
+                case Colour::Blue:      return setColour( "[0;34m" );
+                case Colour::Cyan:      return setColour( "[0;36m" );
+                case Colour::Yellow:    return setColour( "[0;33m" );
+                case Colour::Grey:      return setColour( "[1;30m" );
 
-            case Colour::LightGrey:     return setColour( "[0;37m" );
-            case Colour::BrightRed:     return setColour( "[1;31m" );
-            case Colour::BrightGreen:   return setColour( "[1;32m" );
-            case Colour::BrightWhite:   return setColour( "[1;37m" );
-            case Colour::BrightYellow:  return setColour( "[1;33m" );
+                case Colour::LightGrey:     return setColour( "[0;37m" );
+                case Colour::BrightRed:     return setColour( "[1;31m" );
+                case Colour::BrightGreen:   return setColour( "[1;32m" );
+                case Colour::BrightWhite:   return setColour( "[1;37m" );
+                case Colour::BrightYellow:  return setColour( "[1;33m" );
 
-            case Colour::Bright: CATCH_INTERNAL_ERROR( "not a colour" );
-            default: CATCH_INTERNAL_ERROR( "Unknown colour requested" );
+                case Colour::Bright: CATCH_INTERNAL_ERROR( "not a colour" );
+                default: CATCH_INTERNAL_ERROR( "Unknown colour requested" );
+            }
         }
-    }
-    static IColourImpl* instance() {
-        static PosixColourImpl s_instance;
-        return &s_instance;
-    }
+        static IColourImpl* instance() {
+            static PosixColourImpl s_instance;
+            return &s_instance;
+        }
 
-private:
-    void setColour( const char* _escapeCode ) {
-        getCurrentContext().getConfig()->stream()
-            << '\033' << _escapeCode;
-    }
-};
+    private:
+        void setColour( const char* _escapeCode ) {
+            getCurrentContext().getConfig()->stream()
+                << '\033' << _escapeCode;
+        }
+    };
 
-bool useColourOnPlatform() {
-    return
+    bool useColourOnPlatform() {
+        return
 #if defined(CATCH_PLATFORM_MAC) || defined(CATCH_PLATFORM_IPHONE)
-        !isDebuggerActive() &&
+            !isDebuggerActive() &&
 #endif
 #if !(defined(__DJGPP__) && defined(__STRICT_ANSI__))
-        isatty(STDOUT_FILENO)
+            isatty(STDOUT_FILENO)
 #else
-        false
+            false
 #endif
-        ;
-}
-IColourImpl* platformColourInstance() {
-    ErrnoGuard guard;
-    IConfigPtr config = getCurrentContext().getConfig();
-    UseColour::YesOrNo colourMode = config
-                                    ? config->useColour()
-                                    : UseColour::Auto;
-    if( colourMode == UseColour::Auto )
-        colourMode = useColourOnPlatform()
-                     ? UseColour::Yes
-                     : UseColour::No;
-    return colourMode == UseColour::Yes
-           ? PosixColourImpl::instance()
-           : NoColourImpl::instance();
-}
+            ;
+    }
+    IColourImpl* platformColourInstance() {
+        ErrnoGuard guard;
+        IConfigPtr config = getCurrentContext().getConfig();
+        UseColour::YesOrNo colourMode = config
+            ? config->useColour()
+            : UseColour::Auto;
+        if( colourMode == UseColour::Auto )
+            colourMode = useColourOnPlatform()
+                ? UseColour::Yes
+                : UseColour::No;
+        return colourMode == UseColour::Yes
+            ? PosixColourImpl::instance()
+            : NoColourImpl::instance();
+    }
 
 } // end anon namespace
 } // end namespace Catch
@@ -10245,33 +10259,33 @@ namespace Catch {
 
 namespace Catch {
 
-Colour::Colour( Code _colourCode ) { use( _colourCode ); }
-Colour::Colour( Colour&& other ) noexcept {
-    m_moved = other.m_moved;
-    other.m_moved = true;
-}
-Colour& Colour::operator=( Colour&& other ) noexcept {
-    m_moved = other.m_moved;
-    other.m_moved  = true;
-    return *this;
-}
-
-Colour::~Colour(){ if( !m_moved ) use( None ); }
-
-void Colour::use( Code _colourCode ) {
-    static IColourImpl* impl = platformColourInstance();
-    // Strictly speaking, this cannot possibly happen.
-    // However, under some conditions it does happen (see #1626),
-    // and this change is small enough that we can let practicality
-    // triumph over purity in this case.
-    if (impl != nullptr) {
-        impl->use( _colourCode );
+    Colour::Colour( Code _colourCode ) { use( _colourCode ); }
+    Colour::Colour( Colour&& other ) noexcept {
+        m_moved = other.m_moved;
+        other.m_moved = true;
     }
-}
+    Colour& Colour::operator=( Colour&& other ) noexcept {
+        m_moved = other.m_moved;
+        other.m_moved  = true;
+        return *this;
+    }
 
-std::ostream& operator << ( std::ostream& os, Colour const& ) {
-    return os;
-}
+    Colour::~Colour(){ if( !m_moved ) use( None ); }
+
+    void Colour::use( Code _colourCode ) {
+        static IColourImpl* impl = platformColourInstance();
+        // Strictly speaking, this cannot possibly happen.
+        // However, under some conditions it does happen (see #1626),
+        // and this change is small enough that we can let practicality
+        // triumph over purity in this case.
+        if (impl != nullptr) {
+            impl->use( _colourCode );
+        }
+    }
+
+    std::ostream& operator << ( std::ostream& os, Colour const& ) {
+        return os;
+    }
 
 } // end namespace Catch
 
@@ -10284,60 +10298,60 @@ std::ostream& operator << ( std::ostream& os, Colour const& ) {
 
 namespace Catch {
 
-class Context : public IMutableContext, NonCopyable {
+    class Context : public IMutableContext, NonCopyable {
 
-public: // IContext
-    IResultCapture* getResultCapture() override {
-        return m_resultCapture;
+    public: // IContext
+        IResultCapture* getResultCapture() override {
+            return m_resultCapture;
+        }
+        IRunner* getRunner() override {
+            return m_runner;
+        }
+
+        IConfigPtr const& getConfig() const override {
+            return m_config;
+        }
+
+        ~Context() override;
+
+    public: // IMutableContext
+        void setResultCapture( IResultCapture* resultCapture ) override {
+            m_resultCapture = resultCapture;
+        }
+        void setRunner( IRunner* runner ) override {
+            m_runner = runner;
+        }
+        void setConfig( IConfigPtr const& config ) override {
+            m_config = config;
+        }
+
+        friend IMutableContext& getCurrentMutableContext();
+
+    private:
+        IConfigPtr m_config;
+        IRunner* m_runner = nullptr;
+        IResultCapture* m_resultCapture = nullptr;
+    };
+
+    IMutableContext *IMutableContext::currentContext = nullptr;
+
+    void IMutableContext::createContext()
+    {
+        currentContext = new Context();
     }
-    IRunner* getRunner() override {
-        return m_runner;
+
+    void cleanUpContext() {
+        delete IMutableContext::currentContext;
+        IMutableContext::currentContext = nullptr;
     }
+    IContext::~IContext() = default;
+    IMutableContext::~IMutableContext() = default;
+    Context::~Context() = default;
 
-    IConfigPtr const& getConfig() const override {
-        return m_config;
+    SimplePcg32& rng() {
+        static SimplePcg32 s_rng;
+        return s_rng;
     }
-
-    ~Context() override;
-
-public: // IMutableContext
-    void setResultCapture( IResultCapture* resultCapture ) override {
-        m_resultCapture = resultCapture;
-    }
-    void setRunner( IRunner* runner ) override {
-        m_runner = runner;
-    }
-    void setConfig( IConfigPtr const& config ) override {
-        m_config = config;
-    }
-
-    friend IMutableContext& getCurrentMutableContext();
-
-private:
-    IConfigPtr m_config;
-    IRunner* m_runner = nullptr;
-    IResultCapture* m_resultCapture = nullptr;
-};
-
-IMutableContext *IMutableContext::currentContext = nullptr;
-
-void IMutableContext::createContext()
-{
-    currentContext = new Context();
-}
-
-void cleanUpContext() {
-    delete IMutableContext::currentContext;
-    IMutableContext::currentContext = nullptr;
-}
-IContext::~IContext() = default;
-IMutableContext::~IMutableContext() = default;
-Context::~Context() = default;
-
-SimplePcg32& rng() {
-    static SimplePcg32 s_rng;
-    return s_rng;
-}
 
 }
 // end catch_context.cpp
@@ -10348,7 +10362,7 @@ SimplePcg32& rng() {
 #include <string>
 
 namespace Catch {
-void writeToDebugConsole( std::string const& text );
+    void writeToDebugConsole( std::string const& text );
 }
 
 // end catch_debug_console.h
@@ -10363,7 +10377,7 @@ void writeToDebugConsole( std::string const& text );
 
 #elif defined(CATCH_PLATFORM_WINDOWS)
 
-namespace Catch {
+    namespace Catch {
         void writeToDebugConsole( std::string const& text ) {
             ::OutputDebugStringA( text.c_str() );
         }
@@ -10371,12 +10385,12 @@ namespace Catch {
 
 #else
 
-namespace Catch {
-void writeToDebugConsole( std::string const& text ) {
-    // !TBD: Need a version for Mac/ XCode and other IDEs
-    Catch::cout() << text;
-}
-}
+    namespace Catch {
+        void writeToDebugConsole( std::string const& text ) {
+            // !TBD: Need a version for Mac/ XCode and other IDEs
+            Catch::cout() << text;
+        }
+    }
 
 #endif // Platform
 // end catch_debug_console.cpp
@@ -10445,34 +10459,34 @@ void writeToDebugConsole( std::string const& text ) {
     #include <fstream>
     #include <string>
 
-namespace Catch{
-// The standard POSIX way of detecting a debugger is to attempt to
-// ptrace() the process, but this needs to be done from a child and not
-// this process itself to still allow attaching to this process later
-// if wanted, so is rather heavy. Under Linux we have the PID of the
-// "debugger" (which doesn't need to be gdb, of course, it could also
-// be strace, for example) in /proc/$PID/status, so just get it from
-// there instead.
-bool isDebuggerActive(){
-    // Libstdc++ has a bug, where std::ifstream sets errno to 0
-    // This way our users can properly assert over errno values
-    ErrnoGuard guard;
-    std::ifstream in("/proc/self/status");
-    for( std::string line; std::getline(in, line); ) {
-        static const int PREFIX_LEN = 11;
-        if( line.compare(0, PREFIX_LEN, "TracerPid:\t") == 0 ) {
-            // We're traced if the PID is not 0 and no other PID starts
-            // with 0 digit, so it's enough to check for just a single
-            // character.
-            return line.length() > PREFIX_LEN && line[PREFIX_LEN] != '0';
-        }
-    }
+    namespace Catch{
+        // The standard POSIX way of detecting a debugger is to attempt to
+        // ptrace() the process, but this needs to be done from a child and not
+        // this process itself to still allow attaching to this process later
+        // if wanted, so is rather heavy. Under Linux we have the PID of the
+        // "debugger" (which doesn't need to be gdb, of course, it could also
+        // be strace, for example) in /proc/$PID/status, so just get it from
+        // there instead.
+        bool isDebuggerActive(){
+            // Libstdc++ has a bug, where std::ifstream sets errno to 0
+            // This way our users can properly assert over errno values
+            ErrnoGuard guard;
+            std::ifstream in("/proc/self/status");
+            for( std::string line; std::getline(in, line); ) {
+                static const int PREFIX_LEN = 11;
+                if( line.compare(0, PREFIX_LEN, "TracerPid:\t") == 0 ) {
+                    // We're traced if the PID is not 0 and no other PID starts
+                    // with 0 digit, so it's enough to check for just a single
+                    // character.
+                    return line.length() > PREFIX_LEN && line[PREFIX_LEN] != '0';
+                }
+            }
 
-    return false;
-}
-} // namespace Catch
+            return false;
+        }
+    } // namespace Catch
 #elif defined(_MSC_VER)
-extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
+    extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
     namespace Catch {
         bool isDebuggerActive() {
             return IsDebuggerPresent() != 0;
@@ -10495,16 +10509,16 @@ extern "C" __declspec(dllimport) int __stdcall IsDebuggerPresent();
 
 namespace Catch {
 
-ITransientExpression::~ITransientExpression() = default;
+    ITransientExpression::~ITransientExpression() = default;
 
-void formatReconstructedExpression( std::ostream &os, std::string const& lhs, StringRef op, std::string const& rhs ) {
-    if( lhs.size() + rhs.size() < 40 &&
-        lhs.find('\n') == std::string::npos &&
-        rhs.find('\n') == std::string::npos )
-        os << lhs << " " << op << " " << rhs;
-    else
-        os << lhs << "\n" << op << "\n" << rhs;
-}
+    void formatReconstructedExpression( std::ostream &os, std::string const& lhs, StringRef op, std::string const& rhs ) {
+        if( lhs.size() + rhs.size() < 40 &&
+                lhs.find('\n') == std::string::npos &&
+                rhs.find('\n') == std::string::npos )
+            os << lhs << " " << op << " " << rhs;
+        else
+            os << lhs << "\n" << op << "\n" << rhs;
+    }
 }
 // end catch_decomposer.cpp
 // start catch_enforce.cpp
@@ -10513,7 +10527,7 @@ void formatReconstructedExpression( std::ostream &os, std::string const& lhs, St
 
 namespace Catch {
 #if defined(CATCH_CONFIG_DISABLE_EXCEPTIONS) && !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS_CUSTOM_HANDLER)
-[[noreturn]]
+    [[noreturn]]
     void throw_exception(std::exception const& e) {
         Catch::cerr() << "Catch will terminate because it needed to throw an exception.\n"
                       << "The message was: " << e.what() << '\n';
@@ -10521,20 +10535,20 @@ namespace Catch {
     }
 #endif
 
-[[noreturn]]
-void throw_logic_error(std::string const& msg) {
-    throw_exception(std::logic_error(msg));
-}
+    [[noreturn]]
+    void throw_logic_error(std::string const& msg) {
+        throw_exception(std::logic_error(msg));
+    }
 
-[[noreturn]]
-void throw_domain_error(std::string const& msg) {
-    throw_exception(std::domain_error(msg));
-}
+    [[noreturn]]
+    void throw_domain_error(std::string const& msg) {
+        throw_exception(std::domain_error(msg));
+    }
 
-[[noreturn]]
-void throw_runtime_error(std::string const& msg) {
-    throw_exception(std::runtime_error(msg));
-}
+    [[noreturn]]
+    void throw_runtime_error(std::string const& msg) {
+        throw_exception(std::runtime_error(msg));
+    }
 
 } // namespace Catch;
 // end catch_enforce.cpp
@@ -10546,20 +10560,20 @@ void throw_runtime_error(std::string const& msg) {
 
 namespace Catch {
 
-namespace Detail {
+    namespace Detail {
 
-std::unique_ptr<EnumInfo> makeEnumInfo( StringRef enumName, StringRef allValueNames, std::vector<int> const& values );
+        std::unique_ptr<EnumInfo> makeEnumInfo( StringRef enumName, StringRef allValueNames, std::vector<int> const& values );
 
-class EnumValuesRegistry : public IMutableEnumValuesRegistry {
+        class EnumValuesRegistry : public IMutableEnumValuesRegistry {
 
-    std::vector<std::unique_ptr<EnumInfo>> m_enumInfos;
+            std::vector<std::unique_ptr<EnumInfo>> m_enumInfos;
 
-    EnumInfo const& registerEnum( StringRef enumName, StringRef allEnums, std::vector<int> const& values) override;
-};
+            EnumInfo const& registerEnum( StringRef enumName, StringRef allEnums, std::vector<int> const& values) override;
+        };
 
-std::vector<StringRef> parseEnums( StringRef enums );
+        std::vector<StringRef> parseEnums( StringRef enums );
 
-} // Detail
+    } // Detail
 
 } // Catch
 
@@ -10570,63 +10584,63 @@ std::vector<StringRef> parseEnums( StringRef enums );
 
 namespace Catch {
 
-IMutableEnumValuesRegistry::~IMutableEnumValuesRegistry() {}
+    IMutableEnumValuesRegistry::~IMutableEnumValuesRegistry() {}
 
-namespace Detail {
+    namespace Detail {
 
-namespace {
-// Extracts the actual name part of an enum instance
-// In other words, it returns the Blue part of Bikeshed::Colour::Blue
-StringRef extractInstanceName(StringRef enumInstance) {
-    // Find last occurence of ":"
-    size_t name_start = enumInstance.size();
-    while (name_start > 0 && enumInstance[name_start - 1] != ':') {
-        --name_start;
-    }
-    return enumInstance.substr(name_start, enumInstance.size() - name_start);
-}
-}
+        namespace {
+            // Extracts the actual name part of an enum instance
+            // In other words, it returns the Blue part of Bikeshed::Colour::Blue
+            StringRef extractInstanceName(StringRef enumInstance) {
+                // Find last occurrence of ":"
+                size_t name_start = enumInstance.size();
+                while (name_start > 0 && enumInstance[name_start - 1] != ':') {
+                    --name_start;
+                }
+                return enumInstance.substr(name_start, enumInstance.size() - name_start);
+            }
+        }
 
-std::vector<StringRef> parseEnums( StringRef enums ) {
-    auto enumValues = splitStringRef( enums, ',' );
-    std::vector<StringRef> parsed;
-    parsed.reserve( enumValues.size() );
-    for( auto const& enumValue : enumValues ) {
-        parsed.push_back(trim(extractInstanceName(enumValue)));
-    }
-    return parsed;
-}
+        std::vector<StringRef> parseEnums( StringRef enums ) {
+            auto enumValues = splitStringRef( enums, ',' );
+            std::vector<StringRef> parsed;
+            parsed.reserve( enumValues.size() );
+            for( auto const& enumValue : enumValues ) {
+                parsed.push_back(trim(extractInstanceName(enumValue)));
+            }
+            return parsed;
+        }
 
-EnumInfo::~EnumInfo() {}
+        EnumInfo::~EnumInfo() {}
 
-StringRef EnumInfo::lookup( int value ) const {
-    for( auto const& valueToName : m_values ) {
-        if( valueToName.first == value )
-            return valueToName.second;
-    }
-    return "{** unexpected enum value **}"_sr;
-}
+        StringRef EnumInfo::lookup( int value ) const {
+            for( auto const& valueToName : m_values ) {
+                if( valueToName.first == value )
+                    return valueToName.second;
+            }
+            return "{** unexpected enum value **}"_sr;
+        }
 
-std::unique_ptr<EnumInfo> makeEnumInfo( StringRef enumName, StringRef allValueNames, std::vector<int> const& values ) {
-    std::unique_ptr<EnumInfo> enumInfo( new EnumInfo );
-    enumInfo->m_name = enumName;
-    enumInfo->m_values.reserve( values.size() );
+        std::unique_ptr<EnumInfo> makeEnumInfo( StringRef enumName, StringRef allValueNames, std::vector<int> const& values ) {
+            std::unique_ptr<EnumInfo> enumInfo( new EnumInfo );
+            enumInfo->m_name = enumName;
+            enumInfo->m_values.reserve( values.size() );
 
-    const auto valueNames = Catch::Detail::parseEnums( allValueNames );
-    assert( valueNames.size() == values.size() );
-    std::size_t i = 0;
-    for( auto value : values )
-        enumInfo->m_values.emplace_back(value, valueNames[i++]);
+            const auto valueNames = Catch::Detail::parseEnums( allValueNames );
+            assert( valueNames.size() == values.size() );
+            std::size_t i = 0;
+            for( auto value : values )
+                enumInfo->m_values.emplace_back(value, valueNames[i++]);
 
-    return enumInfo;
-}
+            return enumInfo;
+        }
 
-EnumInfo const& EnumValuesRegistry::registerEnum( StringRef enumName, StringRef allValueNames, std::vector<int> const& values ) {
-    m_enumInfos.push_back(makeEnumInfo(enumName, allValueNames, values));
-    return *m_enumInfos.back();
-}
+        EnumInfo const& EnumValuesRegistry::registerEnum( StringRef enumName, StringRef allValueNames, std::vector<int> const& values ) {
+            m_enumInfos.push_back(makeEnumInfo(enumName, allValueNames, values));
+            return *m_enumInfos.back();
+        }
 
-} // Detail
+    } // Detail
 } // Catch
 
 // end catch_enum_values_registry.cpp
@@ -10635,8 +10649,8 @@ EnumInfo const& EnumValuesRegistry::registerEnum( StringRef enumName, StringRef 
 #include <cerrno>
 
 namespace Catch {
-ErrnoGuard::ErrnoGuard():m_oldErrno(errno){}
-ErrnoGuard::~ErrnoGuard() { errno = m_oldErrno; }
+        ErrnoGuard::ErrnoGuard():m_oldErrno(errno){}
+        ErrnoGuard::~ErrnoGuard() { errno = m_oldErrno; }
 }
 // end catch_errno_guard.cpp
 // start catch_exception_translator_registry.cpp
@@ -10649,16 +10663,16 @@ ErrnoGuard::~ErrnoGuard() { errno = m_oldErrno; }
 
 namespace Catch {
 
-class ExceptionTranslatorRegistry : public IExceptionTranslatorRegistry {
-public:
-    ~ExceptionTranslatorRegistry();
-    virtual void registerTranslator( const IExceptionTranslator* translator );
-    std::string translateActiveException() const override;
-    std::string tryTranslators() const;
+    class ExceptionTranslatorRegistry : public IExceptionTranslatorRegistry {
+    public:
+        ~ExceptionTranslatorRegistry();
+        virtual void registerTranslator( const IExceptionTranslator* translator );
+        std::string translateActiveException() const override;
+        std::string tryTranslators() const;
 
-private:
-    std::vector<std::unique_ptr<IExceptionTranslator const>> m_translators;
-};
+    private:
+        std::vector<std::unique_ptr<IExceptionTranslator const>> m_translators;
+    };
 }
 
 // end catch_exception_translator_registry.h
@@ -10668,18 +10682,18 @@ private:
 
 namespace Catch {
 
-ExceptionTranslatorRegistry::~ExceptionTranslatorRegistry() {
-}
+    ExceptionTranslatorRegistry::~ExceptionTranslatorRegistry() {
+    }
 
-void ExceptionTranslatorRegistry::registerTranslator( const IExceptionTranslator* translator ) {
-    m_translators.push_back( std::unique_ptr<const IExceptionTranslator>( translator ) );
-}
+    void ExceptionTranslatorRegistry::registerTranslator( const IExceptionTranslator* translator ) {
+        m_translators.push_back( std::unique_ptr<const IExceptionTranslator>( translator ) );
+    }
 
 #if !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
-std::string ExceptionTranslatorRegistry::translateActiveException() const {
-    try {
+    std::string ExceptionTranslatorRegistry::translateActiveException() const {
+        try {
 #ifdef __OBJC__
-        // In Objective-C try objective-c exceptions first
+            // In Objective-C try objective-c exceptions first
             @try {
                 return tryTranslators();
             }
@@ -10687,47 +10701,47 @@ std::string ExceptionTranslatorRegistry::translateActiveException() const {
                 return Catch::Detail::stringify( [exception description] );
             }
 #else
-        // Compiling a mixed mode project with MSVC means that CLR
-        // exceptions will be caught in (...) as well. However, these
-        // do not fill-in std::current_exception and thus lead to crash
-        // when attempting rethrow.
-        // /EHa switch also causes structured exceptions to be caught
-        // here, but they fill-in current_exception properly, so
-        // at worst the output should be a little weird, instead of
-        // causing a crash.
-        if (std::current_exception() == nullptr) {
-            return "Non C++ exception. Possibly a CLR exception.";
-        }
-        return tryTranslators();
+            // Compiling a mixed mode project with MSVC means that CLR
+            // exceptions will be caught in (...) as well. However, these
+            // do not fill-in std::current_exception and thus lead to crash
+            // when attempting rethrow.
+            // /EHa switch also causes structured exceptions to be caught
+            // here, but they fill-in current_exception properly, so
+            // at worst the output should be a little weird, instead of
+            // causing a crash.
+            if (std::current_exception() == nullptr) {
+                return "Non C++ exception. Possibly a CLR exception.";
+            }
+            return tryTranslators();
 #endif
+        }
+        catch( TestFailureException& ) {
+            std::rethrow_exception(std::current_exception());
+        }
+        catch( std::exception& ex ) {
+            return ex.what();
+        }
+        catch( std::string& msg ) {
+            return msg;
+        }
+        catch( const char* msg ) {
+            return msg;
+        }
+        catch(...) {
+            return "Unknown exception";
+        }
     }
-    catch( TestFailureException& ) {
-        std::rethrow_exception(std::current_exception());
-    }
-    catch( std::exception& ex ) {
-        return ex.what();
-    }
-    catch( std::string& msg ) {
-        return msg;
-    }
-    catch( const char* msg ) {
-        return msg;
-    }
-    catch(...) {
-        return "Unknown exception";
-    }
-}
 
-std::string ExceptionTranslatorRegistry::tryTranslators() const {
-    if (m_translators.empty()) {
-        std::rethrow_exception(std::current_exception());
-    } else {
-        return m_translators[0]->translate(m_translators.begin() + 1, m_translators.end());
+    std::string ExceptionTranslatorRegistry::tryTranslators() const {
+        if (m_translators.empty()) {
+            std::rethrow_exception(std::current_exception());
+        } else {
+            return m_translators[0]->translate(m_translators.begin() + 1, m_translators.end());
+        }
     }
-}
 
 #else // ^^ Exceptions are enabled // Exceptions are disabled vv
-std::string ExceptionTranslatorRegistry::translateActiveException() const {
+    std::string ExceptionTranslatorRegistry::translateActiveException() const {
         CATCH_INTERNAL_ERROR("Attempted to translate active exception under CATCH_CONFIG_DISABLE_EXCEPTIONS!");
     }
 
@@ -10740,25 +10754,47 @@ std::string ExceptionTranslatorRegistry::translateActiveException() const {
 // end catch_exception_translator_registry.cpp
 // start catch_fatal_condition.cpp
 
-#if defined(__GNUC__)
-#    pragma GCC diagnostic push
-#    pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#endif
+#include <algorithm>
+
+#if !defined( CATCH_CONFIG_WINDOWS_SEH ) && !defined( CATCH_CONFIG_POSIX_SIGNALS )
+
+namespace Catch {
+
+    // If neither SEH nor signal handling is required, the handler impls
+    // do not have to do anything, and can be empty.
+    void FatalConditionHandler::engage_platform() {}
+    void FatalConditionHandler::disengage_platform() {}
+    FatalConditionHandler::FatalConditionHandler() = default;
+    FatalConditionHandler::~FatalConditionHandler() = default;
+
+} // end namespace Catch
+
+#endif // !CATCH_CONFIG_WINDOWS_SEH && !CATCH_CONFIG_POSIX_SIGNALS
+
+#if defined( CATCH_CONFIG_WINDOWS_SEH ) && defined( CATCH_CONFIG_POSIX_SIGNALS )
+#error "Inconsistent configuration: Windows' SEH handling and POSIX signals cannot be enabled at the same time"
+#endif // CATCH_CONFIG_WINDOWS_SEH && CATCH_CONFIG_POSIX_SIGNALS
 
 #if defined( CATCH_CONFIG_WINDOWS_SEH ) || defined( CATCH_CONFIG_POSIX_SIGNALS )
 
 namespace {
-// Report the error condition
-void reportFatal( char const * const message ) {
-    Catch::getCurrentContext().getResultCapture()->handleFatalErrorCondition( message );
-}
-}
+    //! Signals fatal error message to the run context
+    void reportFatal( char const * const message ) {
+        Catch::getCurrentContext().getResultCapture()->handleFatalErrorCondition( message );
+    }
 
-#endif // signals/SEH handling
+    //! Minimal size Catch2 needs for its own fatal error handling.
+    //! Picked anecdotally, so it might not be sufficient on all
+    //! platforms, and for all configurations.
+    constexpr std::size_t minStackSizeForErrors = 32 * 1024;
+} // end unnamed namespace
+
+#endif // CATCH_CONFIG_WINDOWS_SEH || CATCH_CONFIG_POSIX_SIGNALS
 
 #if defined( CATCH_CONFIG_WINDOWS_SEH )
 
 namespace Catch {
+
     struct SignalDefs { DWORD id; const char* name; };
 
     // There is no 1-1 mapping between signals and windows exceptions.
@@ -10771,7 +10807,7 @@ namespace Catch {
         { static_cast<DWORD>(EXCEPTION_INT_DIVIDE_BY_ZERO), "Divide by zero error" },
     };
 
-    LONG CALLBACK FatalConditionHandler::handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo) {
+    static LONG CALLBACK handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo) {
         for (auto const& def : signalDefs) {
             if (ExceptionInfo->ExceptionRecord->ExceptionCode == def.id) {
                 reportFatal(def.name);
@@ -10782,122 +10818,149 @@ namespace Catch {
         return EXCEPTION_CONTINUE_SEARCH;
     }
 
-    FatalConditionHandler::FatalConditionHandler() {
-        isSet = true;
-        // 32k seems enough for Catch to handle stack overflow,
-        // but the value was found experimentally, so there is no strong guarantee
-        guaranteeSize = 32 * 1024;
-        exceptionHandlerHandle = nullptr;
-        // Register as first handler in current chain
-        exceptionHandlerHandle = AddVectoredExceptionHandler(1, handleVectoredException);
-        // Pass in guarantee size to be filled
-        SetThreadStackGuarantee(&guaranteeSize);
-    }
+    // Since we do not support multiple instantiations, we put these
+    // into global variables and rely on cleaning them up in outlined
+    // constructors/destructors
+    static PVOID exceptionHandlerHandle = nullptr;
 
-    void FatalConditionHandler::reset() {
-        if (isSet) {
-            RemoveVectoredExceptionHandler(exceptionHandlerHandle);
-            SetThreadStackGuarantee(&guaranteeSize);
-            exceptionHandlerHandle = nullptr;
-            isSet = false;
+    // For MSVC, we reserve part of the stack memory for handling
+    // memory overflow structured exception.
+    FatalConditionHandler::FatalConditionHandler() {
+        ULONG guaranteeSize = static_cast<ULONG>(minStackSizeForErrors);
+        if (!SetThreadStackGuarantee(&guaranteeSize)) {
+            // We do not want to fully error out, because needing
+            // the stack reserve should be rare enough anyway.
+            Catch::cerr()
+                << "Failed to reserve piece of stack."
+                << " Stack overflows will not be reported successfully.";
         }
     }
 
-    FatalConditionHandler::~FatalConditionHandler() {
-        reset();
+    // We do not attempt to unset the stack guarantee, because
+    // Windows does not support lowering the stack size guarantee.
+    FatalConditionHandler::~FatalConditionHandler() = default;
+
+    void FatalConditionHandler::engage_platform() {
+        // Register as first handler in current chain
+        exceptionHandlerHandle = AddVectoredExceptionHandler(1, handleVectoredException);
+        if (!exceptionHandlerHandle) {
+            CATCH_RUNTIME_ERROR("Could not register vectored exception handler");
+        }
     }
 
-bool FatalConditionHandler::isSet = false;
-ULONG FatalConditionHandler::guaranteeSize = 0;
-PVOID FatalConditionHandler::exceptionHandlerHandle = nullptr;
+    void FatalConditionHandler::disengage_platform() {
+        if (!RemoveVectoredExceptionHandler(exceptionHandlerHandle)) {
+            CATCH_RUNTIME_ERROR("Could not unregister vectored exception handler");
+        }
+        exceptionHandlerHandle = nullptr;
+    }
 
-} // namespace Catch
+} // end namespace Catch
 
-#elif defined( CATCH_CONFIG_POSIX_SIGNALS )
+#endif // CATCH_CONFIG_WINDOWS_SEH
+
+#if defined( CATCH_CONFIG_POSIX_SIGNALS )
+
+#include <signal.h>
 
 namespace Catch {
 
-struct SignalDefs {
-    int id;
-    const char* name;
-};
+    struct SignalDefs {
+        int id;
+        const char* name;
+    };
 
-// 32kb for the alternate stack seems to be sufficient. However, this value
-// is experimentally determined, so that's not guaranteed.
-static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
+    static SignalDefs signalDefs[] = {
+        { SIGINT,  "SIGINT - Terminal interrupt signal" },
+        { SIGILL,  "SIGILL - Illegal instruction signal" },
+        { SIGFPE,  "SIGFPE - Floating point error signal" },
+        { SIGSEGV, "SIGSEGV - Segmentation violation signal" },
+        { SIGTERM, "SIGTERM - Termination request signal" },
+        { SIGABRT, "SIGABRT - Abort (abnormal termination) signal" }
+    };
 
-static SignalDefs signalDefs[] = {
-    { SIGINT,  "SIGINT - Terminal interrupt signal" },
-    { SIGILL,  "SIGILL - Illegal instruction signal" },
-    { SIGFPE,  "SIGFPE - Floating point error signal" },
-    { SIGSEGV, "SIGSEGV - Segmentation violation signal" },
-    { SIGTERM, "SIGTERM - Termination request signal" },
-    { SIGABRT, "SIGABRT - Abort (abnormal termination) signal" }
-};
+// Older GCCs trigger -Wmissing-field-initializers for T foo = {}
+// which is zero initialization, but not explicit. We want to avoid
+// that.
+#if defined(__GNUC__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
 
-void FatalConditionHandler::handleSignal( int sig ) {
-    char const * name = "<unknown signal>";
-    for (auto const& def : signalDefs) {
-        if (sig == def.id) {
-            name = def.name;
-            break;
-        }
-    }
-    reset();
-    reportFatal(name);
-    raise( sig );
-}
+    static char* altStackMem = nullptr;
+    static std::size_t altStackSize = 0;
+    static stack_t oldSigStack{};
+    static struct sigaction oldSigActions[sizeof(signalDefs) / sizeof(SignalDefs)]{};
 
-FatalConditionHandler::FatalConditionHandler() {
-    isSet = true;
-    stack_t sigStack;
-    sigStack.ss_sp = altStackMem;
-    sigStack.ss_size = sigStackSize;
-    sigStack.ss_flags = 0;
-    sigaltstack(&sigStack, &oldSigStack);
-    struct sigaction sa = { };
-
-    sa.sa_handler = handleSignal;
-    sa.sa_flags = SA_ONSTACK;
-    for (std::size_t i = 0; i < sizeof(signalDefs)/sizeof(SignalDefs); ++i) {
-        sigaction(signalDefs[i].id, &sa, &oldSigActions[i]);
-    }
-}
-
-FatalConditionHandler::~FatalConditionHandler() {
-    reset();
-}
-
-void FatalConditionHandler::reset() {
-    if( isSet ) {
-        // Set signals back to previous values -- hopefully nobody overwrote them in the meantime
-        for( std::size_t i = 0; i < sizeof(signalDefs)/sizeof(SignalDefs); ++i ) {
+    static void restorePreviousSignalHandlers() {
+        // We set signal handlers back to the previous ones. Hopefully
+        // nobody overwrote them in the meantime, and doesn't expect
+        // their signal handlers to live past ours given that they
+        // installed them after ours..
+        for (std::size_t i = 0; i < sizeof(signalDefs) / sizeof(SignalDefs); ++i) {
             sigaction(signalDefs[i].id, &oldSigActions[i], nullptr);
         }
         // Return the old stack
         sigaltstack(&oldSigStack, nullptr);
-        isSet = false;
     }
-}
 
-bool FatalConditionHandler::isSet = false;
-struct sigaction FatalConditionHandler::oldSigActions[sizeof(signalDefs)/sizeof(SignalDefs)] = {};
-stack_t FatalConditionHandler::oldSigStack = {};
-char FatalConditionHandler::altStackMem[sigStackSize] = {};
+    static void handleSignal( int sig ) {
+        char const * name = "<unknown signal>";
+        for (auto const& def : signalDefs) {
+            if (sig == def.id) {
+                name = def.name;
+                break;
+            }
+        }
+        // We need to restore previous signal handlers and let them do
+        // their thing, so that the users can have the debugger break
+        // when a signal is raised, and so on.
+        restorePreviousSignalHandlers();
+        reportFatal( name );
+        raise( sig );
+    }
 
-} // namespace Catch
+    FatalConditionHandler::FatalConditionHandler() {
+        assert(!altStackMem && "Cannot initialize POSIX signal handler when one already exists");
+        if (altStackSize == 0) {
+            altStackSize = std::max(static_cast<size_t>(SIGSTKSZ), minStackSizeForErrors);
+        }
+        altStackMem = new char[altStackSize]();
+    }
 
-#else
+    FatalConditionHandler::~FatalConditionHandler() {
+        delete[] altStackMem;
+        // We signal that another instance can be constructed by zeroing
+        // out the pointer.
+        altStackMem = nullptr;
+    }
 
-namespace Catch {
-    void FatalConditionHandler::reset() {}
-}
+    void FatalConditionHandler::engage_platform() {
+        stack_t sigStack;
+        sigStack.ss_sp = altStackMem;
+        sigStack.ss_size = altStackSize;
+        sigStack.ss_flags = 0;
+        sigaltstack(&sigStack, &oldSigStack);
+        struct sigaction sa = { };
 
-#endif // signals/SEH handling
+        sa.sa_handler = handleSignal;
+        sa.sa_flags = SA_ONSTACK;
+        for (std::size_t i = 0; i < sizeof(signalDefs)/sizeof(SignalDefs); ++i) {
+            sigaction(signalDefs[i].id, &sa, &oldSigActions[i]);
+        }
+    }
 
 #if defined(__GNUC__)
 #    pragma GCC diagnostic pop
 #endif
+
+    void FatalConditionHandler::disengage_platform() {
+        restorePreviousSignalHandlers();
+    }
+
+} // end namespace Catch
+
+#endif // CATCH_CONFIG_POSIX_SIGNALS
 // end catch_fatal_condition.cpp
 // start catch_generators.cpp
 
@@ -10914,11 +10977,11 @@ const char* GeneratorException::what() const noexcept {
 
 namespace Generators {
 
-GeneratorUntypedBase::~GeneratorUntypedBase() {}
+    GeneratorUntypedBase::~GeneratorUntypedBase() {}
 
-auto acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker& {
-    return getResultCapture().acquireGeneratorTracker( generatorName, lineInfo );
-}
+    auto acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker& {
+        return getResultCapture().acquireGeneratorTracker( generatorName, lineInfo );
+    }
 
 } // namespace Generators
 } // namespace Catch
@@ -10926,27 +10989,27 @@ auto acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lin
 // start catch_interfaces_capture.cpp
 
 namespace Catch {
-IResultCapture::~IResultCapture() = default;
+    IResultCapture::~IResultCapture() = default;
 }
 // end catch_interfaces_capture.cpp
 // start catch_interfaces_config.cpp
 
 namespace Catch {
-IConfig::~IConfig() = default;
+    IConfig::~IConfig() = default;
 }
 // end catch_interfaces_config.cpp
 // start catch_interfaces_exception.cpp
 
 namespace Catch {
-IExceptionTranslator::~IExceptionTranslator() = default;
-IExceptionTranslatorRegistry::~IExceptionTranslatorRegistry() = default;
+    IExceptionTranslator::~IExceptionTranslator() = default;
+    IExceptionTranslatorRegistry::~IExceptionTranslatorRegistry() = default;
 }
 // end catch_interfaces_exception.cpp
 // start catch_interfaces_registry_hub.cpp
 
 namespace Catch {
-IRegistryHub::~IRegistryHub() = default;
-IMutableRegistryHub::~IMutableRegistryHub() = default;
+    IRegistryHub::~IRegistryHub() = default;
+    IMutableRegistryHub::~IMutableRegistryHub() = default;
 }
 // end catch_interfaces_registry_hub.cpp
 // start catch_interfaces_reporter.cpp
@@ -10955,169 +11018,169 @@ IMutableRegistryHub::~IMutableRegistryHub() = default;
 
 namespace Catch {
 
-class ListeningReporter : public IStreamingReporter {
-    using Reporters = std::vector<IStreamingReporterPtr>;
-    Reporters m_listeners;
-    IStreamingReporterPtr m_reporter = nullptr;
-    ReporterPreferences m_preferences;
+    class ListeningReporter : public IStreamingReporter {
+        using Reporters = std::vector<IStreamingReporterPtr>;
+        Reporters m_listeners;
+        IStreamingReporterPtr m_reporter = nullptr;
+        ReporterPreferences m_preferences;
 
-public:
-    ListeningReporter();
+    public:
+        ListeningReporter();
 
-    void addListener( IStreamingReporterPtr&& listener );
-    void addReporter( IStreamingReporterPtr&& reporter );
+        void addListener( IStreamingReporterPtr&& listener );
+        void addReporter( IStreamingReporterPtr&& reporter );
 
-public: // IStreamingReporter
+    public: // IStreamingReporter
 
-    ReporterPreferences getPreferences() const override;
+        ReporterPreferences getPreferences() const override;
 
-    void noMatchingTestCases( std::string const& spec ) override;
+        void noMatchingTestCases( std::string const& spec ) override;
 
-    void reportInvalidArguments(std::string const&arg) override;
+        void reportInvalidArguments(std::string const&arg) override;
 
-    static std::set<Verbosity> getSupportedVerbosities();
+        static std::set<Verbosity> getSupportedVerbosities();
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
-    void benchmarkPreparing(std::string const& name) override;
+        void benchmarkPreparing(std::string const& name) override;
         void benchmarkStarting( BenchmarkInfo const& benchmarkInfo ) override;
         void benchmarkEnded( BenchmarkStats<> const& benchmarkStats ) override;
         void benchmarkFailed(std::string const&) override;
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-    void testRunStarting( TestRunInfo const& testRunInfo ) override;
-    void testGroupStarting( GroupInfo const& groupInfo ) override;
-    void testCaseStarting( TestCaseInfo const& testInfo ) override;
-    void sectionStarting( SectionInfo const& sectionInfo ) override;
-    void assertionStarting( AssertionInfo const& assertionInfo ) override;
+        void testRunStarting( TestRunInfo const& testRunInfo ) override;
+        void testGroupStarting( GroupInfo const& groupInfo ) override;
+        void testCaseStarting( TestCaseInfo const& testInfo ) override;
+        void sectionStarting( SectionInfo const& sectionInfo ) override;
+        void assertionStarting( AssertionInfo const& assertionInfo ) override;
 
-    // The return value indicates if the messages buffer should be cleared:
-    bool assertionEnded( AssertionStats const& assertionStats ) override;
-    void sectionEnded( SectionStats const& sectionStats ) override;
-    void testCaseEnded( TestCaseStats const& testCaseStats ) override;
-    void testGroupEnded( TestGroupStats const& testGroupStats ) override;
-    void testRunEnded( TestRunStats const& testRunStats ) override;
+        // The return value indicates if the messages buffer should be cleared:
+        bool assertionEnded( AssertionStats const& assertionStats ) override;
+        void sectionEnded( SectionStats const& sectionStats ) override;
+        void testCaseEnded( TestCaseStats const& testCaseStats ) override;
+        void testGroupEnded( TestGroupStats const& testGroupStats ) override;
+        void testRunEnded( TestRunStats const& testRunStats ) override;
 
-    void skipTest( TestCaseInfo const& testInfo ) override;
-    bool isMulti() const override;
+        void skipTest( TestCaseInfo const& testInfo ) override;
+        bool isMulti() const override;
 
-};
+    };
 
 } // end namespace Catch
 
 // end catch_reporter_listening.h
 namespace Catch {
 
-ReporterConfig::ReporterConfig( IConfigPtr const& _fullConfig )
+    ReporterConfig::ReporterConfig( IConfigPtr const& _fullConfig )
     :   m_stream( &_fullConfig->stream() ), m_fullConfig( _fullConfig ) {}
 
-ReporterConfig::ReporterConfig( IConfigPtr const& _fullConfig, std::ostream& _stream )
+    ReporterConfig::ReporterConfig( IConfigPtr const& _fullConfig, std::ostream& _stream )
     :   m_stream( &_stream ), m_fullConfig( _fullConfig ) {}
 
-std::ostream& ReporterConfig::stream() const { return *m_stream; }
-IConfigPtr ReporterConfig::fullConfig() const { return m_fullConfig; }
+    std::ostream& ReporterConfig::stream() const { return *m_stream; }
+    IConfigPtr ReporterConfig::fullConfig() const { return m_fullConfig; }
 
-TestRunInfo::TestRunInfo( std::string const& _name ) : name( _name ) {}
+    TestRunInfo::TestRunInfo( std::string const& _name ) : name( _name ) {}
 
-GroupInfo::GroupInfo(  std::string const& _name,
-                       std::size_t _groupIndex,
-                       std::size_t _groupsCount )
+    GroupInfo::GroupInfo(  std::string const& _name,
+                           std::size_t _groupIndex,
+                           std::size_t _groupsCount )
     :   name( _name ),
         groupIndex( _groupIndex ),
         groupsCounts( _groupsCount )
-{}
+    {}
 
-AssertionStats::AssertionStats( AssertionResult const& _assertionResult,
-                                std::vector<MessageInfo> const& _infoMessages,
-                                Totals const& _totals )
+     AssertionStats::AssertionStats( AssertionResult const& _assertionResult,
+                                     std::vector<MessageInfo> const& _infoMessages,
+                                     Totals const& _totals )
     :   assertionResult( _assertionResult ),
         infoMessages( _infoMessages ),
         totals( _totals )
-{
-    assertionResult.m_resultData.lazyExpression.m_transientExpression = _assertionResult.m_resultData.lazyExpression.m_transientExpression;
+    {
+        assertionResult.m_resultData.lazyExpression.m_transientExpression = _assertionResult.m_resultData.lazyExpression.m_transientExpression;
 
-    if( assertionResult.hasMessage() ) {
-        // Copy message into messages list.
-        // !TBD This should have been done earlier, somewhere
-        MessageBuilder builder( assertionResult.getTestMacroName(), assertionResult.getSourceInfo(), assertionResult.getResultType() );
-        builder << assertionResult.getMessage();
-        builder.m_info.message = builder.m_stream.str();
+        if( assertionResult.hasMessage() ) {
+            // Copy message into messages list.
+            // !TBD This should have been done earlier, somewhere
+            MessageBuilder builder( assertionResult.getTestMacroName(), assertionResult.getSourceInfo(), assertionResult.getResultType() );
+            builder << assertionResult.getMessage();
+            builder.m_info.message = builder.m_stream.str();
 
-        infoMessages.push_back( builder.m_info );
+            infoMessages.push_back( builder.m_info );
+        }
     }
-}
 
-AssertionStats::~AssertionStats() = default;
+     AssertionStats::~AssertionStats() = default;
 
-SectionStats::SectionStats(  SectionInfo const& _sectionInfo,
-                             Counts const& _assertions,
-                             double _durationInSeconds,
-                             bool _missingAssertions )
+    SectionStats::SectionStats(  SectionInfo const& _sectionInfo,
+                                 Counts const& _assertions,
+                                 double _durationInSeconds,
+                                 bool _missingAssertions )
     :   sectionInfo( _sectionInfo ),
         assertions( _assertions ),
         durationInSeconds( _durationInSeconds ),
         missingAssertions( _missingAssertions )
-{}
+    {}
 
-SectionStats::~SectionStats() = default;
+    SectionStats::~SectionStats() = default;
 
-TestCaseStats::TestCaseStats(  TestCaseInfo const& _testInfo,
-                               Totals const& _totals,
-                               std::string const& _stdOut,
-                               std::string const& _stdErr,
-                               bool _aborting )
+    TestCaseStats::TestCaseStats(  TestCaseInfo const& _testInfo,
+                                   Totals const& _totals,
+                                   std::string const& _stdOut,
+                                   std::string const& _stdErr,
+                                   bool _aborting )
     : testInfo( _testInfo ),
-      totals( _totals ),
-      stdOut( _stdOut ),
-      stdErr( _stdErr ),
-      aborting( _aborting )
-{}
+        totals( _totals ),
+        stdOut( _stdOut ),
+        stdErr( _stdErr ),
+        aborting( _aborting )
+    {}
 
-TestCaseStats::~TestCaseStats() = default;
+    TestCaseStats::~TestCaseStats() = default;
 
-TestGroupStats::TestGroupStats( GroupInfo const& _groupInfo,
-                                Totals const& _totals,
-                                bool _aborting )
+    TestGroupStats::TestGroupStats( GroupInfo const& _groupInfo,
+                                    Totals const& _totals,
+                                    bool _aborting )
     :   groupInfo( _groupInfo ),
         totals( _totals ),
         aborting( _aborting )
-{}
+    {}
 
-TestGroupStats::TestGroupStats( GroupInfo const& _groupInfo )
+    TestGroupStats::TestGroupStats( GroupInfo const& _groupInfo )
     :   groupInfo( _groupInfo ),
         aborting( false )
-{}
+    {}
 
-TestGroupStats::~TestGroupStats() = default;
+    TestGroupStats::~TestGroupStats() = default;
 
-TestRunStats::TestRunStats(   TestRunInfo const& _runInfo,
-                              Totals const& _totals,
-                              bool _aborting )
+    TestRunStats::TestRunStats(   TestRunInfo const& _runInfo,
+                    Totals const& _totals,
+                    bool _aborting )
     :   runInfo( _runInfo ),
         totals( _totals ),
         aborting( _aborting )
-{}
+    {}
 
-TestRunStats::~TestRunStats() = default;
+    TestRunStats::~TestRunStats() = default;
 
-void IStreamingReporter::fatalErrorEncountered( StringRef ) {}
-bool IStreamingReporter::isMulti() const { return false; }
+    void IStreamingReporter::fatalErrorEncountered( StringRef ) {}
+    bool IStreamingReporter::isMulti() const { return false; }
 
-IReporterFactory::~IReporterFactory() = default;
-IReporterRegistry::~IReporterRegistry() = default;
+    IReporterFactory::~IReporterFactory() = default;
+    IReporterRegistry::~IReporterRegistry() = default;
 
 } // end namespace Catch
 // end catch_interfaces_reporter.cpp
 // start catch_interfaces_runner.cpp
 
 namespace Catch {
-IRunner::~IRunner() = default;
+    IRunner::~IRunner() = default;
 }
 // end catch_interfaces_runner.cpp
 // start catch_interfaces_testcase.cpp
 
 namespace Catch {
-ITestInvoker::~ITestInvoker() = default;
-ITestCaseRegistry::~ITestCaseRegistry() = default;
+    ITestInvoker::~ITestInvoker() = default;
+    ITestCaseRegistry::~ITestCaseRegistry() = default;
 }
 // end catch_interfaces_testcase.cpp
 // start catch_leak_detector.cpp
@@ -11141,7 +11204,7 @@ namespace Catch {
 
 #else
 
-Catch::LeakDetector::LeakDetector() {}
+    Catch::LeakDetector::LeakDetector() {}
 
 #endif
 
@@ -11157,23 +11220,23 @@ Catch::LeakDetector::~LeakDetector() {
 
 namespace Catch {
 
-std::size_t listTests( Config const& config );
+    std::size_t listTests( Config const& config );
 
-std::size_t listTestsNamesOnly( Config const& config );
+    std::size_t listTestsNamesOnly( Config const& config );
 
-struct TagInfo {
-    void add( std::string const& spelling );
-    std::string all() const;
+    struct TagInfo {
+        void add( std::string const& spelling );
+        std::string all() const;
 
-    std::set<std::string> spellings;
-    std::size_t count = 0;
-};
+        std::set<std::string> spellings;
+        std::size_t count = 0;
+    };
 
-std::size_t listTags( Config const& config );
+    std::size_t listTags( Config const& config );
 
-std::size_t listReporters();
+    std::size_t listReporters();
 
-Option<std::size_t> list( std::shared_ptr<Config> const& config );
+    Option<std::size_t> list( std::shared_ptr<Config> const& config );
 
 } // end namespace Catch
 
@@ -11181,7 +11244,7 @@ Option<std::size_t> list( std::shared_ptr<Config> const& config );
 // start catch_text.h
 
 namespace Catch {
-using namespace clara::TextFlow;
+    using namespace clara::TextFlow;
 }
 
 // end catch_text.h
@@ -11191,148 +11254,148 @@ using namespace clara::TextFlow;
 
 namespace Catch {
 
-std::size_t listTests( Config const& config ) {
-    TestSpec const& testSpec = config.testSpec();
-    if( config.hasTestFilters() )
-        Catch::cout() << "Matching test cases:\n";
-    else {
-        Catch::cout() << "All available test cases:\n";
-    }
-
-    auto matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
-    for( auto const& testCaseInfo : matchedTestCases ) {
-        Colour::Code colour = testCaseInfo.isHidden()
-                              ? Colour::SecondaryText
-                              : Colour::None;
-        Colour colourGuard( colour );
-
-        Catch::cout() << Column( testCaseInfo.name ).initialIndent( 2 ).indent( 4 ) << "\n";
-        if( config.verbosity() >= Verbosity::High ) {
-            Catch::cout() << Column( Catch::Detail::stringify( testCaseInfo.lineInfo ) ).indent(4) << std::endl;
-            std::string description = testCaseInfo.description;
-            if( description.empty() )
-                description = "(NO DESCRIPTION)";
-            Catch::cout() << Column( description ).indent(4) << std::endl;
+    std::size_t listTests( Config const& config ) {
+        TestSpec const& testSpec = config.testSpec();
+        if( config.hasTestFilters() )
+            Catch::cout() << "Matching test cases:\n";
+        else {
+            Catch::cout() << "All available test cases:\n";
         }
-        if( !testCaseInfo.tags.empty() )
-            Catch::cout() << Column( testCaseInfo.tagsAsString() ).indent( 6 ) << "\n";
-    }
 
-    if( !config.hasTestFilters() )
-        Catch::cout() << pluralise( matchedTestCases.size(), "test case" ) << '\n' << std::endl;
-    else
-        Catch::cout() << pluralise( matchedTestCases.size(), "matching test case" ) << '\n' << std::endl;
-    return matchedTestCases.size();
-}
+        auto matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
+        for( auto const& testCaseInfo : matchedTestCases ) {
+            Colour::Code colour = testCaseInfo.isHidden()
+                ? Colour::SecondaryText
+                : Colour::None;
+            Colour colourGuard( colour );
 
-std::size_t listTestsNamesOnly( Config const& config ) {
-    TestSpec const& testSpec = config.testSpec();
-    std::size_t matchedTests = 0;
-    std::vector<TestCase> matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
-    for( auto const& testCaseInfo : matchedTestCases ) {
-        matchedTests++;
-        if( startsWith( testCaseInfo.name, '#' ) )
-            Catch::cout() << '"' << testCaseInfo.name << '"';
+            Catch::cout() << Column( testCaseInfo.name ).initialIndent( 2 ).indent( 4 ) << "\n";
+            if( config.verbosity() >= Verbosity::High ) {
+                Catch::cout() << Column( Catch::Detail::stringify( testCaseInfo.lineInfo ) ).indent(4) << std::endl;
+                std::string description = testCaseInfo.description;
+                if( description.empty() )
+                    description = "(NO DESCRIPTION)";
+                Catch::cout() << Column( description ).indent(4) << std::endl;
+            }
+            if( !testCaseInfo.tags.empty() )
+                Catch::cout() << Column( testCaseInfo.tagsAsString() ).indent( 6 ) << "\n";
+        }
+
+        if( !config.hasTestFilters() )
+            Catch::cout() << pluralise( matchedTestCases.size(), "test case" ) << '\n' << std::endl;
         else
-            Catch::cout() << testCaseInfo.name;
-        if ( config.verbosity() >= Verbosity::High )
-            Catch::cout() << "\t@" << testCaseInfo.lineInfo;
-        Catch::cout() << std::endl;
-    }
-    return matchedTests;
-}
-
-void TagInfo::add( std::string const& spelling ) {
-    ++count;
-    spellings.insert( spelling );
-}
-
-std::string TagInfo::all() const {
-    size_t size = 0;
-    for (auto const& spelling : spellings) {
-        // Add 2 for the brackes
-        size += spelling.size() + 2;
+            Catch::cout() << pluralise( matchedTestCases.size(), "matching test case" ) << '\n' << std::endl;
+        return matchedTestCases.size();
     }
 
-    std::string out; out.reserve(size);
-    for (auto const& spelling : spellings) {
-        out += '[';
-        out += spelling;
-        out += ']';
-    }
-    return out;
-}
-
-std::size_t listTags( Config const& config ) {
-    TestSpec const& testSpec = config.testSpec();
-    if( config.hasTestFilters() )
-        Catch::cout() << "Tags for matching test cases:\n";
-    else {
-        Catch::cout() << "All available tags:\n";
-    }
-
-    std::map<std::string, TagInfo> tagCounts;
-
-    std::vector<TestCase> matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
-    for( auto const& testCase : matchedTestCases ) {
-        for( auto const& tagName : testCase.getTestCaseInfo().tags ) {
-            std::string lcaseTagName = toLower( tagName );
-            auto countIt = tagCounts.find( lcaseTagName );
-            if( countIt == tagCounts.end() )
-                countIt = tagCounts.insert( std::make_pair( lcaseTagName, TagInfo() ) ).first;
-            countIt->second.add( tagName );
+    std::size_t listTestsNamesOnly( Config const& config ) {
+        TestSpec const& testSpec = config.testSpec();
+        std::size_t matchedTests = 0;
+        std::vector<TestCase> matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
+        for( auto const& testCaseInfo : matchedTestCases ) {
+            matchedTests++;
+            if( startsWith( testCaseInfo.name, '#' ) )
+               Catch::cout() << '"' << testCaseInfo.name << '"';
+            else
+               Catch::cout() << testCaseInfo.name;
+            if ( config.verbosity() >= Verbosity::High )
+                Catch::cout() << "\t@" << testCaseInfo.lineInfo;
+            Catch::cout() << std::endl;
         }
+        return matchedTests;
     }
 
-    for( auto const& tagCount : tagCounts ) {
-        ReusableStringStream rss;
-        rss << "  " << std::setw(2) << tagCount.second.count << "  ";
-        auto str = rss.str();
-        auto wrapper = Column( tagCount.second.all() )
-            .initialIndent( 0 )
-            .indent( str.size() )
-            .width( CATCH_CONFIG_CONSOLE_WIDTH-10 );
-        Catch::cout() << str << wrapper << '\n';
+    void TagInfo::add( std::string const& spelling ) {
+        ++count;
+        spellings.insert( spelling );
     }
-    Catch::cout() << pluralise( tagCounts.size(), "tag" ) << '\n' << std::endl;
-    return tagCounts.size();
-}
 
-std::size_t listReporters() {
-    Catch::cout() << "Available reporters:\n";
-    IReporterRegistry::FactoryMap const& factories = getRegistryHub().getReporterRegistry().getFactories();
-    std::size_t maxNameLen = 0;
-    for( auto const& factoryKvp : factories )
-        maxNameLen = (std::max)( maxNameLen, factoryKvp.first.size() );
+    std::string TagInfo::all() const {
+        size_t size = 0;
+        for (auto const& spelling : spellings) {
+            // Add 2 for the brackes
+            size += spelling.size() + 2;
+        }
 
-    for( auto const& factoryKvp : factories ) {
-        Catch::cout()
-            << Column( factoryKvp.first + ":" )
-                .indent(2)
-                .width( 5+maxNameLen )
-                +  Column( factoryKvp.second->getDescription() )
-                    .initialIndent(0)
-                    .indent(2)
-                    .width( CATCH_CONFIG_CONSOLE_WIDTH - maxNameLen-8 )
-            << "\n";
+        std::string out; out.reserve(size);
+        for (auto const& spelling : spellings) {
+            out += '[';
+            out += spelling;
+            out += ']';
+        }
+        return out;
     }
-    Catch::cout() << std::endl;
-    return factories.size();
-}
 
-Option<std::size_t> list( std::shared_ptr<Config> const& config ) {
-    Option<std::size_t> listedCount;
-    getCurrentMutableContext().setConfig( config );
-    if( config->listTests() )
-        listedCount = listedCount.valueOr(0) + listTests( *config );
-    if( config->listTestNamesOnly() )
-        listedCount = listedCount.valueOr(0) + listTestsNamesOnly( *config );
-    if( config->listTags() )
-        listedCount = listedCount.valueOr(0) + listTags( *config );
-    if( config->listReporters() )
-        listedCount = listedCount.valueOr(0) + listReporters();
-    return listedCount;
-}
+    std::size_t listTags( Config const& config ) {
+        TestSpec const& testSpec = config.testSpec();
+        if( config.hasTestFilters() )
+            Catch::cout() << "Tags for matching test cases:\n";
+        else {
+            Catch::cout() << "All available tags:\n";
+        }
+
+        std::map<std::string, TagInfo> tagCounts;
+
+        std::vector<TestCase> matchedTestCases = filterTests( getAllTestCasesSorted( config ), testSpec, config );
+        for( auto const& testCase : matchedTestCases ) {
+            for( auto const& tagName : testCase.getTestCaseInfo().tags ) {
+                std::string lcaseTagName = toLower( tagName );
+                auto countIt = tagCounts.find( lcaseTagName );
+                if( countIt == tagCounts.end() )
+                    countIt = tagCounts.insert( std::make_pair( lcaseTagName, TagInfo() ) ).first;
+                countIt->second.add( tagName );
+            }
+        }
+
+        for( auto const& tagCount : tagCounts ) {
+            ReusableStringStream rss;
+            rss << "  " << std::setw(2) << tagCount.second.count << "  ";
+            auto str = rss.str();
+            auto wrapper = Column( tagCount.second.all() )
+                                                    .initialIndent( 0 )
+                                                    .indent( str.size() )
+                                                    .width( CATCH_CONFIG_CONSOLE_WIDTH-10 );
+            Catch::cout() << str << wrapper << '\n';
+        }
+        Catch::cout() << pluralise( tagCounts.size(), "tag" ) << '\n' << std::endl;
+        return tagCounts.size();
+    }
+
+    std::size_t listReporters() {
+        Catch::cout() << "Available reporters:\n";
+        IReporterRegistry::FactoryMap const& factories = getRegistryHub().getReporterRegistry().getFactories();
+        std::size_t maxNameLen = 0;
+        for( auto const& factoryKvp : factories )
+            maxNameLen = (std::max)( maxNameLen, factoryKvp.first.size() );
+
+        for( auto const& factoryKvp : factories ) {
+            Catch::cout()
+                    << Column( factoryKvp.first + ":" )
+                            .indent(2)
+                            .width( 5+maxNameLen )
+                    +  Column( factoryKvp.second->getDescription() )
+                            .initialIndent(0)
+                            .indent(2)
+                            .width( CATCH_CONFIG_CONSOLE_WIDTH - maxNameLen-8 )
+                    << "\n";
+        }
+        Catch::cout() << std::endl;
+        return factories.size();
+    }
+
+    Option<std::size_t> list( std::shared_ptr<Config> const& config ) {
+        Option<std::size_t> listedCount;
+        getCurrentMutableContext().setConfig( config );
+        if( config->listTests() )
+            listedCount = listedCount.valueOr(0) + listTests( *config );
+        if( config->listTestNamesOnly() )
+            listedCount = listedCount.valueOr(0) + listTestsNamesOnly( *config );
+        if( config->listTags() )
+            listedCount = listedCount.valueOr(0) + listTags( *config );
+        if( config->listReporters() )
+            listedCount = listedCount.valueOr(0) + listReporters();
+        return listedCount;
+    }
 
 } // end namespace Catch
 // end catch_list.cpp
@@ -11340,17 +11403,17 @@ Option<std::size_t> list( std::shared_ptr<Config> const& config ) {
 
 namespace Catch {
 namespace Matchers {
-namespace Impl {
+    namespace Impl {
 
-std::string MatcherUntypedBase::toString() const {
-    if( m_cachedToString.empty() )
-        m_cachedToString = describe();
-    return m_cachedToString;
-}
+        std::string MatcherUntypedBase::toString() const {
+            if( m_cachedToString.empty() )
+                m_cachedToString = describe();
+            return m_cachedToString;
+        }
 
-MatcherUntypedBase::~MatcherUntypedBase() = default;
+        MatcherUntypedBase::~MatcherUntypedBase() = default;
 
-} // namespace Impl
+    } // namespace Impl
 } // namespace Matchers
 
 using namespace Matchers;
@@ -11386,8 +11449,8 @@ Exception::ExceptionMessageMatcher Message(std::string const& message) {
 // start catch_polyfills.hpp
 
 namespace Catch {
-bool isnan(float f);
-bool isnan(double d);
+    bool isnan(float f);
+    bool isnan(double d);
 }
 
 // end catch_polyfills.hpp
@@ -11396,16 +11459,16 @@ bool isnan(double d);
 #include <string>
 
 namespace Catch {
-template <typename T>
-std::string to_string(T const& t) {
+    template <typename T>
+    std::string to_string(T const& t) {
 #if defined(CATCH_CONFIG_CPP11_TO_STRING)
-    return std::to_string(t);
+        return std::to_string(t);
 #else
-    ReusableStringStream rss;
+        ReusableStringStream rss;
         rss << t;
         return rss.str();
 #endif
-}
+    }
 } // end namespace Catch
 
 // end catch_to_string.hpp
@@ -11422,49 +11485,50 @@ std::string to_string(T const& t) {
 namespace Catch {
 namespace {
 
-int32_t convert(float f) {
-    static_assert(sizeof(float) == sizeof(int32_t), "Important ULP matcher assumption violated");
-    int32_t i;
-    std::memcpy(&i, &f, sizeof(f));
-    return i;
-}
-
-int64_t convert(double d) {
-    static_assert(sizeof(double) == sizeof(int64_t), "Important ULP matcher assumption violated");
-    int64_t i;
-    std::memcpy(&i, &d, sizeof(d));
-    return i;
-}
-
-template <typename FP>
-bool almostEqualUlps(FP lhs, FP rhs, uint64_t maxUlpDiff) {
-    // Comparison with NaN should always be false.
-    // This way we can rule it out before getting into the ugly details
-    if (Catch::isnan(lhs) || Catch::isnan(rhs)) {
-        return false;
+    int32_t convert(float f) {
+        static_assert(sizeof(float) == sizeof(int32_t), "Important ULP matcher assumption violated");
+        int32_t i;
+        std::memcpy(&i, &f, sizeof(f));
+        return i;
     }
 
-    auto lc = convert(lhs);
-    auto rc = convert(rhs);
-
-    if ((lc < 0) != (rc < 0)) {
-        // Potentially we can have +0 and -0
-        return lhs == rhs;
+    int64_t convert(double d) {
+        static_assert(sizeof(double) == sizeof(int64_t), "Important ULP matcher assumption violated");
+        int64_t i;
+        std::memcpy(&i, &d, sizeof(d));
+        return i;
     }
 
-    auto ulpDiff = std::abs(lc - rc);
-    return static_cast<uint64_t>(ulpDiff) <= maxUlpDiff;
-}
+    template <typename FP>
+    bool almostEqualUlps(FP lhs, FP rhs, uint64_t maxUlpDiff) {
+        // Comparison with NaN should always be false.
+        // This way we can rule it out before getting into the ugly details
+        if (Catch::isnan(lhs) || Catch::isnan(rhs)) {
+            return false;
+        }
+
+        auto lc = convert(lhs);
+        auto rc = convert(rhs);
+
+        if ((lc < 0) != (rc < 0)) {
+            // Potentially we can have +0 and -0
+            return lhs == rhs;
+        }
+
+        // static cast as a workaround for IBM XLC
+        auto ulpDiff = std::abs(static_cast<FP>(lc - rc));
+        return static_cast<uint64_t>(ulpDiff) <= maxUlpDiff;
+    }
 
 #if defined(CATCH_CONFIG_GLOBAL_NEXTAFTER)
 
-float nextafter(float x, float y) {
-    return ::nextafterf(x, y);
-}
+    float nextafter(float x, float y) {
+        return ::nextafterf(x, y);
+    }
 
-double nextafter(double x, double y) {
-    return ::nextafter(x, y);
-}
+    double nextafter(double x, double y) {
+        return ::nextafter(x, y);
+    }
 
 #endif // ^^^ CATCH_CONFIG_GLOBAL_NEXTAFTER ^^^
 
@@ -11498,33 +11562,33 @@ void write(std::ostream& out, FloatingPoint num) {
 namespace Matchers {
 namespace Floating {
 
-enum class FloatingPointKind : uint8_t {
-    Float,
-    Double
-};
+    enum class FloatingPointKind : uint8_t {
+        Float,
+        Double
+    };
 
-WithinAbsMatcher::WithinAbsMatcher(double target, double margin)
-    :m_target{ target }, m_margin{ margin } {
-    CATCH_ENFORCE(margin >= 0, "Invalid margin: " << margin << '.'
-                                                  << " Margin has to be non-negative.");
-}
+    WithinAbsMatcher::WithinAbsMatcher(double target, double margin)
+        :m_target{ target }, m_margin{ margin } {
+        CATCH_ENFORCE(margin >= 0, "Invalid margin: " << margin << '.'
+            << " Margin has to be non-negative.");
+    }
 
-// Performs equivalent check of std::fabs(lhs - rhs) <= margin
-// But without the subtraction to allow for INFINITY in comparison
-bool WithinAbsMatcher::match(double const& matchee) const {
-    return (matchee + m_margin >= m_target) && (m_target + m_margin >= matchee);
-}
+    // Performs equivalent check of std::fabs(lhs - rhs) <= margin
+    // But without the subtraction to allow for INFINITY in comparison
+    bool WithinAbsMatcher::match(double const& matchee) const {
+        return (matchee + m_margin >= m_target) && (m_target + m_margin >= matchee);
+    }
 
-std::string WithinAbsMatcher::describe() const {
-    return "is within " + ::Catch::Detail::stringify(m_margin) + " of " + ::Catch::Detail::stringify(m_target);
-}
+    std::string WithinAbsMatcher::describe() const {
+        return "is within " + ::Catch::Detail::stringify(m_margin) + " of " + ::Catch::Detail::stringify(m_target);
+    }
 
-WithinUlpsMatcher::WithinUlpsMatcher(double target, uint64_t ulps, FloatingPointKind baseType)
-    :m_target{ target }, m_ulps{ ulps }, m_type{ baseType } {
-    CATCH_ENFORCE(m_type == FloatingPointKind::Double
-                      || m_ulps < (std::numeric_limits<uint32_t>::max)(),
-                  "Provided ULP is impossibly large for a float comparison.");
-}
+    WithinUlpsMatcher::WithinUlpsMatcher(double target, uint64_t ulps, FloatingPointKind baseType)
+        :m_target{ target }, m_ulps{ ulps }, m_type{ baseType } {
+        CATCH_ENFORCE(m_type == FloatingPointKind::Double
+                   || m_ulps < (std::numeric_limits<uint32_t>::max)(),
+            "Provided ULP is impossibly large for a float comparison.");
+    }
 
 #if defined(__clang__)
 #pragma clang diagnostic push
@@ -11532,67 +11596,67 @@ WithinUlpsMatcher::WithinUlpsMatcher(double target, uint64_t ulps, FloatingPoint
 #pragma clang diagnostic ignored "-Wunreachable-code"
 #endif
 
-bool WithinUlpsMatcher::match(double const& matchee) const {
-    switch (m_type) {
+    bool WithinUlpsMatcher::match(double const& matchee) const {
+        switch (m_type) {
         case FloatingPointKind::Float:
             return almostEqualUlps<float>(static_cast<float>(matchee), static_cast<float>(m_target), m_ulps);
         case FloatingPointKind::Double:
             return almostEqualUlps<double>(matchee, m_target, m_ulps);
         default:
             CATCH_INTERNAL_ERROR( "Unknown FloatingPointKind value" );
+        }
     }
-}
 
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
 
-std::string WithinUlpsMatcher::describe() const {
-    std::stringstream ret;
+    std::string WithinUlpsMatcher::describe() const {
+        std::stringstream ret;
 
-    ret << "is within " << m_ulps << " ULPs of ";
+        ret << "is within " << m_ulps << " ULPs of ";
 
-    if (m_type == FloatingPointKind::Float) {
-        write(ret, static_cast<float>(m_target));
-        ret << 'f';
-    } else {
-        write(ret, m_target);
+        if (m_type == FloatingPointKind::Float) {
+            write(ret, static_cast<float>(m_target));
+            ret << 'f';
+        } else {
+            write(ret, m_target);
+        }
+
+        ret << " ([";
+        if (m_type == FloatingPointKind::Double) {
+            write(ret, step(m_target, static_cast<double>(-INFINITY), m_ulps));
+            ret << ", ";
+            write(ret, step(m_target, static_cast<double>( INFINITY), m_ulps));
+        } else {
+            // We have to cast INFINITY to float because of MinGW, see #1782
+            write(ret, step(static_cast<float>(m_target), static_cast<float>(-INFINITY), m_ulps));
+            ret << ", ";
+            write(ret, step(static_cast<float>(m_target), static_cast<float>( INFINITY), m_ulps));
+        }
+        ret << "])";
+
+        return ret.str();
     }
 
-    ret << " ([";
-    if (m_type == FloatingPointKind::Double) {
-        write(ret, step(m_target, static_cast<double>(-INFINITY), m_ulps));
-        ret << ", ";
-        write(ret, step(m_target, static_cast<double>( INFINITY), m_ulps));
-    } else {
-        // We have to cast INFINITY to float because of MinGW, see #1782
-        write(ret, step(static_cast<float>(m_target), static_cast<float>(-INFINITY), m_ulps));
-        ret << ", ";
-        write(ret, step(static_cast<float>(m_target), static_cast<float>( INFINITY), m_ulps));
+    WithinRelMatcher::WithinRelMatcher(double target, double epsilon):
+        m_target(target),
+        m_epsilon(epsilon){
+        CATCH_ENFORCE(m_epsilon >= 0., "Relative comparison with epsilon <  0 does not make sense.");
+        CATCH_ENFORCE(m_epsilon  < 1., "Relative comparison with epsilon >= 1 does not make sense.");
     }
-    ret << "])";
 
-    return ret.str();
-}
+    bool WithinRelMatcher::match(double const& matchee) const {
+        const auto relMargin = m_epsilon * (std::max)(std::fabs(matchee), std::fabs(m_target));
+        return marginComparison(matchee, m_target,
+                                std::isinf(relMargin)? 0 : relMargin);
+    }
 
-WithinRelMatcher::WithinRelMatcher(double target, double epsilon):
-    m_target(target),
-    m_epsilon(epsilon){
-    CATCH_ENFORCE(m_epsilon >= 0., "Relative comparison with epsilon <  0 does not make sense.");
-    CATCH_ENFORCE(m_epsilon  < 1., "Relative comparison with epsilon >= 1 does not make sense.");
-}
-
-bool WithinRelMatcher::match(double const& matchee) const {
-    const auto relMargin = m_epsilon * (std::max)(std::fabs(matchee), std::fabs(m_target));
-    return marginComparison(matchee, m_target,
-                            std::isinf(relMargin)? 0 : relMargin);
-}
-
-std::string WithinRelMatcher::describe() const {
-    Catch::ReusableStringStream sstr;
-    sstr << "and " << m_target << " are within " << m_epsilon * 100. << "% of each other";
-    return sstr.str();
-}
+    std::string WithinRelMatcher::describe() const {
+        Catch::ReusableStringStream sstr;
+        sstr << "and " << m_target << " are within " << m_epsilon * 100. << "% of each other";
+        return sstr.str();
+    }
 
 }// namespace Floating
 
@@ -11626,7 +11690,6 @@ Floating::WithinRelMatcher WithinRel(float target) {
 
 } // namespace Matchers
 } // namespace Catch
-
 // end catch_matchers_floating.cpp
 // start catch_matchers_generic.cpp
 
@@ -11645,97 +11708,97 @@ std::string Catch::Matchers::Generic::Detail::finalizeDescription(const std::str
 namespace Catch {
 namespace Matchers {
 
-namespace StdString {
+    namespace StdString {
 
-CasedString::CasedString( std::string const& str, CaseSensitive::Choice caseSensitivity )
-    :   m_caseSensitivity( caseSensitivity ),
-        m_str( adjustString( str ) )
-{}
-std::string CasedString::adjustString( std::string const& str ) const {
-    return m_caseSensitivity == CaseSensitive::No
-           ? toLower( str )
-           : str;
-}
-std::string CasedString::caseSensitivitySuffix() const {
-    return m_caseSensitivity == CaseSensitive::No
-           ? " (case insensitive)"
-           : std::string();
-}
+        CasedString::CasedString( std::string const& str, CaseSensitive::Choice caseSensitivity )
+        :   m_caseSensitivity( caseSensitivity ),
+            m_str( adjustString( str ) )
+        {}
+        std::string CasedString::adjustString( std::string const& str ) const {
+            return m_caseSensitivity == CaseSensitive::No
+                   ? toLower( str )
+                   : str;
+        }
+        std::string CasedString::caseSensitivitySuffix() const {
+            return m_caseSensitivity == CaseSensitive::No
+                   ? " (case insensitive)"
+                   : std::string();
+        }
 
-StringMatcherBase::StringMatcherBase( std::string const& operation, CasedString const& comparator )
-    : m_comparator( comparator ),
-      m_operation( operation ) {
-}
+        StringMatcherBase::StringMatcherBase( std::string const& operation, CasedString const& comparator )
+        : m_comparator( comparator ),
+          m_operation( operation ) {
+        }
 
-std::string StringMatcherBase::describe() const {
-    std::string description;
-    description.reserve(5 + m_operation.size() + m_comparator.m_str.size() +
-        m_comparator.caseSensitivitySuffix().size());
-    description += m_operation;
-    description += ": \"";
-    description += m_comparator.m_str;
-    description += "\"";
-    description += m_comparator.caseSensitivitySuffix();
-    return description;
-}
+        std::string StringMatcherBase::describe() const {
+            std::string description;
+            description.reserve(5 + m_operation.size() + m_comparator.m_str.size() +
+                                        m_comparator.caseSensitivitySuffix().size());
+            description += m_operation;
+            description += ": \"";
+            description += m_comparator.m_str;
+            description += "\"";
+            description += m_comparator.caseSensitivitySuffix();
+            return description;
+        }
 
-EqualsMatcher::EqualsMatcher( CasedString const& comparator ) : StringMatcherBase( "equals", comparator ) {}
+        EqualsMatcher::EqualsMatcher( CasedString const& comparator ) : StringMatcherBase( "equals", comparator ) {}
 
-bool EqualsMatcher::match( std::string const& source ) const {
-    return m_comparator.adjustString( source ) == m_comparator.m_str;
-}
+        bool EqualsMatcher::match( std::string const& source ) const {
+            return m_comparator.adjustString( source ) == m_comparator.m_str;
+        }
 
-ContainsMatcher::ContainsMatcher( CasedString const& comparator ) : StringMatcherBase( "contains", comparator ) {}
+        ContainsMatcher::ContainsMatcher( CasedString const& comparator ) : StringMatcherBase( "contains", comparator ) {}
 
-bool ContainsMatcher::match( std::string const& source ) const {
-    return contains( m_comparator.adjustString( source ), m_comparator.m_str );
-}
+        bool ContainsMatcher::match( std::string const& source ) const {
+            return contains( m_comparator.adjustString( source ), m_comparator.m_str );
+        }
 
-StartsWithMatcher::StartsWithMatcher( CasedString const& comparator ) : StringMatcherBase( "starts with", comparator ) {}
+        StartsWithMatcher::StartsWithMatcher( CasedString const& comparator ) : StringMatcherBase( "starts with", comparator ) {}
 
-bool StartsWithMatcher::match( std::string const& source ) const {
-    return startsWith( m_comparator.adjustString( source ), m_comparator.m_str );
-}
+        bool StartsWithMatcher::match( std::string const& source ) const {
+            return startsWith( m_comparator.adjustString( source ), m_comparator.m_str );
+        }
 
-EndsWithMatcher::EndsWithMatcher( CasedString const& comparator ) : StringMatcherBase( "ends with", comparator ) {}
+        EndsWithMatcher::EndsWithMatcher( CasedString const& comparator ) : StringMatcherBase( "ends with", comparator ) {}
 
-bool EndsWithMatcher::match( std::string const& source ) const {
-    return endsWith( m_comparator.adjustString( source ), m_comparator.m_str );
-}
+        bool EndsWithMatcher::match( std::string const& source ) const {
+            return endsWith( m_comparator.adjustString( source ), m_comparator.m_str );
+        }
 
-RegexMatcher::RegexMatcher(std::string regex, CaseSensitive::Choice caseSensitivity): m_regex(std::move(regex)), m_caseSensitivity(caseSensitivity) {}
+        RegexMatcher::RegexMatcher(std::string regex, CaseSensitive::Choice caseSensitivity): m_regex(std::move(regex)), m_caseSensitivity(caseSensitivity) {}
 
-bool RegexMatcher::match(std::string const& matchee) const {
-    auto flags = std::regex::ECMAScript; // ECMAScript is the default syntax option anyway
-    if (m_caseSensitivity == CaseSensitive::Choice::No) {
-        flags |= std::regex::icase;
+        bool RegexMatcher::match(std::string const& matchee) const {
+            auto flags = std::regex::ECMAScript; // ECMAScript is the default syntax option anyway
+            if (m_caseSensitivity == CaseSensitive::Choice::No) {
+                flags |= std::regex::icase;
+            }
+            auto reg = std::regex(m_regex, flags);
+            return std::regex_match(matchee, reg);
+        }
+
+        std::string RegexMatcher::describe() const {
+            return "matches " + ::Catch::Detail::stringify(m_regex) + ((m_caseSensitivity == CaseSensitive::Choice::Yes)? " case sensitively" : " case insensitively");
+        }
+
+    } // namespace StdString
+
+    StdString::EqualsMatcher Equals( std::string const& str, CaseSensitive::Choice caseSensitivity ) {
+        return StdString::EqualsMatcher( StdString::CasedString( str, caseSensitivity) );
     }
-    auto reg = std::regex(m_regex, flags);
-    return std::regex_match(matchee, reg);
-}
+    StdString::ContainsMatcher Contains( std::string const& str, CaseSensitive::Choice caseSensitivity ) {
+        return StdString::ContainsMatcher( StdString::CasedString( str, caseSensitivity) );
+    }
+    StdString::EndsWithMatcher EndsWith( std::string const& str, CaseSensitive::Choice caseSensitivity ) {
+        return StdString::EndsWithMatcher( StdString::CasedString( str, caseSensitivity) );
+    }
+    StdString::StartsWithMatcher StartsWith( std::string const& str, CaseSensitive::Choice caseSensitivity ) {
+        return StdString::StartsWithMatcher( StdString::CasedString( str, caseSensitivity) );
+    }
 
-std::string RegexMatcher::describe() const {
-    return "matches " + ::Catch::Detail::stringify(m_regex) + ((m_caseSensitivity == CaseSensitive::Choice::Yes)? " case sensitively" : " case insensitively");
-}
-
-} // namespace StdString
-
-StdString::EqualsMatcher Equals( std::string const& str, CaseSensitive::Choice caseSensitivity ) {
-    return StdString::EqualsMatcher( StdString::CasedString( str, caseSensitivity) );
-}
-StdString::ContainsMatcher Contains( std::string const& str, CaseSensitive::Choice caseSensitivity ) {
-    return StdString::ContainsMatcher( StdString::CasedString( str, caseSensitivity) );
-}
-StdString::EndsWithMatcher EndsWith( std::string const& str, CaseSensitive::Choice caseSensitivity ) {
-    return StdString::EndsWithMatcher( StdString::CasedString( str, caseSensitivity) );
-}
-StdString::StartsWithMatcher StartsWith( std::string const& str, CaseSensitive::Choice caseSensitivity ) {
-    return StdString::StartsWithMatcher( StdString::CasedString( str, caseSensitivity) );
-}
-
-StdString::RegexMatcher Matches(std::string const& regex, CaseSensitive::Choice caseSensitivity) {
-    return StdString::RegexMatcher(regex, caseSensitivity);
-}
+    StdString::RegexMatcher Matches(std::string const& regex, CaseSensitive::Choice caseSensitivity) {
+        return StdString::RegexMatcher(regex, caseSensitivity);
+    }
 
 } // namespace Matchers
 } // namespace Catch
@@ -11745,7 +11808,7 @@ StdString::RegexMatcher Matches(std::string const& regex, CaseSensitive::Choice 
 // start catch_uncaught_exceptions.h
 
 namespace Catch {
-bool uncaught_exceptions();
+    bool uncaught_exceptions();
 } // end namespace Catch
 
 // end catch_uncaught_exceptions.h
@@ -11754,84 +11817,84 @@ bool uncaught_exceptions();
 
 namespace Catch {
 
-MessageInfo::MessageInfo(   StringRef const& _macroName,
-                            SourceLineInfo const& _lineInfo,
-                            ResultWas::OfType _type )
+    MessageInfo::MessageInfo(   StringRef const& _macroName,
+                                SourceLineInfo const& _lineInfo,
+                                ResultWas::OfType _type )
     :   macroName( _macroName ),
         lineInfo( _lineInfo ),
         type( _type ),
         sequence( ++globalCount )
-{}
+    {}
 
-bool MessageInfo::operator==( MessageInfo const& other ) const {
-    return sequence == other.sequence;
-}
-
-bool MessageInfo::operator<( MessageInfo const& other ) const {
-    return sequence < other.sequence;
-}
-
-// This may need protecting if threading support is added
-unsigned int MessageInfo::globalCount = 0;
-
-////////////////////////////////////////////////////////////////////////////
-
-Catch::MessageBuilder::MessageBuilder( StringRef const& macroName,
-                                       SourceLineInfo const& lineInfo,
-                                       ResultWas::OfType type )
-    :m_info(macroName, lineInfo, type) {}
-
-////////////////////////////////////////////////////////////////////////////
-
-ScopedMessage::ScopedMessage( MessageBuilder const& builder )
-    : m_info( builder.m_info ), m_moved()
-{
-    m_info.message = builder.m_stream.str();
-    getResultCapture().pushScopedMessage( m_info );
-}
-
-ScopedMessage::ScopedMessage( ScopedMessage&& old )
-    : m_info( old.m_info ), m_moved()
-{
-    old.m_moved = true;
-}
-
-ScopedMessage::~ScopedMessage() {
-    if ( !uncaught_exceptions() && !m_moved ){
-        getResultCapture().popScopedMessage(m_info);
+    bool MessageInfo::operator==( MessageInfo const& other ) const {
+        return sequence == other.sequence;
     }
-}
 
-Capturer::Capturer( StringRef macroName, SourceLineInfo const& lineInfo, ResultWas::OfType resultType, StringRef names ) {
-    auto trimmed = [&] (size_t start, size_t end) {
-        while (names[start] == ',' || isspace(static_cast<unsigned char>(names[start]))) {
-            ++start;
-        }
-        while (names[end] == ',' || isspace(static_cast<unsigned char>(names[end]))) {
-            --end;
-        }
-        return names.substr(start, end - start + 1);
-    };
-    auto skipq = [&] (size_t start, char quote) {
-        for (auto i = start + 1; i < names.size() ; ++i) {
-            if (names[i] == quote)
-                return i;
-            if (names[i] == '\\')
-                ++i;
-        }
-        CATCH_INTERNAL_ERROR("CAPTURE parsing encountered unmatched quote");
-    };
+    bool MessageInfo::operator<( MessageInfo const& other ) const {
+        return sequence < other.sequence;
+    }
 
-    size_t start = 0;
-    std::stack<char> openings;
-    for (size_t pos = 0; pos < names.size(); ++pos) {
-        char c = names[pos];
-        switch (c) {
+    // This may need protecting if threading support is added
+    unsigned int MessageInfo::globalCount = 0;
+
+    ////////////////////////////////////////////////////////////////////////////
+
+    Catch::MessageBuilder::MessageBuilder( StringRef const& macroName,
+                                           SourceLineInfo const& lineInfo,
+                                           ResultWas::OfType type )
+        :m_info(macroName, lineInfo, type) {}
+
+    ////////////////////////////////////////////////////////////////////////////
+
+    ScopedMessage::ScopedMessage( MessageBuilder const& builder )
+    : m_info( builder.m_info ), m_moved()
+    {
+        m_info.message = builder.m_stream.str();
+        getResultCapture().pushScopedMessage( m_info );
+    }
+
+    ScopedMessage::ScopedMessage( ScopedMessage&& old )
+    : m_info( old.m_info ), m_moved()
+    {
+        old.m_moved = true;
+    }
+
+    ScopedMessage::~ScopedMessage() {
+        if ( !uncaught_exceptions() && !m_moved ){
+            getResultCapture().popScopedMessage(m_info);
+        }
+    }
+
+    Capturer::Capturer( StringRef macroName, SourceLineInfo const& lineInfo, ResultWas::OfType resultType, StringRef names ) {
+        auto trimmed = [&] (size_t start, size_t end) {
+            while (names[start] == ',' || isspace(static_cast<unsigned char>(names[start]))) {
+                ++start;
+            }
+            while (names[end] == ',' || isspace(static_cast<unsigned char>(names[end]))) {
+                --end;
+            }
+            return names.substr(start, end - start + 1);
+        };
+        auto skipq = [&] (size_t start, char quote) {
+            for (auto i = start + 1; i < names.size() ; ++i) {
+                if (names[i] == quote)
+                    return i;
+                if (names[i] == '\\')
+                    ++i;
+            }
+            CATCH_INTERNAL_ERROR("CAPTURE parsing encountered unmatched quote");
+        };
+
+        size_t start = 0;
+        std::stack<char> openings;
+        for (size_t pos = 0; pos < names.size(); ++pos) {
+            char c = names[pos];
+            switch (c) {
             case '[':
             case '{':
             case '(':
-                // It is basically impossible to disambiguate between
-                // comparison and start of template args in this context
+            // It is basically impossible to disambiguate between
+            // comparison and start of template args in this context
 //            case '<':
                 openings.push(c);
                 break;
@@ -11852,27 +11915,27 @@ Capturer::Capturer( StringRef macroName, SourceLineInfo const& lineInfo, ResultW
                     m_messages.back().message += " := ";
                     start = pos;
                 }
+            }
+        }
+        assert(openings.empty() && "Mismatched openings");
+        m_messages.emplace_back(macroName, lineInfo, resultType);
+        m_messages.back().message = static_cast<std::string>(trimmed(start, names.size() - 1));
+        m_messages.back().message += " := ";
+    }
+    Capturer::~Capturer() {
+        if ( !uncaught_exceptions() ){
+            assert( m_captured == m_messages.size() );
+            for( size_t i = 0; i < m_captured; ++i  )
+                m_resultCapture.popScopedMessage( m_messages[i] );
         }
     }
-    assert(openings.empty() && "Mismatched openings");
-    m_messages.emplace_back(macroName, lineInfo, resultType);
-    m_messages.back().message = static_cast<std::string>(trimmed(start, names.size() - 1));
-    m_messages.back().message += " := ";
-}
-Capturer::~Capturer() {
-    if ( !uncaught_exceptions() ){
-        assert( m_captured == m_messages.size() );
-        for( size_t i = 0; i < m_captured; ++i  )
-            m_resultCapture.popScopedMessage( m_messages[i] );
-    }
-}
 
-void Capturer::captureValue( size_t index, std::string const& value ) {
-    assert( index < m_messages.size() );
-    m_messages[index].message += value;
-    m_resultCapture.pushScopedMessage( m_messages[index] );
-    m_captured++;
-}
+    void Capturer::captureValue( size_t index, std::string const& value ) {
+        assert( index < m_messages.size() );
+        m_messages[index].message += value;
+        m_resultCapture.pushScopedMessage( m_messages[index] );
+        m_captured++;
+    }
 
 } // end namespace Catch
 // end catch_message.cpp
@@ -11888,55 +11951,55 @@ void Capturer::captureValue( size_t index, std::string const& value ) {
 
 namespace Catch {
 
-class RedirectedStream {
-    std::ostream& m_originalStream;
-    std::ostream& m_redirectionStream;
-    std::streambuf* m_prevBuf;
+    class RedirectedStream {
+        std::ostream& m_originalStream;
+        std::ostream& m_redirectionStream;
+        std::streambuf* m_prevBuf;
 
-public:
-    RedirectedStream( std::ostream& originalStream, std::ostream& redirectionStream );
-    ~RedirectedStream();
-};
+    public:
+        RedirectedStream( std::ostream& originalStream, std::ostream& redirectionStream );
+        ~RedirectedStream();
+    };
 
-class RedirectedStdOut {
-    ReusableStringStream m_rss;
-    RedirectedStream m_cout;
-public:
-    RedirectedStdOut();
-    auto str() const -> std::string;
-};
+    class RedirectedStdOut {
+        ReusableStringStream m_rss;
+        RedirectedStream m_cout;
+    public:
+        RedirectedStdOut();
+        auto str() const -> std::string;
+    };
 
-// StdErr has two constituent streams in C++, std::cerr and std::clog
-// This means that we need to redirect 2 streams into 1 to keep proper
-// order of writes
-class RedirectedStdErr {
-    ReusableStringStream m_rss;
-    RedirectedStream m_cerr;
-    RedirectedStream m_clog;
-public:
-    RedirectedStdErr();
-    auto str() const -> std::string;
-};
+    // StdErr has two constituent streams in C++, std::cerr and std::clog
+    // This means that we need to redirect 2 streams into 1 to keep proper
+    // order of writes
+    class RedirectedStdErr {
+        ReusableStringStream m_rss;
+        RedirectedStream m_cerr;
+        RedirectedStream m_clog;
+    public:
+        RedirectedStdErr();
+        auto str() const -> std::string;
+    };
 
-class RedirectedStreams {
-public:
-    RedirectedStreams(RedirectedStreams const&) = delete;
-    RedirectedStreams& operator=(RedirectedStreams const&) = delete;
-    RedirectedStreams(RedirectedStreams&&) = delete;
-    RedirectedStreams& operator=(RedirectedStreams&&) = delete;
+    class RedirectedStreams {
+    public:
+        RedirectedStreams(RedirectedStreams const&) = delete;
+        RedirectedStreams& operator=(RedirectedStreams const&) = delete;
+        RedirectedStreams(RedirectedStreams&&) = delete;
+        RedirectedStreams& operator=(RedirectedStreams&&) = delete;
 
-    RedirectedStreams(std::string& redirectedCout, std::string& redirectedCerr);
-    ~RedirectedStreams();
-private:
-    std::string& m_redirectedCout;
-    std::string& m_redirectedCerr;
-    RedirectedStdOut m_redirectedStdOut;
-    RedirectedStdErr m_redirectedStdErr;
-};
+        RedirectedStreams(std::string& redirectedCout, std::string& redirectedCerr);
+        ~RedirectedStreams();
+    private:
+        std::string& m_redirectedCout;
+        std::string& m_redirectedCerr;
+        RedirectedStdOut m_redirectedStdOut;
+        RedirectedStdErr m_redirectedStdErr;
+    };
 
 #if defined(CATCH_CONFIG_NEW_CAPTURE)
 
-// Windows's implementation of std::tmpfile is terrible (it tries
+    // Windows's implementation of std::tmpfile is terrible (it tries
     // to create a file inside system folder, thus requiring elevated
     // privileges for the binary), so we have to use tmpnam(_s) and
     // create the file ourselves there.
@@ -11992,7 +12055,7 @@ private:
 #include <stdexcept>
 
 #if defined(CATCH_CONFIG_NEW_CAPTURE)
-#if defined(_MSC_VER)
+    #if defined(_MSC_VER)
     #include <io.h>      //_dup and _dup2
     #define dup _dup
     #define dup2 _dup2
@@ -12004,36 +12067,36 @@ private:
 
 namespace Catch {
 
-RedirectedStream::RedirectedStream( std::ostream& originalStream, std::ostream& redirectionStream )
+    RedirectedStream::RedirectedStream( std::ostream& originalStream, std::ostream& redirectionStream )
     :   m_originalStream( originalStream ),
         m_redirectionStream( redirectionStream ),
         m_prevBuf( m_originalStream.rdbuf() )
-{
-    m_originalStream.rdbuf( m_redirectionStream.rdbuf() );
-}
+    {
+        m_originalStream.rdbuf( m_redirectionStream.rdbuf() );
+    }
 
-RedirectedStream::~RedirectedStream() {
-    m_originalStream.rdbuf( m_prevBuf );
-}
+    RedirectedStream::~RedirectedStream() {
+        m_originalStream.rdbuf( m_prevBuf );
+    }
 
-RedirectedStdOut::RedirectedStdOut() : m_cout( Catch::cout(), m_rss.get() ) {}
-auto RedirectedStdOut::str() const -> std::string { return m_rss.str(); }
+    RedirectedStdOut::RedirectedStdOut() : m_cout( Catch::cout(), m_rss.get() ) {}
+    auto RedirectedStdOut::str() const -> std::string { return m_rss.str(); }
 
-RedirectedStdErr::RedirectedStdErr()
+    RedirectedStdErr::RedirectedStdErr()
     :   m_cerr( Catch::cerr(), m_rss.get() ),
         m_clog( Catch::clog(), m_rss.get() )
-{}
-auto RedirectedStdErr::str() const -> std::string { return m_rss.str(); }
+    {}
+    auto RedirectedStdErr::str() const -> std::string { return m_rss.str(); }
 
-RedirectedStreams::RedirectedStreams(std::string& redirectedCout, std::string& redirectedCerr)
+    RedirectedStreams::RedirectedStreams(std::string& redirectedCout, std::string& redirectedCerr)
     :   m_redirectedCout(redirectedCout),
         m_redirectedCerr(redirectedCerr)
-{}
+    {}
 
-RedirectedStreams::~RedirectedStreams() {
-    m_redirectedCout += m_redirectedStdOut.str();
-    m_redirectedCerr += m_redirectedStdErr.str();
-}
+    RedirectedStreams::~RedirectedStreams() {
+        m_redirectedCout += m_redirectedStdOut.str();
+        m_redirectedCerr += m_redirectedStdErr.str();
+    }
 
 #if defined(CATCH_CONFIG_NEW_CAPTURE)
 
@@ -12042,7 +12105,7 @@ RedirectedStreams::~RedirectedStreams() {
         if (tmpnam_s(m_buffer)) {
             CATCH_RUNTIME_ERROR("Could not get a temp filename");
         }
-        if (fopen_s(&m_file, m_buffer, "w")) {
+        if (fopen_s(&m_file, m_buffer, "w+")) {
             char buffer[100];
             if (strerror_s(buffer, errno)) {
                 CATCH_RUNTIME_ERROR("Could not translate errno to a string");
@@ -12114,7 +12177,7 @@ RedirectedStreams::~RedirectedStreams() {
 } // namespace Catch
 
 #if defined(CATCH_CONFIG_NEW_CAPTURE)
-#if defined(_MSC_VER)
+    #if defined(_MSC_VER)
     #undef dup
     #undef dup2
     #undef fileno
@@ -12128,14 +12191,14 @@ RedirectedStreams::~RedirectedStreams() {
 namespace Catch {
 
 #if !defined(CATCH_CONFIG_POLYFILL_ISNAN)
-bool isnan(float f) {
-    return std::isnan(f);
-}
-bool isnan(double d) {
-    return std::isnan(d);
-}
+    bool isnan(float f) {
+        return std::isnan(f);
+    }
+    bool isnan(double d) {
+        return std::isnan(d);
+    }
 #else
-// For now we only use this for embarcadero
+    // For now we only use this for embarcadero
     bool isnan(float f) {
         return std::_isnan(f);
     }
@@ -12156,12 +12219,12 @@ namespace {
 #pragma warning(push)
 #pragma warning(disable:4146) // we negate uint32 during the rotate
 #endif
-// Safe rotr implementation thanks to John Regehr
-uint32_t rotate_right(uint32_t val, uint32_t count) {
-    const uint32_t mask = 31;
-    count &= mask;
-    return (val >> count) | (val << (-count & mask));
-}
+        // Safe rotr implementation thanks to John Regehr
+        uint32_t rotate_right(uint32_t val, uint32_t count) {
+            const uint32_t mask = 31;
+            count &= mask;
+            return (val >> count) | (val << (-count & mask));
+        }
 
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -12169,43 +12232,43 @@ uint32_t rotate_right(uint32_t val, uint32_t count) {
 
 }
 
-SimplePcg32::SimplePcg32(result_type seed_) {
-    seed(seed_);
-}
-
-void SimplePcg32::seed(result_type seed_) {
-    m_state = 0;
-    (*this)();
-    m_state += seed_;
-    (*this)();
-}
-
-void SimplePcg32::discard(uint64_t skip) {
-    // We could implement this to run in O(log n) steps, but this
-    // should suffice for our use case.
-    for (uint64_t s = 0; s < skip; ++s) {
-        static_cast<void>((*this)());
+    SimplePcg32::SimplePcg32(result_type seed_) {
+        seed(seed_);
     }
-}
 
-SimplePcg32::result_type SimplePcg32::operator()() {
-    // prepare the output value
-    const uint32_t xorshifted = static_cast<uint32_t>(((m_state >> 18u) ^ m_state) >> 27u);
-    const auto output = rotate_right(xorshifted, m_state >> 59u);
+    void SimplePcg32::seed(result_type seed_) {
+        m_state = 0;
+        (*this)();
+        m_state += seed_;
+        (*this)();
+    }
 
-    // advance state
-    m_state = m_state * 6364136223846793005ULL + s_inc;
+    void SimplePcg32::discard(uint64_t skip) {
+        // We could implement this to run in O(log n) steps, but this
+        // should suffice for our use case.
+        for (uint64_t s = 0; s < skip; ++s) {
+            static_cast<void>((*this)());
+        }
+    }
 
-    return output;
-}
+    SimplePcg32::result_type SimplePcg32::operator()() {
+        // prepare the output value
+        const uint32_t xorshifted = static_cast<uint32_t>(((m_state >> 18u) ^ m_state) >> 27u);
+        const auto output = rotate_right(xorshifted, m_state >> 59u);
 
-bool operator==(SimplePcg32 const& lhs, SimplePcg32 const& rhs) {
-    return lhs.m_state == rhs.m_state;
-}
+        // advance state
+        m_state = m_state * 6364136223846793005ULL + s_inc;
 
-bool operator!=(SimplePcg32 const& lhs, SimplePcg32 const& rhs) {
-    return lhs.m_state != rhs.m_state;
-}
+        return output;
+    }
+
+    bool operator==(SimplePcg32 const& lhs, SimplePcg32 const& rhs) {
+        return lhs.m_state == rhs.m_state;
+    }
+
+    bool operator!=(SimplePcg32 const& lhs, SimplePcg32 const& rhs) {
+        return lhs.m_state != rhs.m_state;
+    }
 }
 // end catch_random_number_generator.cpp
 // start catch_registry_hub.cpp
@@ -12219,49 +12282,49 @@ bool operator!=(SimplePcg32 const& lhs, SimplePcg32 const& rhs) {
 
 namespace Catch {
 
-class TestCase;
-struct IConfig;
+    class TestCase;
+    struct IConfig;
 
-std::vector<TestCase> sortTests( IConfig const& config, std::vector<TestCase> const& unsortedTestCases );
+    std::vector<TestCase> sortTests( IConfig const& config, std::vector<TestCase> const& unsortedTestCases );
 
-bool isThrowSafe( TestCase const& testCase, IConfig const& config );
-bool matchTest( TestCase const& testCase, TestSpec const& testSpec, IConfig const& config );
+    bool isThrowSafe( TestCase const& testCase, IConfig const& config );
+    bool matchTest( TestCase const& testCase, TestSpec const& testSpec, IConfig const& config );
 
-void enforceNoDuplicateTestCases( std::vector<TestCase> const& functions );
+    void enforceNoDuplicateTestCases( std::vector<TestCase> const& functions );
 
-std::vector<TestCase> filterTests( std::vector<TestCase> const& testCases, TestSpec const& testSpec, IConfig const& config );
-std::vector<TestCase> const& getAllTestCasesSorted( IConfig const& config );
+    std::vector<TestCase> filterTests( std::vector<TestCase> const& testCases, TestSpec const& testSpec, IConfig const& config );
+    std::vector<TestCase> const& getAllTestCasesSorted( IConfig const& config );
 
-class TestRegistry : public ITestCaseRegistry {
-public:
-    virtual ~TestRegistry() = default;
+    class TestRegistry : public ITestCaseRegistry {
+    public:
+        virtual ~TestRegistry() = default;
 
-    virtual void registerTest( TestCase const& testCase );
+        virtual void registerTest( TestCase const& testCase );
 
-    std::vector<TestCase> const& getAllTests() const override;
-    std::vector<TestCase> const& getAllTestsSorted( IConfig const& config ) const override;
+        std::vector<TestCase> const& getAllTests() const override;
+        std::vector<TestCase> const& getAllTestsSorted( IConfig const& config ) const override;
 
-private:
-    std::vector<TestCase> m_functions;
-    mutable RunTests::InWhatOrder m_currentSortOrder = RunTests::InDeclarationOrder;
-    mutable std::vector<TestCase> m_sortedFunctions;
-    std::size_t m_unnamedCount = 0;
-    std::ios_base::Init m_ostreamInit; // Forces cout/ cerr to be initialised
-};
+    private:
+        std::vector<TestCase> m_functions;
+        mutable RunTests::InWhatOrder m_currentSortOrder = RunTests::InDeclarationOrder;
+        mutable std::vector<TestCase> m_sortedFunctions;
+        std::size_t m_unnamedCount = 0;
+        std::ios_base::Init m_ostreamInit; // Forces cout/ cerr to be initialised
+    };
 
-///////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
 
-class TestInvokerAsFunction : public ITestInvoker {
-    void(*m_testAsFunction)();
-public:
-    TestInvokerAsFunction( void(*testAsFunction)() ) noexcept;
+    class TestInvokerAsFunction : public ITestInvoker {
+        void(*m_testAsFunction)();
+    public:
+        TestInvokerAsFunction( void(*testAsFunction)() ) noexcept;
 
-    void invoke() const override;
-};
+        void invoke() const override;
+    };
 
-std::string extractClassName( StringRef const& classOrQualifiedMethodName );
+    std::string extractClassName( StringRef const& classOrQualifiedMethodName );
 
-///////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
 
 } // end namespace Catch
 
@@ -12272,24 +12335,24 @@ std::string extractClassName( StringRef const& classOrQualifiedMethodName );
 
 namespace Catch {
 
-class ReporterRegistry : public IReporterRegistry {
+    class ReporterRegistry : public IReporterRegistry {
 
-public:
+    public:
 
-    ~ReporterRegistry() override;
+        ~ReporterRegistry() override;
 
-    IStreamingReporterPtr create( std::string const& name, IConfigPtr const& config ) const override;
+        IStreamingReporterPtr create( std::string const& name, IConfigPtr const& config ) const override;
 
-    void registerReporter( std::string const& name, IReporterFactoryPtr const& factory );
-    void registerListener( IReporterFactoryPtr const& factory );
+        void registerReporter( std::string const& name, IReporterFactoryPtr const& factory );
+        void registerListener( IReporterFactoryPtr const& factory );
 
-    FactoryMap const& getFactories() const override;
-    Listeners const& getListeners() const override;
+        FactoryMap const& getFactories() const override;
+        Listeners const& getListeners() const override;
 
-private:
-    FactoryMap m_factories;
-    Listeners m_listeners;
-};
+    private:
+        FactoryMap m_factories;
+        Listeners m_listeners;
+    };
 }
 
 // end catch_reporter_registry.h
@@ -12301,12 +12364,12 @@ private:
 
 namespace Catch {
 
-struct TagAlias {
-    TagAlias(std::string const& _tag, SourceLineInfo _lineInfo);
+    struct TagAlias {
+        TagAlias(std::string const& _tag, SourceLineInfo _lineInfo);
 
-    std::string tag;
-    SourceLineInfo lineInfo;
-};
+        std::string tag;
+        SourceLineInfo lineInfo;
+    };
 
 } // end namespace Catch
 
@@ -12315,16 +12378,16 @@ struct TagAlias {
 
 namespace Catch {
 
-class TagAliasRegistry : public ITagAliasRegistry {
-public:
-    ~TagAliasRegistry() override;
-    TagAlias const* find( std::string const& alias ) const override;
-    std::string expandAliases( std::string const& unexpandedTestSpec ) const override;
-    void add( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo );
+    class TagAliasRegistry : public ITagAliasRegistry {
+    public:
+        ~TagAliasRegistry() override;
+        TagAlias const* find( std::string const& alias ) const override;
+        std::string expandAliases( std::string const& unexpandedTestSpec ) const override;
+        void add( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo );
 
-private:
-    std::map<std::string, TagAlias> m_registry;
-};
+    private:
+        std::map<std::string, TagAlias> m_registry;
+    };
 
 } // end namespace Catch
 
@@ -12336,15 +12399,15 @@ private:
 
 namespace Catch {
 
-class StartupExceptionRegistry {
+    class StartupExceptionRegistry {
 #if !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
-public:
-    void add(std::exception_ptr const& exception) noexcept;
-    std::vector<std::exception_ptr> const& getExceptions() const noexcept;
-private:
-    std::vector<std::exception_ptr> m_exceptions;
+    public:
+        void add(std::exception_ptr const& exception) noexcept;
+        std::vector<std::exception_ptr> const& getExceptions() const noexcept;
+    private:
+        std::vector<std::exception_ptr> m_exceptions;
 #endif
-};
+    };
 
 } // end namespace Catch
 
@@ -12353,114 +12416,114 @@ private:
 
 namespace Catch {
 
-struct ISingleton {
-    virtual ~ISingleton();
-};
+    struct ISingleton {
+        virtual ~ISingleton();
+    };
 
-void addSingleton( ISingleton* singleton );
-void cleanupSingletons();
+    void addSingleton( ISingleton* singleton );
+    void cleanupSingletons();
 
-template<typename SingletonImplT, typename InterfaceT = SingletonImplT, typename MutableInterfaceT = InterfaceT>
-class Singleton : SingletonImplT, public ISingleton {
+    template<typename SingletonImplT, typename InterfaceT = SingletonImplT, typename MutableInterfaceT = InterfaceT>
+    class Singleton : SingletonImplT, public ISingleton {
 
-    static auto getInternal() -> Singleton* {
-        static Singleton* s_instance = nullptr;
-        if( !s_instance ) {
-            s_instance = new Singleton;
-            addSingleton( s_instance );
+        static auto getInternal() -> Singleton* {
+            static Singleton* s_instance = nullptr;
+            if( !s_instance ) {
+                s_instance = new Singleton;
+                addSingleton( s_instance );
+            }
+            return s_instance;
         }
-        return s_instance;
-    }
 
-public:
-    static auto get() -> InterfaceT const& {
-        return *getInternal();
-    }
-    static auto getMutable() -> MutableInterfaceT& {
-        return *getInternal();
-    }
-};
+    public:
+        static auto get() -> InterfaceT const& {
+            return *getInternal();
+        }
+        static auto getMutable() -> MutableInterfaceT& {
+            return *getInternal();
+        }
+    };
 
 } // namespace Catch
 
 // end catch_singletons.hpp
 namespace Catch {
 
-namespace {
+    namespace {
 
-class RegistryHub : public IRegistryHub, public IMutableRegistryHub,
-                    private NonCopyable {
+        class RegistryHub : public IRegistryHub, public IMutableRegistryHub,
+                            private NonCopyable {
 
-public: // IRegistryHub
-    RegistryHub() = default;
-    IReporterRegistry const& getReporterRegistry() const override {
-        return m_reporterRegistry;
-    }
-    ITestCaseRegistry const& getTestCaseRegistry() const override {
-        return m_testCaseRegistry;
-    }
-    IExceptionTranslatorRegistry const& getExceptionTranslatorRegistry() const override {
-        return m_exceptionTranslatorRegistry;
-    }
-    ITagAliasRegistry const& getTagAliasRegistry() const override {
-        return m_tagAliasRegistry;
-    }
-    StartupExceptionRegistry const& getStartupExceptionRegistry() const override {
-        return m_exceptionRegistry;
-    }
+        public: // IRegistryHub
+            RegistryHub() = default;
+            IReporterRegistry const& getReporterRegistry() const override {
+                return m_reporterRegistry;
+            }
+            ITestCaseRegistry const& getTestCaseRegistry() const override {
+                return m_testCaseRegistry;
+            }
+            IExceptionTranslatorRegistry const& getExceptionTranslatorRegistry() const override {
+                return m_exceptionTranslatorRegistry;
+            }
+            ITagAliasRegistry const& getTagAliasRegistry() const override {
+                return m_tagAliasRegistry;
+            }
+            StartupExceptionRegistry const& getStartupExceptionRegistry() const override {
+                return m_exceptionRegistry;
+            }
 
-public: // IMutableRegistryHub
-    void registerReporter( std::string const& name, IReporterFactoryPtr const& factory ) override {
-        m_reporterRegistry.registerReporter( name, factory );
-    }
-    void registerListener( IReporterFactoryPtr const& factory ) override {
-        m_reporterRegistry.registerListener( factory );
-    }
-    void registerTest( TestCase const& testInfo ) override {
-        m_testCaseRegistry.registerTest( testInfo );
-    }
-    void registerTranslator( const IExceptionTranslator* translator ) override {
-        m_exceptionTranslatorRegistry.registerTranslator( translator );
-    }
-    void registerTagAlias( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo ) override {
-        m_tagAliasRegistry.add( alias, tag, lineInfo );
-    }
-    void registerStartupException() noexcept override {
+        public: // IMutableRegistryHub
+            void registerReporter( std::string const& name, IReporterFactoryPtr const& factory ) override {
+                m_reporterRegistry.registerReporter( name, factory );
+            }
+            void registerListener( IReporterFactoryPtr const& factory ) override {
+                m_reporterRegistry.registerListener( factory );
+            }
+            void registerTest( TestCase const& testInfo ) override {
+                m_testCaseRegistry.registerTest( testInfo );
+            }
+            void registerTranslator( const IExceptionTranslator* translator ) override {
+                m_exceptionTranslatorRegistry.registerTranslator( translator );
+            }
+            void registerTagAlias( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo ) override {
+                m_tagAliasRegistry.add( alias, tag, lineInfo );
+            }
+            void registerStartupException() noexcept override {
 #if !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
-        m_exceptionRegistry.add(std::current_exception());
+                m_exceptionRegistry.add(std::current_exception());
 #else
-        CATCH_INTERNAL_ERROR("Attempted to register active exception under CATCH_CONFIG_DISABLE_EXCEPTIONS!");
+                CATCH_INTERNAL_ERROR("Attempted to register active exception under CATCH_CONFIG_DISABLE_EXCEPTIONS!");
 #endif
+            }
+            IMutableEnumValuesRegistry& getMutableEnumValuesRegistry() override {
+                return m_enumValuesRegistry;
+            }
+
+        private:
+            TestRegistry m_testCaseRegistry;
+            ReporterRegistry m_reporterRegistry;
+            ExceptionTranslatorRegistry m_exceptionTranslatorRegistry;
+            TagAliasRegistry m_tagAliasRegistry;
+            StartupExceptionRegistry m_exceptionRegistry;
+            Detail::EnumValuesRegistry m_enumValuesRegistry;
+        };
     }
-    IMutableEnumValuesRegistry& getMutableEnumValuesRegistry() override {
-        return m_enumValuesRegistry;
+
+    using RegistryHubSingleton = Singleton<RegistryHub, IRegistryHub, IMutableRegistryHub>;
+
+    IRegistryHub const& getRegistryHub() {
+        return RegistryHubSingleton::get();
     }
-
-private:
-    TestRegistry m_testCaseRegistry;
-    ReporterRegistry m_reporterRegistry;
-    ExceptionTranslatorRegistry m_exceptionTranslatorRegistry;
-    TagAliasRegistry m_tagAliasRegistry;
-    StartupExceptionRegistry m_exceptionRegistry;
-    Detail::EnumValuesRegistry m_enumValuesRegistry;
-};
-}
-
-using RegistryHubSingleton = Singleton<RegistryHub, IRegistryHub, IMutableRegistryHub>;
-
-IRegistryHub const& getRegistryHub() {
-    return RegistryHubSingleton::get();
-}
-IMutableRegistryHub& getMutableRegistryHub() {
-    return RegistryHubSingleton::getMutable();
-}
-void cleanUp() {
-    cleanupSingletons();
-    cleanUpContext();
-}
-std::string translateActiveException() {
-    return getRegistryHub().getExceptionTranslatorRegistry().translateActiveException();
-}
+    IMutableRegistryHub& getMutableRegistryHub() {
+        return RegistryHubSingleton::getMutable();
+    }
+    void cleanUp() {
+        cleanupSingletons();
+        cleanUpContext();
+    }
+    std::string translateActiveException() {
+        return getRegistryHub().getExceptionTranslatorRegistry().translateActiveException();
+    }
 
 } // end namespace Catch
 // end catch_registry_hub.cpp
@@ -12468,28 +12531,28 @@ std::string translateActiveException() {
 
 namespace Catch {
 
-ReporterRegistry::~ReporterRegistry() = default;
+    ReporterRegistry::~ReporterRegistry() = default;
 
-IStreamingReporterPtr ReporterRegistry::create( std::string const& name, IConfigPtr const& config ) const {
-    auto it =  m_factories.find( name );
-    if( it == m_factories.end() )
-        return nullptr;
-    return it->second->create( ReporterConfig( config ) );
-}
+    IStreamingReporterPtr ReporterRegistry::create( std::string const& name, IConfigPtr const& config ) const {
+        auto it =  m_factories.find( name );
+        if( it == m_factories.end() )
+            return nullptr;
+        return it->second->create( ReporterConfig( config ) );
+    }
 
-void ReporterRegistry::registerReporter( std::string const& name, IReporterFactoryPtr const& factory ) {
-    m_factories.emplace(name, factory);
-}
-void ReporterRegistry::registerListener( IReporterFactoryPtr const& factory ) {
-    m_listeners.push_back( factory );
-}
+    void ReporterRegistry::registerReporter( std::string const& name, IReporterFactoryPtr const& factory ) {
+        m_factories.emplace(name, factory);
+    }
+    void ReporterRegistry::registerListener( IReporterFactoryPtr const& factory ) {
+        m_listeners.push_back( factory );
+    }
 
-IReporterRegistry::FactoryMap const& ReporterRegistry::getFactories() const {
-    return m_factories;
-}
-IReporterRegistry::Listeners const& ReporterRegistry::getListeners() const {
-    return m_listeners;
-}
+    IReporterRegistry::FactoryMap const& ReporterRegistry::getFactories() const {
+        return m_factories;
+    }
+    IReporterRegistry::Listeners const& ReporterRegistry::getListeners() const {
+        return m_listeners;
+    }
 
 }
 // end catch_reporter_registry.cpp
@@ -12497,19 +12560,19 @@ IReporterRegistry::Listeners const& ReporterRegistry::getListeners() const {
 
 namespace Catch {
 
-bool isOk( ResultWas::OfType resultType ) {
-    return ( resultType & ResultWas::FailureBit ) == 0;
-}
-bool isJustInfo( int flags ) {
-    return flags == ResultWas::Info;
-}
+    bool isOk( ResultWas::OfType resultType ) {
+        return ( resultType & ResultWas::FailureBit ) == 0;
+    }
+    bool isJustInfo( int flags ) {
+        return flags == ResultWas::Info;
+    }
 
-ResultDisposition::Flags operator | ( ResultDisposition::Flags lhs, ResultDisposition::Flags rhs ) {
-    return static_cast<ResultDisposition::Flags>( static_cast<int>( lhs ) | static_cast<int>( rhs ) );
-}
+    ResultDisposition::Flags operator | ( ResultDisposition::Flags lhs, ResultDisposition::Flags rhs ) {
+        return static_cast<ResultDisposition::Flags>( static_cast<int>( lhs ) | static_cast<int>( rhs ) );
+    }
 
-bool shouldContinueOnFailure( int flags )    { return ( flags & ResultDisposition::ContinueOnFailure ) != 0; }
-bool shouldSuppressFailure( int flags )      { return ( flags & ResultDisposition::SuppressFail ) != 0; }
+    bool shouldContinueOnFailure( int flags )    { return ( flags & ResultDisposition::ContinueOnFailure ) != 0; }
+    bool shouldSuppressFailure( int flags )      { return ( flags & ResultDisposition::SuppressFail ) != 0; }
 
 } // end namespace Catch
 // end catch_result_type.cpp
@@ -12521,261 +12584,301 @@ bool shouldSuppressFailure( int flags )      { return ( flags & ResultDispositio
 
 namespace Catch {
 
-namespace Generators {
-struct GeneratorTracker : TestCaseTracking::TrackerBase, IGeneratorTracker {
-    GeneratorBasePtr m_generator;
+    namespace Generators {
+        struct GeneratorTracker : TestCaseTracking::TrackerBase, IGeneratorTracker {
+            GeneratorBasePtr m_generator;
 
-    GeneratorTracker( TestCaseTracking::NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent )
-        :   TrackerBase( nameAndLocation, ctx, parent )
-    {}
-    ~GeneratorTracker();
+            GeneratorTracker( TestCaseTracking::NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent )
+            :   TrackerBase( nameAndLocation, ctx, parent )
+            {}
+            ~GeneratorTracker();
 
-    static GeneratorTracker& acquire( TrackerContext& ctx, TestCaseTracking::NameAndLocation const& nameAndLocation ) {
-        std::shared_ptr<GeneratorTracker> tracker;
+            static GeneratorTracker& acquire( TrackerContext& ctx, TestCaseTracking::NameAndLocation const& nameAndLocation ) {
+                std::shared_ptr<GeneratorTracker> tracker;
 
-        ITracker& currentTracker = ctx.currentTracker();
-        // Under specific circumstances, the generator we want
-        // to acquire is also the current tracker. If this is
-        // the case, we have to avoid looking through current
-        // tracker's children, and instead return the current
-        // tracker.
-        // A case where this check is important is e.g.
-        //     for (int i = 0; i < 5; ++i) {
-        //         int n = GENERATE(1, 2);
-        //     }
-        //
-        // without it, the code above creates 5 nested generators.
-        if (currentTracker.nameAndLocation() == nameAndLocation) {
-            auto thisTracker = currentTracker.parent().findChild(nameAndLocation);
-            assert(thisTracker);
-            assert(thisTracker->isGeneratorTracker());
-            tracker = std::static_pointer_cast<GeneratorTracker>(thisTracker);
-        } else if ( TestCaseTracking::ITrackerPtr childTracker = currentTracker.findChild( nameAndLocation ) ) {
-            assert( childTracker );
-            assert( childTracker->isGeneratorTracker() );
-            tracker = std::static_pointer_cast<GeneratorTracker>( childTracker );
-        } else {
-            tracker = std::make_shared<GeneratorTracker>( nameAndLocation, ctx, &currentTracker );
-            currentTracker.addChild( tracker );
-        }
+                ITracker& currentTracker = ctx.currentTracker();
+                // Under specific circumstances, the generator we want
+                // to acquire is also the current tracker. If this is
+                // the case, we have to avoid looking through current
+                // tracker's children, and instead return the current
+                // tracker.
+                // A case where this check is important is e.g.
+                //     for (int i = 0; i < 5; ++i) {
+                //         int n = GENERATE(1, 2);
+                //     }
+                //
+                // without it, the code above creates 5 nested generators.
+                if (currentTracker.nameAndLocation() == nameAndLocation) {
+                    auto thisTracker = currentTracker.parent().findChild(nameAndLocation);
+                    assert(thisTracker);
+                    assert(thisTracker->isGeneratorTracker());
+                    tracker = std::static_pointer_cast<GeneratorTracker>(thisTracker);
+                } else if ( TestCaseTracking::ITrackerPtr childTracker = currentTracker.findChild( nameAndLocation ) ) {
+                    assert( childTracker );
+                    assert( childTracker->isGeneratorTracker() );
+                    tracker = std::static_pointer_cast<GeneratorTracker>( childTracker );
+                } else {
+                    tracker = std::make_shared<GeneratorTracker>( nameAndLocation, ctx, &currentTracker );
+                    currentTracker.addChild( tracker );
+                }
 
-        if( !tracker->isComplete() ) {
-            tracker->open();
-        }
+                if( !tracker->isComplete() ) {
+                    tracker->open();
+                }
 
-        return *tracker;
+                return *tracker;
+            }
+
+            // TrackerBase interface
+            bool isGeneratorTracker() const override { return true; }
+            auto hasGenerator() const -> bool override {
+                return !!m_generator;
+            }
+            void close() override {
+                TrackerBase::close();
+                // If a generator has a child (it is followed by a section)
+                // and none of its children have started, then we must wait
+                // until later to start consuming its values.
+                // This catches cases where `GENERATE` is placed between two
+                // `SECTION`s.
+                // **The check for m_children.empty cannot be removed**.
+                // doing so would break `GENERATE` _not_ followed by `SECTION`s.
+                const bool should_wait_for_child = [&]() {
+                    // No children -> nobody to wait for
+                    if ( m_children.empty() ) {
+                        return false;
+                    }
+                    // If at least one child started executing, don't wait
+                    if ( std::find_if(
+                             m_children.begin(),
+                             m_children.end(),
+                             []( TestCaseTracking::ITrackerPtr tracker ) {
+                                 return tracker->hasStarted();
+                             } ) != m_children.end() ) {
+                        return false;
+                    }
+
+                    // No children have started. We need to check if they _can_
+                    // start, and thus we should wait for them, or they cannot
+                    // start (due to filters), and we shouldn't wait for them
+                    auto* parent = m_parent;
+                    // This is safe: there is always at least one section
+                    // tracker in a test case tracking tree
+                    while ( !parent->isSectionTracker() ) {
+                        parent = &( parent->parent() );
+                    }
+                    assert( parent &&
+                            "Missing root (test case) level section" );
+
+                    auto const& parentSection =
+                        static_cast<SectionTracker&>( *parent );
+                    auto const& filters = parentSection.getFilters();
+                    // No filters -> no restrictions on running sections
+                    if ( filters.empty() ) {
+                        return true;
+                    }
+
+                    for ( auto const& child : m_children ) {
+                        if ( child->isSectionTracker() &&
+                             std::find( filters.begin(),
+                                        filters.end(),
+                                        static_cast<SectionTracker&>( *child )
+                                            .trimmedName() ) !=
+                                 filters.end() ) {
+                            return true;
+                        }
+                    }
+                    return false;
+                }();
+
+                // This check is a bit tricky, because m_generator->next()
+                // has a side-effect, where it consumes generator's current
+                // value, but we do not want to invoke the side-effect if
+                // this generator is still waiting for any child to start.
+                if ( should_wait_for_child ||
+                     ( m_runState == CompletedSuccessfully &&
+                       m_generator->next() ) ) {
+                    m_children.clear();
+                    m_runState = Executing;
+                }
+            }
+
+            // IGeneratorTracker interface
+            auto getGenerator() const -> GeneratorBasePtr const& override {
+                return m_generator;
+            }
+            void setGenerator( GeneratorBasePtr&& generator ) override {
+                m_generator = std::move( generator );
+            }
+        };
+        GeneratorTracker::~GeneratorTracker() {}
     }
 
-    // TrackerBase interface
-    bool isGeneratorTracker() const override { return true; }
-    auto hasGenerator() const -> bool override {
-        return !!m_generator;
-    }
-    void close() override {
-        TrackerBase::close();
-        // If a generator has a child (it is followed by a section)
-        // and none of its children have started, then we must wait
-        // until later to start consuming its values.
-        // This catches cases where `GENERATE` is placed between two
-        // `SECTION`s.
-        // **The check for m_children.empty cannot be removed**.
-        // doing so would break `GENERATE` _not_ followed by `SECTION`s.
-        const bool should_wait_for_child =
-            !m_children.empty() &&
-                std::find_if( m_children.begin(),
-                              m_children.end(),
-                              []( TestCaseTracking::ITrackerPtr tracker ) {
-                                  return tracker->hasStarted();
-                              } ) == m_children.end();
-
-        // This check is a bit tricky, because m_generator->next()
-        // has a side-effect, where it consumes generator's current
-        // value, but we do not want to invoke the side-effect if
-        // this generator is still waiting for any child to start.
-        if ( should_wait_for_child ||
-            ( m_runState == CompletedSuccessfully &&
-                m_generator->next() ) ) {
-            m_children.clear();
-            m_runState = Executing;
-        }
-    }
-
-    // IGeneratorTracker interface
-    auto getGenerator() const -> GeneratorBasePtr const& override {
-        return m_generator;
-    }
-    void setGenerator( GeneratorBasePtr&& generator ) override {
-        m_generator = std::move( generator );
-    }
-};
-GeneratorTracker::~GeneratorTracker() {}
-}
-
-RunContext::RunContext(IConfigPtr const& _config, IStreamingReporterPtr&& reporter)
+    RunContext::RunContext(IConfigPtr const& _config, IStreamingReporterPtr&& reporter)
     :   m_runInfo(_config->name()),
         m_context(getCurrentMutableContext()),
         m_config(_config),
         m_reporter(std::move(reporter)),
         m_lastAssertionInfo{ StringRef(), SourceLineInfo("",0), StringRef(), ResultDisposition::Normal },
         m_includeSuccessfulResults( m_config->includeSuccessfulResults() || m_reporter->getPreferences().shouldReportAllAssertions )
-{
-    m_context.setRunner(this);
-    m_context.setConfig(m_config);
-    m_context.setResultCapture(this);
-    m_reporter->testRunStarting(m_runInfo);
-}
-
-RunContext::~RunContext() {
-    m_reporter->testRunEnded(TestRunStats(m_runInfo, m_totals, aborting()));
-}
-
-void RunContext::testGroupStarting(std::string const& testSpec, std::size_t groupIndex, std::size_t groupsCount) {
-    m_reporter->testGroupStarting(GroupInfo(testSpec, groupIndex, groupsCount));
-}
-
-void RunContext::testGroupEnded(std::string const& testSpec, Totals const& totals, std::size_t groupIndex, std::size_t groupsCount) {
-    m_reporter->testGroupEnded(TestGroupStats(GroupInfo(testSpec, groupIndex, groupsCount), totals, aborting()));
-}
-
-Totals RunContext::runTest(TestCase const& testCase) {
-    Totals prevTotals = m_totals;
-
-    std::string redirectedCout;
-    std::string redirectedCerr;
-
-    auto const& testInfo = testCase.getTestCaseInfo();
-
-    m_reporter->testCaseStarting(testInfo);
-
-    m_activeTestCase = &testCase;
-
-    ITracker& rootTracker = m_trackerContext.startRun();
-    assert(rootTracker.isSectionTracker());
-    static_cast<SectionTracker&>(rootTracker).addInitialFilters(m_config->getSectionsToRun());
-    do {
-        m_trackerContext.startCycle();
-        m_testCaseTracker = &SectionTracker::acquire(m_trackerContext, TestCaseTracking::NameAndLocation(testInfo.name, testInfo.lineInfo));
-        runCurrentTest(redirectedCout, redirectedCerr);
-    } while (!m_testCaseTracker->isSuccessfullyCompleted() && !aborting());
-
-    Totals deltaTotals = m_totals.delta(prevTotals);
-    if (testInfo.expectedToFail() && deltaTotals.testCases.passed > 0) {
-        deltaTotals.assertions.failed++;
-        deltaTotals.testCases.passed--;
-        deltaTotals.testCases.failed++;
-    }
-    m_totals.testCases += deltaTotals.testCases;
-    m_reporter->testCaseEnded(TestCaseStats(testInfo,
-                                            deltaTotals,
-                                            redirectedCout,
-                                            redirectedCerr,
-                                            aborting()));
-
-    m_activeTestCase = nullptr;
-    m_testCaseTracker = nullptr;
-
-    return deltaTotals;
-}
-
-IConfigPtr RunContext::config() const {
-    return m_config;
-}
-
-IStreamingReporter& RunContext::reporter() const {
-    return *m_reporter;
-}
-
-void RunContext::assertionEnded(AssertionResult const & result) {
-    if (result.getResultType() == ResultWas::Ok) {
-        m_totals.assertions.passed++;
-        m_lastAssertionPassed = true;
-    } else if (!result.isOk()) {
-        m_lastAssertionPassed = false;
-        if( m_activeTestCase->getTestCaseInfo().okToFail() )
-            m_totals.assertions.failedButOk++;
-        else
-            m_totals.assertions.failed++;
-    }
-    else {
-        m_lastAssertionPassed = true;
+    {
+        m_context.setRunner(this);
+        m_context.setConfig(m_config);
+        m_context.setResultCapture(this);
+        m_reporter->testRunStarting(m_runInfo);
     }
 
-    // We have no use for the return value (whether messages should be cleared), because messages were made scoped
-    // and should be let to clear themselves out.
-    static_cast<void>(m_reporter->assertionEnded(AssertionStats(result, m_messages, m_totals)));
+    RunContext::~RunContext() {
+        m_reporter->testRunEnded(TestRunStats(m_runInfo, m_totals, aborting()));
+    }
 
-    if (result.getResultType() != ResultWas::Warning)
+    void RunContext::testGroupStarting(std::string const& testSpec, std::size_t groupIndex, std::size_t groupsCount) {
+        m_reporter->testGroupStarting(GroupInfo(testSpec, groupIndex, groupsCount));
+    }
+
+    void RunContext::testGroupEnded(std::string const& testSpec, Totals const& totals, std::size_t groupIndex, std::size_t groupsCount) {
+        m_reporter->testGroupEnded(TestGroupStats(GroupInfo(testSpec, groupIndex, groupsCount), totals, aborting()));
+    }
+
+    Totals RunContext::runTest(TestCase const& testCase) {
+        Totals prevTotals = m_totals;
+
+        std::string redirectedCout;
+        std::string redirectedCerr;
+
+        auto const& testInfo = testCase.getTestCaseInfo();
+
+        m_reporter->testCaseStarting(testInfo);
+
+        m_activeTestCase = &testCase;
+
+        ITracker& rootTracker = m_trackerContext.startRun();
+        assert(rootTracker.isSectionTracker());
+        static_cast<SectionTracker&>(rootTracker).addInitialFilters(m_config->getSectionsToRun());
+        do {
+            m_trackerContext.startCycle();
+            m_testCaseTracker = &SectionTracker::acquire(m_trackerContext, TestCaseTracking::NameAndLocation(testInfo.name, testInfo.lineInfo));
+            runCurrentTest(redirectedCout, redirectedCerr);
+        } while (!m_testCaseTracker->isSuccessfullyCompleted() && !aborting());
+
+        Totals deltaTotals = m_totals.delta(prevTotals);
+        if (testInfo.expectedToFail() && deltaTotals.testCases.passed > 0) {
+            deltaTotals.assertions.failed++;
+            deltaTotals.testCases.passed--;
+            deltaTotals.testCases.failed++;
+        }
+        m_totals.testCases += deltaTotals.testCases;
+        m_reporter->testCaseEnded(TestCaseStats(testInfo,
+                                  deltaTotals,
+                                  redirectedCout,
+                                  redirectedCerr,
+                                  aborting()));
+
+        m_activeTestCase = nullptr;
+        m_testCaseTracker = nullptr;
+
+        return deltaTotals;
+    }
+
+    IConfigPtr RunContext::config() const {
+        return m_config;
+    }
+
+    IStreamingReporter& RunContext::reporter() const {
+        return *m_reporter;
+    }
+
+    void RunContext::assertionEnded(AssertionResult const & result) {
+        if (result.getResultType() == ResultWas::Ok) {
+            m_totals.assertions.passed++;
+            m_lastAssertionPassed = true;
+        } else if (!result.isOk()) {
+            m_lastAssertionPassed = false;
+            if( m_activeTestCase->getTestCaseInfo().okToFail() )
+                m_totals.assertions.failedButOk++;
+            else
+                m_totals.assertions.failed++;
+        }
+        else {
+            m_lastAssertionPassed = true;
+        }
+
+        // We have no use for the return value (whether messages should be cleared), because messages were made scoped
+        // and should be let to clear themselves out.
+        static_cast<void>(m_reporter->assertionEnded(AssertionStats(result, m_messages, m_totals)));
+
+        if (result.getResultType() != ResultWas::Warning)
+            m_messageScopes.clear();
+
+        // Reset working state
+        resetAssertionInfo();
+        m_lastResult = result;
+    }
+    void RunContext::resetAssertionInfo() {
+        m_lastAssertionInfo.macroName = StringRef();
+        m_lastAssertionInfo.capturedExpression = "{Unknown expression after the reported line}"_sr;
+    }
+
+    bool RunContext::sectionStarted(SectionInfo const & sectionInfo, Counts & assertions) {
+        ITracker& sectionTracker = SectionTracker::acquire(m_trackerContext, TestCaseTracking::NameAndLocation(sectionInfo.name, sectionInfo.lineInfo));
+        if (!sectionTracker.isOpen())
+            return false;
+        m_activeSections.push_back(&sectionTracker);
+
+        m_lastAssertionInfo.lineInfo = sectionInfo.lineInfo;
+
+        m_reporter->sectionStarting(sectionInfo);
+
+        assertions = m_totals.assertions;
+
+        return true;
+    }
+    auto RunContext::acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker& {
+        using namespace Generators;
+        GeneratorTracker& tracker = GeneratorTracker::acquire(m_trackerContext,
+                                                              TestCaseTracking::NameAndLocation( static_cast<std::string>(generatorName), lineInfo ) );
+        m_lastAssertionInfo.lineInfo = lineInfo;
+        return tracker;
+    }
+
+    bool RunContext::testForMissingAssertions(Counts& assertions) {
+        if (assertions.total() != 0)
+            return false;
+        if (!m_config->warnAboutMissingAssertions())
+            return false;
+        if (m_trackerContext.currentTracker().hasChildren())
+            return false;
+        m_totals.assertions.failed++;
+        assertions.failed++;
+        return true;
+    }
+
+    void RunContext::sectionEnded(SectionEndInfo const & endInfo) {
+        Counts assertions = m_totals.assertions - endInfo.prevAssertions;
+        bool missingAssertions = testForMissingAssertions(assertions);
+
+        if (!m_activeSections.empty()) {
+            m_activeSections.back()->close();
+            m_activeSections.pop_back();
+        }
+
+        m_reporter->sectionEnded(SectionStats(endInfo.sectionInfo, assertions, endInfo.durationInSeconds, missingAssertions));
+        m_messages.clear();
         m_messageScopes.clear();
-
-    // Reset working state
-    resetAssertionInfo();
-    m_lastResult = result;
-}
-void RunContext::resetAssertionInfo() {
-    m_lastAssertionInfo.macroName = StringRef();
-    m_lastAssertionInfo.capturedExpression = "{Unknown expression after the reported line}"_sr;
-}
-
-bool RunContext::sectionStarted(SectionInfo const & sectionInfo, Counts & assertions) {
-    ITracker& sectionTracker = SectionTracker::acquire(m_trackerContext, TestCaseTracking::NameAndLocation(sectionInfo.name, sectionInfo.lineInfo));
-    if (!sectionTracker.isOpen())
-        return false;
-    m_activeSections.push_back(&sectionTracker);
-
-    m_lastAssertionInfo.lineInfo = sectionInfo.lineInfo;
-
-    m_reporter->sectionStarting(sectionInfo);
-
-    assertions = m_totals.assertions;
-
-    return true;
-}
-auto RunContext::acquireGeneratorTracker( StringRef generatorName, SourceLineInfo const& lineInfo ) -> IGeneratorTracker& {
-    using namespace Generators;
-    GeneratorTracker& tracker = GeneratorTracker::acquire(m_trackerContext,
-                                                          TestCaseTracking::NameAndLocation( static_cast<std::string>(generatorName), lineInfo ) );
-    m_lastAssertionInfo.lineInfo = lineInfo;
-    return tracker;
-}
-
-bool RunContext::testForMissingAssertions(Counts& assertions) {
-    if (assertions.total() != 0)
-        return false;
-    if (!m_config->warnAboutMissingAssertions())
-        return false;
-    if (m_trackerContext.currentTracker().hasChildren())
-        return false;
-    m_totals.assertions.failed++;
-    assertions.failed++;
-    return true;
-}
-
-void RunContext::sectionEnded(SectionEndInfo const & endInfo) {
-    Counts assertions = m_totals.assertions - endInfo.prevAssertions;
-    bool missingAssertions = testForMissingAssertions(assertions);
-
-    if (!m_activeSections.empty()) {
-        m_activeSections.back()->close();
-        m_activeSections.pop_back();
     }
 
-    m_reporter->sectionEnded(SectionStats(endInfo.sectionInfo, assertions, endInfo.durationInSeconds, missingAssertions));
-    m_messages.clear();
-    m_messageScopes.clear();
-}
+    void RunContext::sectionEndedEarly(SectionEndInfo const & endInfo) {
+        if (m_unfinishedSections.empty())
+            m_activeSections.back()->fail();
+        else
+            m_activeSections.back()->close();
+        m_activeSections.pop_back();
 
-void RunContext::sectionEndedEarly(SectionEndInfo const & endInfo) {
-    if (m_unfinishedSections.empty())
-        m_activeSections.back()->fail();
-    else
-        m_activeSections.back()->close();
-    m_activeSections.pop_back();
-
-    m_unfinishedSections.push_back(endInfo);
-}
+        m_unfinishedSections.push_back(endInfo);
+    }
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
-void RunContext::benchmarkPreparing(std::string const& name) {
+    void RunContext::benchmarkPreparing(std::string const& name) {
         m_reporter->benchmarkPreparing(name);
     }
     void RunContext::benchmarkStarting( BenchmarkInfo const& info ) {
@@ -12789,276 +12892,275 @@ void RunContext::benchmarkPreparing(std::string const& name) {
     }
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-void RunContext::pushScopedMessage(MessageInfo const & message) {
-    m_messages.push_back(message);
-}
+    void RunContext::pushScopedMessage(MessageInfo const & message) {
+        m_messages.push_back(message);
+    }
 
-void RunContext::popScopedMessage(MessageInfo const & message) {
-    m_messages.erase(std::remove(m_messages.begin(), m_messages.end(), message), m_messages.end());
-}
+    void RunContext::popScopedMessage(MessageInfo const & message) {
+        m_messages.erase(std::remove(m_messages.begin(), m_messages.end(), message), m_messages.end());
+    }
 
-void RunContext::emplaceUnscopedMessage( MessageBuilder const& builder ) {
-    m_messageScopes.emplace_back( builder );
-}
+    void RunContext::emplaceUnscopedMessage( MessageBuilder const& builder ) {
+        m_messageScopes.emplace_back( builder );
+    }
 
-std::string RunContext::getCurrentTestName() const {
-    return m_activeTestCase
-           ? m_activeTestCase->getTestCaseInfo().name
-           : std::string();
-}
+    std::string RunContext::getCurrentTestName() const {
+        return m_activeTestCase
+            ? m_activeTestCase->getTestCaseInfo().name
+            : std::string();
+    }
 
-const AssertionResult * RunContext::getLastResult() const {
-    return &(*m_lastResult);
-}
+    const AssertionResult * RunContext::getLastResult() const {
+        return &(*m_lastResult);
+    }
 
-void RunContext::exceptionEarlyReported() {
-    m_shouldReportUnexpected = false;
-}
+    void RunContext::exceptionEarlyReported() {
+        m_shouldReportUnexpected = false;
+    }
 
-void RunContext::handleFatalErrorCondition( StringRef message ) {
-    // First notify reporter that bad things happened
-    m_reporter->fatalErrorEncountered(message);
+    void RunContext::handleFatalErrorCondition( StringRef message ) {
+        // First notify reporter that bad things happened
+        m_reporter->fatalErrorEncountered(message);
 
-    // Don't rebuild the result -- the stringification itself can cause more fatal errors
-    // Instead, fake a result data.
-    AssertionResultData tempResult( ResultWas::FatalErrorCondition, { false } );
-    tempResult.message = static_cast<std::string>(message);
-    AssertionResult result(m_lastAssertionInfo, tempResult);
+        // Don't rebuild the result -- the stringification itself can cause more fatal errors
+        // Instead, fake a result data.
+        AssertionResultData tempResult( ResultWas::FatalErrorCondition, { false } );
+        tempResult.message = static_cast<std::string>(message);
+        AssertionResult result(m_lastAssertionInfo, tempResult);
 
-    assertionEnded(result);
+        assertionEnded(result);
 
-    handleUnfinishedSections();
+        handleUnfinishedSections();
 
-    // Recreate section for test case (as we will lose the one that was in scope)
-    auto const& testCaseInfo = m_activeTestCase->getTestCaseInfo();
-    SectionInfo testCaseSection(testCaseInfo.lineInfo, testCaseInfo.name);
+        // Recreate section for test case (as we will lose the one that was in scope)
+        auto const& testCaseInfo = m_activeTestCase->getTestCaseInfo();
+        SectionInfo testCaseSection(testCaseInfo.lineInfo, testCaseInfo.name);
 
-    Counts assertions;
-    assertions.failed = 1;
-    SectionStats testCaseSectionStats(testCaseSection, assertions, 0, false);
-    m_reporter->sectionEnded(testCaseSectionStats);
+        Counts assertions;
+        assertions.failed = 1;
+        SectionStats testCaseSectionStats(testCaseSection, assertions, 0, false);
+        m_reporter->sectionEnded(testCaseSectionStats);
 
-    auto const& testInfo = m_activeTestCase->getTestCaseInfo();
+        auto const& testInfo = m_activeTestCase->getTestCaseInfo();
 
-    Totals deltaTotals;
-    deltaTotals.testCases.failed = 1;
-    deltaTotals.assertions.failed = 1;
-    m_reporter->testCaseEnded(TestCaseStats(testInfo,
-                                            deltaTotals,
-                                            std::string(),
-                                            std::string(),
-                                            false));
-    m_totals.testCases.failed++;
-    testGroupEnded(std::string(), m_totals, 1, 1);
-    m_reporter->testRunEnded(TestRunStats(m_runInfo, m_totals, false));
-}
+        Totals deltaTotals;
+        deltaTotals.testCases.failed = 1;
+        deltaTotals.assertions.failed = 1;
+        m_reporter->testCaseEnded(TestCaseStats(testInfo,
+                                  deltaTotals,
+                                  std::string(),
+                                  std::string(),
+                                  false));
+        m_totals.testCases.failed++;
+        testGroupEnded(std::string(), m_totals, 1, 1);
+        m_reporter->testRunEnded(TestRunStats(m_runInfo, m_totals, false));
+    }
 
-bool RunContext::lastAssertionPassed() {
-    return m_lastAssertionPassed;
-}
+    bool RunContext::lastAssertionPassed() {
+         return m_lastAssertionPassed;
+    }
 
-void RunContext::assertionPassed() {
-    m_lastAssertionPassed = true;
-    ++m_totals.assertions.passed;
-    resetAssertionInfo();
-    m_messageScopes.clear();
-}
+    void RunContext::assertionPassed() {
+        m_lastAssertionPassed = true;
+        ++m_totals.assertions.passed;
+        resetAssertionInfo();
+        m_messageScopes.clear();
+    }
 
-bool RunContext::aborting() const {
-    return m_totals.assertions.failed >= static_cast<std::size_t>(m_config->abortAfter());
-}
+    bool RunContext::aborting() const {
+        return m_totals.assertions.failed >= static_cast<std::size_t>(m_config->abortAfter());
+    }
 
-void RunContext::runCurrentTest(std::string & redirectedCout, std::string & redirectedCerr) {
-    auto const& testCaseInfo = m_activeTestCase->getTestCaseInfo();
-    SectionInfo testCaseSection(testCaseInfo.lineInfo, testCaseInfo.name);
-    m_reporter->sectionStarting(testCaseSection);
-    Counts prevAssertions = m_totals.assertions;
-    double duration = 0;
-    m_shouldReportUnexpected = true;
-    m_lastAssertionInfo = { "TEST_CASE"_sr, testCaseInfo.lineInfo, StringRef(), ResultDisposition::Normal };
+    void RunContext::runCurrentTest(std::string & redirectedCout, std::string & redirectedCerr) {
+        auto const& testCaseInfo = m_activeTestCase->getTestCaseInfo();
+        SectionInfo testCaseSection(testCaseInfo.lineInfo, testCaseInfo.name);
+        m_reporter->sectionStarting(testCaseSection);
+        Counts prevAssertions = m_totals.assertions;
+        double duration = 0;
+        m_shouldReportUnexpected = true;
+        m_lastAssertionInfo = { "TEST_CASE"_sr, testCaseInfo.lineInfo, StringRef(), ResultDisposition::Normal };
 
-    seedRng(*m_config);
+        seedRng(*m_config);
 
-    Timer timer;
-    CATCH_TRY {
-        if (m_reporter->getPreferences().shouldRedirectStdOut) {
+        Timer timer;
+        CATCH_TRY {
+            if (m_reporter->getPreferences().shouldRedirectStdOut) {
 #if !defined(CATCH_CONFIG_EXPERIMENTAL_REDIRECT)
-            RedirectedStreams redirectedStreams(redirectedCout, redirectedCerr);
+                RedirectedStreams redirectedStreams(redirectedCout, redirectedCerr);
 
-            timer.start();
-            invokeActiveTestCase();
+                timer.start();
+                invokeActiveTestCase();
 #else
-            OutputRedirect r(redirectedCout, redirectedCerr);
+                OutputRedirect r(redirectedCout, redirectedCerr);
                 timer.start();
                 invokeActiveTestCase();
 #endif
-        } else {
-            timer.start();
-            invokeActiveTestCase();
+            } else {
+                timer.start();
+                invokeActiveTestCase();
+            }
+            duration = timer.getElapsedSeconds();
+        } CATCH_CATCH_ANON (TestFailureException&) {
+            // This just means the test was aborted due to failure
+        } CATCH_CATCH_ALL {
+            // Under CATCH_CONFIG_FAST_COMPILE, unexpected exceptions under REQUIRE assertions
+            // are reported without translation at the point of origin.
+            if( m_shouldReportUnexpected ) {
+                AssertionReaction dummyReaction;
+                handleUnexpectedInflightException( m_lastAssertionInfo, translateActiveException(), dummyReaction );
+            }
         }
-        duration = timer.getElapsedSeconds();
-    } CATCH_CATCH_ANON (TestFailureException&) {
-        // This just means the test was aborted due to failure
-    } CATCH_CATCH_ALL {
-        // Under CATCH_CONFIG_FAST_COMPILE, unexpected exceptions under REQUIRE assertions
-        // are reported without translation at the point of origin.
-        if( m_shouldReportUnexpected ) {
-            AssertionReaction dummyReaction;
-            handleUnexpectedInflightException( m_lastAssertionInfo, translateActiveException(), dummyReaction );
-        }
+        Counts assertions = m_totals.assertions - prevAssertions;
+        bool missingAssertions = testForMissingAssertions(assertions);
+
+        m_testCaseTracker->close();
+        handleUnfinishedSections();
+        m_messages.clear();
+        m_messageScopes.clear();
+
+        SectionStats testCaseSectionStats(testCaseSection, assertions, duration, missingAssertions);
+        m_reporter->sectionEnded(testCaseSectionStats);
     }
-    Counts assertions = m_totals.assertions - prevAssertions;
-    bool missingAssertions = testForMissingAssertions(assertions);
 
-    m_testCaseTracker->close();
-    handleUnfinishedSections();
-    m_messages.clear();
-    m_messageScopes.clear();
+    void RunContext::invokeActiveTestCase() {
+        FatalConditionHandlerGuard _(&m_fatalConditionhandler);
+        m_activeTestCase->invoke();
+    }
 
-    SectionStats testCaseSectionStats(testCaseSection, assertions, duration, missingAssertions);
-    m_reporter->sectionEnded(testCaseSectionStats);
-}
-
-void RunContext::invokeActiveTestCase() {
-    FatalConditionHandler fatalConditionHandler; // Handle signals
-    m_activeTestCase->invoke();
-    fatalConditionHandler.reset();
-}
-
-void RunContext::handleUnfinishedSections() {
-    // If sections ended prematurely due to an exception we stored their
-    // infos here so we can tear them down outside the unwind process.
-    for (auto it = m_unfinishedSections.rbegin(),
+    void RunContext::handleUnfinishedSections() {
+        // If sections ended prematurely due to an exception we stored their
+        // infos here so we can tear them down outside the unwind process.
+        for (auto it = m_unfinishedSections.rbegin(),
              itEnd = m_unfinishedSections.rend();
-         it != itEnd;
-         ++it)
-        sectionEnded(*it);
-    m_unfinishedSections.clear();
-}
+             it != itEnd;
+             ++it)
+            sectionEnded(*it);
+        m_unfinishedSections.clear();
+    }
 
-void RunContext::handleExpr(
-    AssertionInfo const& info,
-    ITransientExpression const& expr,
-    AssertionReaction& reaction
-) {
-    m_reporter->assertionStarting( info );
+    void RunContext::handleExpr(
+        AssertionInfo const& info,
+        ITransientExpression const& expr,
+        AssertionReaction& reaction
+    ) {
+        m_reporter->assertionStarting( info );
 
-    bool negated = isFalseTest( info.resultDisposition );
-    bool result = expr.getResult() != negated;
+        bool negated = isFalseTest( info.resultDisposition );
+        bool result = expr.getResult() != negated;
 
-    if( result ) {
-        if (!m_includeSuccessfulResults) {
-            assertionPassed();
+        if( result ) {
+            if (!m_includeSuccessfulResults) {
+                assertionPassed();
+            }
+            else {
+                reportExpr(info, ResultWas::Ok, &expr, negated);
+            }
         }
         else {
-            reportExpr(info, ResultWas::Ok, &expr, negated);
+            reportExpr(info, ResultWas::ExpressionFailed, &expr, negated );
+            populateReaction( reaction );
         }
     }
-    else {
-        reportExpr(info, ResultWas::ExpressionFailed, &expr, negated );
+    void RunContext::reportExpr(
+            AssertionInfo const &info,
+            ResultWas::OfType resultType,
+            ITransientExpression const *expr,
+            bool negated ) {
+
+        m_lastAssertionInfo = info;
+        AssertionResultData data( resultType, LazyExpression( negated ) );
+
+        AssertionResult assertionResult{ info, data };
+        assertionResult.m_resultData.lazyExpression.m_transientExpression = expr;
+
+        assertionEnded( assertionResult );
+    }
+
+    void RunContext::handleMessage(
+            AssertionInfo const& info,
+            ResultWas::OfType resultType,
+            StringRef const& message,
+            AssertionReaction& reaction
+    ) {
+        m_reporter->assertionStarting( info );
+
+        m_lastAssertionInfo = info;
+
+        AssertionResultData data( resultType, LazyExpression( false ) );
+        data.message = static_cast<std::string>(message);
+        AssertionResult assertionResult{ m_lastAssertionInfo, data };
+        assertionEnded( assertionResult );
+        if( !assertionResult.isOk() )
+            populateReaction( reaction );
+    }
+    void RunContext::handleUnexpectedExceptionNotThrown(
+            AssertionInfo const& info,
+            AssertionReaction& reaction
+    ) {
+        handleNonExpr(info, Catch::ResultWas::DidntThrowException, reaction);
+    }
+
+    void RunContext::handleUnexpectedInflightException(
+            AssertionInfo const& info,
+            std::string const& message,
+            AssertionReaction& reaction
+    ) {
+        m_lastAssertionInfo = info;
+
+        AssertionResultData data( ResultWas::ThrewException, LazyExpression( false ) );
+        data.message = message;
+        AssertionResult assertionResult{ info, data };
+        assertionEnded( assertionResult );
         populateReaction( reaction );
     }
-}
-void RunContext::reportExpr(
-    AssertionInfo const &info,
-    ResultWas::OfType resultType,
-    ITransientExpression const *expr,
-    bool negated ) {
 
-    m_lastAssertionInfo = info;
-    AssertionResultData data( resultType, LazyExpression( negated ) );
-
-    AssertionResult assertionResult{ info, data };
-    assertionResult.m_resultData.lazyExpression.m_transientExpression = expr;
-
-    assertionEnded( assertionResult );
-}
-
-void RunContext::handleMessage(
-    AssertionInfo const& info,
-    ResultWas::OfType resultType,
-    StringRef const& message,
-    AssertionReaction& reaction
-) {
-    m_reporter->assertionStarting( info );
-
-    m_lastAssertionInfo = info;
-
-    AssertionResultData data( resultType, LazyExpression( false ) );
-    data.message = static_cast<std::string>(message);
-    AssertionResult assertionResult{ m_lastAssertionInfo, data };
-    assertionEnded( assertionResult );
-    if( !assertionResult.isOk() )
-        populateReaction( reaction );
-}
-void RunContext::handleUnexpectedExceptionNotThrown(
-    AssertionInfo const& info,
-    AssertionReaction& reaction
-) {
-    handleNonExpr(info, Catch::ResultWas::DidntThrowException, reaction);
-}
-
-void RunContext::handleUnexpectedInflightException(
-    AssertionInfo const& info,
-    std::string const& message,
-    AssertionReaction& reaction
-) {
-    m_lastAssertionInfo = info;
-
-    AssertionResultData data( ResultWas::ThrewException, LazyExpression( false ) );
-    data.message = message;
-    AssertionResult assertionResult{ info, data };
-    assertionEnded( assertionResult );
-    populateReaction( reaction );
-}
-
-void RunContext::populateReaction( AssertionReaction& reaction ) {
-    reaction.shouldDebugBreak = m_config->shouldDebugBreak();
-    reaction.shouldThrow = aborting() || (m_lastAssertionInfo.resultDisposition & ResultDisposition::Normal);
-}
-
-void RunContext::handleIncomplete(
-    AssertionInfo const& info
-) {
-    m_lastAssertionInfo = info;
-
-    AssertionResultData data( ResultWas::ThrewException, LazyExpression( false ) );
-    data.message = "Exception translation was disabled by CATCH_CONFIG_FAST_COMPILE";
-    AssertionResult assertionResult{ info, data };
-    assertionEnded( assertionResult );
-}
-void RunContext::handleNonExpr(
-    AssertionInfo const &info,
-    ResultWas::OfType resultType,
-    AssertionReaction &reaction
-) {
-    m_lastAssertionInfo = info;
-
-    AssertionResultData data( resultType, LazyExpression( false ) );
-    AssertionResult assertionResult{ info, data };
-    assertionEnded( assertionResult );
-
-    if( !assertionResult.isOk() )
-        populateReaction( reaction );
-}
-
-IResultCapture& getResultCapture() {
-    if (auto* capture = getCurrentContext().getResultCapture())
-        return *capture;
-    else
-        CATCH_INTERNAL_ERROR("No result capture instance");
-}
-
-void seedRng(IConfig const& config) {
-    if (config.rngSeed() != 0) {
-        std::srand(config.rngSeed());
-        rng().seed(config.rngSeed());
+    void RunContext::populateReaction( AssertionReaction& reaction ) {
+        reaction.shouldDebugBreak = m_config->shouldDebugBreak();
+        reaction.shouldThrow = aborting() || (m_lastAssertionInfo.resultDisposition & ResultDisposition::Normal);
     }
-}
 
-unsigned int rngSeed() {
-    return getCurrentContext().getConfig()->rngSeed();
-}
+    void RunContext::handleIncomplete(
+            AssertionInfo const& info
+    ) {
+        m_lastAssertionInfo = info;
+
+        AssertionResultData data( ResultWas::ThrewException, LazyExpression( false ) );
+        data.message = "Exception translation was disabled by CATCH_CONFIG_FAST_COMPILE";
+        AssertionResult assertionResult{ info, data };
+        assertionEnded( assertionResult );
+    }
+    void RunContext::handleNonExpr(
+            AssertionInfo const &info,
+            ResultWas::OfType resultType,
+            AssertionReaction &reaction
+    ) {
+        m_lastAssertionInfo = info;
+
+        AssertionResultData data( resultType, LazyExpression( false ) );
+        AssertionResult assertionResult{ info, data };
+        assertionEnded( assertionResult );
+
+        if( !assertionResult.isOk() )
+            populateReaction( reaction );
+    }
+
+    IResultCapture& getResultCapture() {
+        if (auto* capture = getCurrentContext().getResultCapture())
+            return *capture;
+        else
+            CATCH_INTERNAL_ERROR("No result capture instance");
+    }
+
+    void seedRng(IConfig const& config) {
+        if (config.rngSeed() != 0) {
+            std::srand(config.rngSeed());
+            rng().seed(config.rngSeed());
+        }
+    }
+
+    unsigned int rngSeed() {
+        return getCurrentContext().getConfig()->rngSeed();
+    }
 
 }
 // end catch_run_context.cpp
@@ -13066,27 +13168,27 @@ unsigned int rngSeed() {
 
 namespace Catch {
 
-Section::Section( SectionInfo const& info )
+    Section::Section( SectionInfo const& info )
     :   m_info( info ),
         m_sectionIncluded( getResultCapture().sectionStarted( m_info, m_assertions ) )
-{
-    m_timer.start();
-}
-
-Section::~Section() {
-    if( m_sectionIncluded ) {
-        SectionEndInfo endInfo{ m_info, m_assertions, m_timer.getElapsedSeconds() };
-        if( uncaught_exceptions() )
-            getResultCapture().sectionEndedEarly( endInfo );
-        else
-            getResultCapture().sectionEnded( endInfo );
+    {
+        m_timer.start();
     }
-}
 
-// This indicates whether the section should be executed or not
-Section::operator bool() const {
-    return m_sectionIncluded;
-}
+    Section::~Section() {
+        if( m_sectionIncluded ) {
+            SectionEndInfo endInfo{ m_info, m_assertions, m_timer.getElapsedSeconds() };
+            if( uncaught_exceptions() )
+                getResultCapture().sectionEndedEarly( endInfo );
+            else
+                getResultCapture().sectionEnded( endInfo );
+        }
+    }
+
+    // This indicates whether the section should be executed or not
+    Section::operator bool() const {
+        return m_sectionIncluded;
+    }
 
 } // end namespace Catch
 // end catch_section.cpp
@@ -13094,12 +13196,12 @@ Section::operator bool() const {
 
 namespace Catch {
 
-SectionInfo::SectionInfo
-    (   SourceLineInfo const& _lineInfo,
-        std::string const& _name )
+    SectionInfo::SectionInfo
+        (   SourceLineInfo const& _lineInfo,
+            std::string const& _name )
     :   name( _name ),
         lineInfo( _lineInfo )
-{}
+    {}
 
 } // end namespace Catch
 // end catch_section_info.cpp
@@ -13111,46 +13213,46 @@ SectionInfo::SectionInfo
 
 namespace Catch {
 
-class Session : NonCopyable {
-public:
+    class Session : NonCopyable {
+    public:
 
-    Session();
-    ~Session() override;
+        Session();
+        ~Session() override;
 
-    void showHelp() const;
-    void libIdentify();
+        void showHelp() const;
+        void libIdentify();
 
-    int applyCommandLine( int argc, char const * const * argv );
+        int applyCommandLine( int argc, char const * const * argv );
     #if defined(CATCH_CONFIG_WCHAR) && defined(_WIN32) && defined(UNICODE)
-    int applyCommandLine( int argc, wchar_t const * const * argv );
+        int applyCommandLine( int argc, wchar_t const * const * argv );
     #endif
 
-    void useConfigData( ConfigData const& configData );
+        void useConfigData( ConfigData const& configData );
 
-    template<typename CharT>
-    int run(int argc, CharT const * const argv[]) {
-        if (m_startupExceptions)
-            return 1;
-        int returnCode = applyCommandLine(argc, argv);
-        if (returnCode == 0)
-            returnCode = run();
-        return returnCode;
-    }
+        template<typename CharT>
+        int run(int argc, CharT const * const argv[]) {
+            if (m_startupExceptions)
+                return 1;
+            int returnCode = applyCommandLine(argc, argv);
+            if (returnCode == 0)
+                returnCode = run();
+            return returnCode;
+        }
 
-    int run();
+        int run();
 
-    clara::Parser const& cli() const;
-    void cli( clara::Parser const& newParser );
-    ConfigData& configData();
-    Config& config();
-private:
-    int runInternal();
+        clara::Parser const& cli() const;
+        void cli( clara::Parser const& newParser );
+        ConfigData& configData();
+        Config& config();
+    private:
+        int runInternal();
 
-    clara::Parser m_cli;
-    ConfigData m_configData;
-    std::shared_ptr<Config> m_config;
-    bool m_startupExceptions = false;
-};
+        clara::Parser m_cli;
+        ConfigData m_configData;
+        std::shared_ptr<Config> m_config;
+        bool m_startupExceptions = false;
+    };
 
 } // end namespace Catch
 
@@ -13161,28 +13263,28 @@ private:
 
 namespace Catch {
 
-// Versioning information
-struct Version {
-    Version( Version const& ) = delete;
-    Version& operator=( Version const& ) = delete;
-    Version(    unsigned int _majorVersion,
-                unsigned int _minorVersion,
-                unsigned int _patchNumber,
-                char const * const _branchName,
-                unsigned int _buildNumber );
+    // Versioning information
+    struct Version {
+        Version( Version const& ) = delete;
+        Version& operator=( Version const& ) = delete;
+        Version(    unsigned int _majorVersion,
+                    unsigned int _minorVersion,
+                    unsigned int _patchNumber,
+                    char const * const _branchName,
+                    unsigned int _buildNumber );
 
-    unsigned int const majorVersion;
-    unsigned int const minorVersion;
-    unsigned int const patchNumber;
+        unsigned int const majorVersion;
+        unsigned int const minorVersion;
+        unsigned int const patchNumber;
 
-    // buildNumber is only used if branchName is not null
-    char const * const branchName;
-    unsigned int const buildNumber;
+        // buildNumber is only used if branchName is not null
+        char const * const branchName;
+        unsigned int const buildNumber;
 
-    friend std::ostream& operator << ( std::ostream& os, Version const& version );
-};
+        friend std::ostream& operator << ( std::ostream& os, Version const& version );
+    };
 
-Version const& libraryVersion();
+    Version const& libraryVersion();
 }
 
 // end catch_version.h
@@ -13193,192 +13295,192 @@ Version const& libraryVersion();
 
 namespace Catch {
 
-namespace {
-const int MaxExitCode = 255;
+    namespace {
+        const int MaxExitCode = 255;
 
-IStreamingReporterPtr createReporter(std::string const& reporterName, IConfigPtr const& config) {
-    auto reporter = Catch::getRegistryHub().getReporterRegistry().create(reporterName, config);
-    CATCH_ENFORCE(reporter, "No reporter registered with name: '" << reporterName << "'");
+        IStreamingReporterPtr createReporter(std::string const& reporterName, IConfigPtr const& config) {
+            auto reporter = Catch::getRegistryHub().getReporterRegistry().create(reporterName, config);
+            CATCH_ENFORCE(reporter, "No reporter registered with name: '" << reporterName << "'");
 
-    return reporter;
-}
-
-IStreamingReporterPtr makeReporter(std::shared_ptr<Config> const& config) {
-    if (Catch::getRegistryHub().getReporterRegistry().getListeners().empty()) {
-        return createReporter(config->getReporterName(), config);
-    }
-
-    // On older platforms, returning std::unique_ptr<ListeningReporter>
-    // when the return type is std::unique_ptr<IStreamingReporter>
-    // doesn't compile without a std::move call. However, this causes
-    // a warning on newer platforms. Thus, we have to work around
-    // it a bit and downcast the pointer manually.
-    auto ret = std::unique_ptr<IStreamingReporter>(new ListeningReporter);
-    auto& multi = static_cast<ListeningReporter&>(*ret);
-    auto const& listeners = Catch::getRegistryHub().getReporterRegistry().getListeners();
-    for (auto const& listener : listeners) {
-        multi.addListener(listener->create(Catch::ReporterConfig(config)));
-    }
-    multi.addReporter(createReporter(config->getReporterName(), config));
-    return ret;
-}
-
-class TestGroup {
-public:
-    explicit TestGroup(std::shared_ptr<Config> const& config)
-        : m_config{config}
-        , m_context{config, makeReporter(config)}
-    {
-        auto const& allTestCases = getAllTestCasesSorted(*m_config);
-        m_matches = m_config->testSpec().matchesByFilter(allTestCases, *m_config);
-        auto const& invalidArgs = m_config->testSpec().getInvalidArgs();
-
-        if (m_matches.empty() && invalidArgs.empty()) {
-            for (auto const& test : allTestCases)
-                if (!test.isHidden())
-                    m_tests.emplace(&test);
-        } else {
-            for (auto const& match : m_matches)
-                m_tests.insert(match.tests.begin(), match.tests.end());
-        }
-    }
-
-    Totals execute() {
-        auto const& invalidArgs = m_config->testSpec().getInvalidArgs();
-        Totals totals;
-        m_context.testGroupStarting(m_config->name(), 1, 1);
-        for (auto const& testCase : m_tests) {
-            if (!m_context.aborting())
-                totals += m_context.runTest(*testCase);
-            else
-                m_context.reporter().skipTest(*testCase);
+            return reporter;
         }
 
-        for (auto const& match : m_matches) {
-            if (match.tests.empty()) {
-                m_context.reporter().noMatchingTestCases(match.name);
-                totals.error = -1;
+        IStreamingReporterPtr makeReporter(std::shared_ptr<Config> const& config) {
+            if (Catch::getRegistryHub().getReporterRegistry().getListeners().empty()) {
+                return createReporter(config->getReporterName(), config);
+            }
+
+            // On older platforms, returning std::unique_ptr<ListeningReporter>
+            // when the return type is std::unique_ptr<IStreamingReporter>
+            // doesn't compile without a std::move call. However, this causes
+            // a warning on newer platforms. Thus, we have to work around
+            // it a bit and downcast the pointer manually.
+            auto ret = std::unique_ptr<IStreamingReporter>(new ListeningReporter);
+            auto& multi = static_cast<ListeningReporter&>(*ret);
+            auto const& listeners = Catch::getRegistryHub().getReporterRegistry().getListeners();
+            for (auto const& listener : listeners) {
+                multi.addListener(listener->create(Catch::ReporterConfig(config)));
+            }
+            multi.addReporter(createReporter(config->getReporterName(), config));
+            return ret;
+        }
+
+        class TestGroup {
+        public:
+            explicit TestGroup(std::shared_ptr<Config> const& config)
+            : m_config{config}
+            , m_context{config, makeReporter(config)}
+            {
+                auto const& allTestCases = getAllTestCasesSorted(*m_config);
+                m_matches = m_config->testSpec().matchesByFilter(allTestCases, *m_config);
+                auto const& invalidArgs = m_config->testSpec().getInvalidArgs();
+
+                if (m_matches.empty() && invalidArgs.empty()) {
+                    for (auto const& test : allTestCases)
+                        if (!test.isHidden())
+                            m_tests.emplace(&test);
+                } else {
+                    for (auto const& match : m_matches)
+                        m_tests.insert(match.tests.begin(), match.tests.end());
+                }
+            }
+
+            Totals execute() {
+                auto const& invalidArgs = m_config->testSpec().getInvalidArgs();
+                Totals totals;
+                m_context.testGroupStarting(m_config->name(), 1, 1);
+                for (auto const& testCase : m_tests) {
+                    if (!m_context.aborting())
+                        totals += m_context.runTest(*testCase);
+                    else
+                        m_context.reporter().skipTest(*testCase);
+                }
+
+                for (auto const& match : m_matches) {
+                    if (match.tests.empty()) {
+                        m_context.reporter().noMatchingTestCases(match.name);
+                        totals.error = -1;
+                    }
+                }
+
+                if (!invalidArgs.empty()) {
+                    for (auto const& invalidArg: invalidArgs)
+                         m_context.reporter().reportInvalidArguments(invalidArg);
+                }
+
+                m_context.testGroupEnded(m_config->name(), totals, 1, 1);
+                return totals;
+            }
+
+        private:
+            using Tests = std::set<TestCase const*>;
+
+            std::shared_ptr<Config> m_config;
+            RunContext m_context;
+            Tests m_tests;
+            TestSpec::Matches m_matches;
+        };
+
+        void applyFilenamesAsTags(Catch::IConfig const& config) {
+            auto& tests = const_cast<std::vector<TestCase>&>(getAllTestCasesSorted(config));
+            for (auto& testCase : tests) {
+                auto tags = testCase.tags;
+
+                std::string filename = testCase.lineInfo.file;
+                auto lastSlash = filename.find_last_of("\\/");
+                if (lastSlash != std::string::npos) {
+                    filename.erase(0, lastSlash);
+                    filename[0] = '#';
+                }
+
+                auto lastDot = filename.find_last_of('.');
+                if (lastDot != std::string::npos) {
+                    filename.erase(lastDot);
+                }
+
+                tags.push_back(std::move(filename));
+                setTags(testCase, tags);
             }
         }
 
-        if (!invalidArgs.empty()) {
-            for (auto const& invalidArg: invalidArgs)
-                m_context.reporter().reportInvalidArguments(invalidArg);
+    } // anon namespace
+
+    Session::Session() {
+        static bool alreadyInstantiated = false;
+        if( alreadyInstantiated ) {
+            CATCH_TRY { CATCH_INTERNAL_ERROR( "Only one instance of Catch::Session can ever be used" ); }
+            CATCH_CATCH_ALL { getMutableRegistryHub().registerStartupException(); }
         }
 
-        m_context.testGroupEnded(m_config->name(), totals, 1, 1);
-        return totals;
-    }
-
-private:
-    using Tests = std::set<TestCase const*>;
-
-    std::shared_ptr<Config> m_config;
-    RunContext m_context;
-    Tests m_tests;
-    TestSpec::Matches m_matches;
-};
-
-void applyFilenamesAsTags(Catch::IConfig const& config) {
-    auto& tests = const_cast<std::vector<TestCase>&>(getAllTestCasesSorted(config));
-    for (auto& testCase : tests) {
-        auto tags = testCase.tags;
-
-        std::string filename = testCase.lineInfo.file;
-        auto lastSlash = filename.find_last_of("\\/");
-        if (lastSlash != std::string::npos) {
-            filename.erase(0, lastSlash);
-            filename[0] = '#';
-        }
-
-        auto lastDot = filename.find_last_of('.');
-        if (lastDot != std::string::npos) {
-            filename.erase(lastDot);
-        }
-
-        tags.push_back(std::move(filename));
-        setTags(testCase, tags);
-    }
-}
-
-} // anon namespace
-
-Session::Session() {
-    static bool alreadyInstantiated = false;
-    if( alreadyInstantiated ) {
-        CATCH_TRY { CATCH_INTERNAL_ERROR( "Only one instance of Catch::Session can ever be used" ); }
-        CATCH_CATCH_ALL { getMutableRegistryHub().registerStartupException(); }
-    }
-
-    // There cannot be exceptions at startup in no-exception mode.
+        // There cannot be exceptions at startup in no-exception mode.
 #if !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
-    const auto& exceptions = getRegistryHub().getStartupExceptionRegistry().getExceptions();
-    if ( !exceptions.empty() ) {
-        config();
-        getCurrentMutableContext().setConfig(m_config);
+        const auto& exceptions = getRegistryHub().getStartupExceptionRegistry().getExceptions();
+        if ( !exceptions.empty() ) {
+            config();
+            getCurrentMutableContext().setConfig(m_config);
 
-        m_startupExceptions = true;
-        Colour colourGuard( Colour::Red );
-        Catch::cerr() << "Errors occurred during startup!" << '\n';
-        // iterate over all exceptions and notify user
-        for ( const auto& ex_ptr : exceptions ) {
-            try {
-                std::rethrow_exception(ex_ptr);
-            } catch ( std::exception const& ex ) {
-                Catch::cerr() << Column( ex.what() ).indent(2) << '\n';
+            m_startupExceptions = true;
+            Colour colourGuard( Colour::Red );
+            Catch::cerr() << "Errors occurred during startup!" << '\n';
+            // iterate over all exceptions and notify user
+            for ( const auto& ex_ptr : exceptions ) {
+                try {
+                    std::rethrow_exception(ex_ptr);
+                } catch ( std::exception const& ex ) {
+                    Catch::cerr() << Column( ex.what() ).indent(2) << '\n';
+                }
             }
         }
-    }
 #endif
 
-    alreadyInstantiated = true;
-    m_cli = makeCommandLineParser( m_configData );
-}
-Session::~Session() {
-    Catch::cleanUp();
-}
-
-void Session::showHelp() const {
-    Catch::cout()
-        << "\nCatch v" << libraryVersion() << "\n"
-        << m_cli << std::endl
-        << "For more detailed usage please see the project docs\n" << std::endl;
-}
-void Session::libIdentify() {
-    Catch::cout()
-        << std::left << std::setw(16) << "description: " << "A Catch2 test executable\n"
-        << std::left << std::setw(16) << "category: " << "testframework\n"
-        << std::left << std::setw(16) << "framework: " << "Catch Test\n"
-        << std::left << std::setw(16) << "version: " << libraryVersion() << std::endl;
-}
-
-int Session::applyCommandLine( int argc, char const * const * argv ) {
-    if( m_startupExceptions )
-        return 1;
-
-    auto result = m_cli.parse( clara::Args( argc, argv ) );
-    if( !result ) {
-        config();
-        getCurrentMutableContext().setConfig(m_config);
-        Catch::cerr()
-            << Colour( Colour::Red )
-            << "\nError(s) in input:\n"
-            << Column( result.errorMessage() ).indent( 2 )
-            << "\n\n";
-        Catch::cerr() << "Run with -? for usage\n" << std::endl;
-        return MaxExitCode;
+        alreadyInstantiated = true;
+        m_cli = makeCommandLineParser( m_configData );
+    }
+    Session::~Session() {
+        Catch::cleanUp();
     }
 
-    if( m_configData.showHelp )
-        showHelp();
-    if( m_configData.libIdentify )
-        libIdentify();
-    m_config.reset();
-    return 0;
-}
+    void Session::showHelp() const {
+        Catch::cout()
+                << "\nCatch v" << libraryVersion() << "\n"
+                << m_cli << std::endl
+                << "For more detailed usage please see the project docs\n" << std::endl;
+    }
+    void Session::libIdentify() {
+        Catch::cout()
+                << std::left << std::setw(16) << "description: " << "A Catch2 test executable\n"
+                << std::left << std::setw(16) << "category: " << "testframework\n"
+                << std::left << std::setw(16) << "framework: " << "Catch Test\n"
+                << std::left << std::setw(16) << "version: " << libraryVersion() << std::endl;
+    }
+
+    int Session::applyCommandLine( int argc, char const * const * argv ) {
+        if( m_startupExceptions )
+            return 1;
+
+        auto result = m_cli.parse( clara::Args( argc, argv ) );
+        if( !result ) {
+            config();
+            getCurrentMutableContext().setConfig(m_config);
+            Catch::cerr()
+                << Colour( Colour::Red )
+                << "\nError(s) in input:\n"
+                << Column( result.errorMessage() ).indent( 2 )
+                << "\n\n";
+            Catch::cerr() << "Run with -? for usage\n" << std::endl;
+            return MaxExitCode;
+        }
+
+        if( m_configData.showHelp )
+            showHelp();
+        if( m_configData.libIdentify )
+            libIdentify();
+        m_config.reset();
+        return 0;
+    }
 
 #if defined(CATCH_CONFIG_WCHAR) && defined(_WIN32) && defined(UNICODE)
-int Session::applyCommandLine( int argc, wchar_t const * const * argv ) {
+    int Session::applyCommandLine( int argc, wchar_t const * const * argv ) {
 
         char **utf8Argv = new char *[ argc ];
 
@@ -13401,77 +13503,77 @@ int Session::applyCommandLine( int argc, wchar_t const * const * argv ) {
     }
 #endif
 
-void Session::useConfigData( ConfigData const& configData ) {
-    m_configData = configData;
-    m_config.reset();
-}
-
-int Session::run() {
-    if( ( m_configData.waitForKeypress & WaitForKeypress::BeforeStart ) != 0 ) {
-        Catch::cout() << "...waiting for enter/ return before starting" << std::endl;
-        static_cast<void>(std::getchar());
-    }
-    int exitCode = runInternal();
-    if( ( m_configData.waitForKeypress & WaitForKeypress::BeforeExit ) != 0 ) {
-        Catch::cout() << "...waiting for enter/ return before exiting, with code: " << exitCode << std::endl;
-        static_cast<void>(std::getchar());
-    }
-    return exitCode;
-}
-
-clara::Parser const& Session::cli() const {
-    return m_cli;
-}
-void Session::cli( clara::Parser const& newParser ) {
-    m_cli = newParser;
-}
-ConfigData& Session::configData() {
-    return m_configData;
-}
-Config& Session::config() {
-    if( !m_config )
-        m_config = std::make_shared<Config>( m_configData );
-    return *m_config;
-}
-
-int Session::runInternal() {
-    if( m_startupExceptions )
-        return 1;
-
-    if (m_configData.showHelp || m_configData.libIdentify) {
-        return 0;
+    void Session::useConfigData( ConfigData const& configData ) {
+        m_configData = configData;
+        m_config.reset();
     }
 
-    CATCH_TRY {
-        config(); // Force config to be constructed
-
-        seedRng( *m_config );
-
-        if( m_configData.filenamesAsTags )
-            applyFilenamesAsTags( *m_config );
-
-        // Handle list request
-        if( Option<std::size_t> listed = list( m_config ) )
-            return static_cast<int>( *listed );
-
-        TestGroup tests { m_config };
-        auto const totals = tests.execute();
-
-        if( m_config->warnAboutNoTests() && totals.error == -1 )
-            return 2;
-
-        // Note that on unices only the lower 8 bits are usually used, clamping
-        // the return value to 255 prevents false negative when some multiple
-        // of 256 tests has failed
-        return (std::min) (MaxExitCode, (std::max) (totals.error, static_cast<int>(totals.assertions.failed)));
+    int Session::run() {
+        if( ( m_configData.waitForKeypress & WaitForKeypress::BeforeStart ) != 0 ) {
+            Catch::cout() << "...waiting for enter/ return before starting" << std::endl;
+            static_cast<void>(std::getchar());
+        }
+        int exitCode = runInternal();
+        if( ( m_configData.waitForKeypress & WaitForKeypress::BeforeExit ) != 0 ) {
+            Catch::cout() << "...waiting for enter/ return before exiting, with code: " << exitCode << std::endl;
+            static_cast<void>(std::getchar());
+        }
+        return exitCode;
     }
+
+    clara::Parser const& Session::cli() const {
+        return m_cli;
+    }
+    void Session::cli( clara::Parser const& newParser ) {
+        m_cli = newParser;
+    }
+    ConfigData& Session::configData() {
+        return m_configData;
+    }
+    Config& Session::config() {
+        if( !m_config )
+            m_config = std::make_shared<Config>( m_configData );
+        return *m_config;
+    }
+
+    int Session::runInternal() {
+        if( m_startupExceptions )
+            return 1;
+
+        if (m_configData.showHelp || m_configData.libIdentify) {
+            return 0;
+        }
+
+        CATCH_TRY {
+            config(); // Force config to be constructed
+
+            seedRng( *m_config );
+
+            if( m_configData.filenamesAsTags )
+                applyFilenamesAsTags( *m_config );
+
+            // Handle list request
+            if( Option<std::size_t> listed = list( m_config ) )
+                return static_cast<int>( *listed );
+
+            TestGroup tests { m_config };
+            auto const totals = tests.execute();
+
+            if( m_config->warnAboutNoTests() && totals.error == -1 )
+                return 2;
+
+            // Note that on unices only the lower 8 bits are usually used, clamping
+            // the return value to 255 prevents false negative when some multiple
+            // of 256 tests has failed
+            return (std::min) (MaxExitCode, (std::max) (totals.error, static_cast<int>(totals.assertions.failed)));
+        }
 #if !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
-    catch( std::exception& ex ) {
-        Catch::cerr() << ex.what() << std::endl;
-        return MaxExitCode;
-    }
+        catch( std::exception& ex ) {
+            Catch::cerr() << ex.what() << std::endl;
+            return MaxExitCode;
+        }
 #endif
-}
+    }
 
 } // end namespace Catch
 // end catch_session.cpp
@@ -13481,27 +13583,27 @@ int Session::runInternal() {
 
 namespace Catch {
 
-namespace {
-static auto getSingletons() -> std::vector<ISingleton*>*& {
-    static std::vector<ISingleton*>* g_singletons = nullptr;
-    if( !g_singletons )
-        g_singletons = new std::vector<ISingleton*>();
-    return g_singletons;
-}
-}
+    namespace {
+        static auto getSingletons() -> std::vector<ISingleton*>*& {
+            static std::vector<ISingleton*>* g_singletons = nullptr;
+            if( !g_singletons )
+                g_singletons = new std::vector<ISingleton*>();
+            return g_singletons;
+        }
+    }
 
-ISingleton::~ISingleton() {}
+    ISingleton::~ISingleton() {}
 
-void addSingleton(ISingleton* singleton ) {
-    getSingletons()->push_back( singleton );
-}
-void cleanupSingletons() {
-    auto& singletons = getSingletons();
-    for( auto singleton : *singletons )
-        delete singleton;
-    delete singletons;
-    singletons = nullptr;
-}
+    void addSingleton(ISingleton* singleton ) {
+        getSingletons()->push_back( singleton );
+    }
+    void cleanupSingletons() {
+        auto& singletons = getSingletons();
+        for( auto singleton : *singletons )
+            delete singleton;
+        delete singletons;
+        singletons = nullptr;
+    }
 
 } // namespace Catch
 // end catch_singletons.cpp
@@ -13510,17 +13612,17 @@ void cleanupSingletons() {
 #if !defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
 namespace Catch {
 void StartupExceptionRegistry::add( std::exception_ptr const& exception ) noexcept {
-    CATCH_TRY {
-        m_exceptions.push_back(exception);
-    } CATCH_CATCH_ALL {
-        // If we run out of memory during start-up there's really not a lot more we can do about it
-        std::terminate();
+        CATCH_TRY {
+            m_exceptions.push_back(exception);
+        } CATCH_CATCH_ALL {
+            // If we run out of memory during start-up there's really not a lot more we can do about it
+            std::terminate();
+        }
     }
-}
 
-std::vector<std::exception_ptr> const& StartupExceptionRegistry::getExceptions() const noexcept {
-    return m_exceptions;
-}
+    std::vector<std::exception_ptr> const& StartupExceptionRegistry::getExceptions() const noexcept {
+        return m_exceptions;
+    }
 
 } // end namespace Catch
 #endif
@@ -13536,163 +13638,163 @@ std::vector<std::exception_ptr> const& StartupExceptionRegistry::getExceptions()
 
 namespace Catch {
 
-Catch::IStream::~IStream() = default;
+    Catch::IStream::~IStream() = default;
 
-namespace Detail { namespace {
-template<typename WriterF, std::size_t bufferSize=256>
-class StreamBufImpl : public std::streambuf {
-    char data[bufferSize];
-    WriterF m_writer;
+    namespace Detail { namespace {
+        template<typename WriterF, std::size_t bufferSize=256>
+        class StreamBufImpl : public std::streambuf {
+            char data[bufferSize];
+            WriterF m_writer;
 
-public:
-    StreamBufImpl() {
-        setp( data, data + sizeof(data) );
-    }
+        public:
+            StreamBufImpl() {
+                setp( data, data + sizeof(data) );
+            }
 
-    ~StreamBufImpl() noexcept {
-        StreamBufImpl::sync();
-    }
+            ~StreamBufImpl() noexcept {
+                StreamBufImpl::sync();
+            }
 
-private:
-    int overflow( int c ) override {
-        sync();
+        private:
+            int overflow( int c ) override {
+                sync();
 
-        if( c != EOF ) {
-            if( pbase() == epptr() )
-                m_writer( std::string( 1, static_cast<char>( c ) ) );
+                if( c != EOF ) {
+                    if( pbase() == epptr() )
+                        m_writer( std::string( 1, static_cast<char>( c ) ) );
+                    else
+                        sputc( static_cast<char>( c ) );
+                }
+                return 0;
+            }
+
+            int sync() override {
+                if( pbase() != pptr() ) {
+                    m_writer( std::string( pbase(), static_cast<std::string::size_type>( pptr() - pbase() ) ) );
+                    setp( pbase(), epptr() );
+                }
+                return 0;
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////////
+
+        struct OutputDebugWriter {
+
+            void operator()( std::string const&str ) {
+                writeToDebugConsole( str );
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////////
+
+        class FileStream : public IStream {
+            mutable std::ofstream m_ofs;
+        public:
+            FileStream( StringRef filename ) {
+                m_ofs.open( filename.c_str() );
+                CATCH_ENFORCE( !m_ofs.fail(), "Unable to open file: '" << filename << "'" );
+            }
+            ~FileStream() override = default;
+        public: // IStream
+            std::ostream& stream() const override {
+                return m_ofs;
+            }
+        };
+
+        ///////////////////////////////////////////////////////////////////////////
+
+        class CoutStream : public IStream {
+            mutable std::ostream m_os;
+        public:
+            // Store the streambuf from cout up-front because
+            // cout may get redirected when running tests
+            CoutStream() : m_os( Catch::cout().rdbuf() ) {}
+            ~CoutStream() override = default;
+
+        public: // IStream
+            std::ostream& stream() const override { return m_os; }
+        };
+
+        ///////////////////////////////////////////////////////////////////////////
+
+        class DebugOutStream : public IStream {
+            std::unique_ptr<StreamBufImpl<OutputDebugWriter>> m_streamBuf;
+            mutable std::ostream m_os;
+        public:
+            DebugOutStream()
+            :   m_streamBuf( new StreamBufImpl<OutputDebugWriter>() ),
+                m_os( m_streamBuf.get() )
+            {}
+
+            ~DebugOutStream() override = default;
+
+        public: // IStream
+            std::ostream& stream() const override { return m_os; }
+        };
+
+    }} // namespace anon::detail
+
+    ///////////////////////////////////////////////////////////////////////////
+
+    auto makeStream( StringRef const &filename ) -> IStream const* {
+        if( filename.empty() )
+            return new Detail::CoutStream();
+        else if( filename[0] == '%' ) {
+            if( filename == "%debug" )
+                return new Detail::DebugOutStream();
             else
-                sputc( static_cast<char>( c ) );
+                CATCH_ERROR( "Unrecognised stream: '" << filename << "'" );
         }
-        return 0;
-    }
-
-    int sync() override {
-        if( pbase() != pptr() ) {
-            m_writer( std::string( pbase(), static_cast<std::string::size_type>( pptr() - pbase() ) ) );
-            setp( pbase(), epptr() );
-        }
-        return 0;
-    }
-};
-
-///////////////////////////////////////////////////////////////////////////
-
-struct OutputDebugWriter {
-
-    void operator()( std::string const&str ) {
-        writeToDebugConsole( str );
-    }
-};
-
-///////////////////////////////////////////////////////////////////////////
-
-class FileStream : public IStream {
-    mutable std::ofstream m_ofs;
-public:
-    FileStream( StringRef filename ) {
-        m_ofs.open( filename.c_str() );
-        CATCH_ENFORCE( !m_ofs.fail(), "Unable to open file: '" << filename << "'" );
-    }
-    ~FileStream() override = default;
-public: // IStream
-    std::ostream& stream() const override {
-        return m_ofs;
-    }
-};
-
-///////////////////////////////////////////////////////////////////////////
-
-class CoutStream : public IStream {
-    mutable std::ostream m_os;
-public:
-    // Store the streambuf from cout up-front because
-    // cout may get redirected when running tests
-    CoutStream() : m_os( Catch::cout().rdbuf() ) {}
-    ~CoutStream() override = default;
-
-public: // IStream
-    std::ostream& stream() const override { return m_os; }
-};
-
-///////////////////////////////////////////////////////////////////////////
-
-class DebugOutStream : public IStream {
-    std::unique_ptr<StreamBufImpl<OutputDebugWriter>> m_streamBuf;
-    mutable std::ostream m_os;
-public:
-    DebugOutStream()
-        :   m_streamBuf( new StreamBufImpl<OutputDebugWriter>() ),
-            m_os( m_streamBuf.get() )
-    {}
-
-    ~DebugOutStream() override = default;
-
-public: // IStream
-    std::ostream& stream() const override { return m_os; }
-};
-
-}} // namespace anon::detail
-
-///////////////////////////////////////////////////////////////////////////
-
-auto makeStream( StringRef const &filename ) -> IStream const* {
-    if( filename.empty() )
-        return new Detail::CoutStream();
-    else if( filename[0] == '%' ) {
-        if( filename == "%debug" )
-            return new Detail::DebugOutStream();
         else
-            CATCH_ERROR( "Unrecognised stream: '" << filename << "'" );
+            return new Detail::FileStream( filename );
     }
-    else
-        return new Detail::FileStream( filename );
-}
 
-// This class encapsulates the idea of a pool of ostringstreams that can be reused.
-struct StringStreams {
-    std::vector<std::unique_ptr<std::ostringstream>> m_streams;
-    std::vector<std::size_t> m_unused;
-    std::ostringstream m_referenceStream; // Used for copy state/ flags from
+    // This class encapsulates the idea of a pool of ostringstreams that can be reused.
+    struct StringStreams {
+        std::vector<std::unique_ptr<std::ostringstream>> m_streams;
+        std::vector<std::size_t> m_unused;
+        std::ostringstream m_referenceStream; // Used for copy state/ flags from
 
-    auto add() -> std::size_t {
-        if( m_unused.empty() ) {
-            m_streams.push_back( std::unique_ptr<std::ostringstream>( new std::ostringstream ) );
-            return m_streams.size()-1;
+        auto add() -> std::size_t {
+            if( m_unused.empty() ) {
+                m_streams.push_back( std::unique_ptr<std::ostringstream>( new std::ostringstream ) );
+                return m_streams.size()-1;
+            }
+            else {
+                auto index = m_unused.back();
+                m_unused.pop_back();
+                return index;
+            }
         }
-        else {
-            auto index = m_unused.back();
-            m_unused.pop_back();
-            return index;
+
+        void release( std::size_t index ) {
+            m_streams[index]->copyfmt( m_referenceStream ); // Restore initial flags and other state
+            m_unused.push_back(index);
         }
-    }
+    };
 
-    void release( std::size_t index ) {
-        m_streams[index]->copyfmt( m_referenceStream ); // Restore initial flags and other state
-        m_unused.push_back(index);
-    }
-};
-
-ReusableStringStream::ReusableStringStream()
+    ReusableStringStream::ReusableStringStream()
     :   m_index( Singleton<StringStreams>::getMutable().add() ),
         m_oss( Singleton<StringStreams>::getMutable().m_streams[m_index].get() )
-{}
+    {}
 
-ReusableStringStream::~ReusableStringStream() {
-    static_cast<std::ostringstream*>( m_oss )->str("");
-    m_oss->clear();
-    Singleton<StringStreams>::getMutable().release( m_index );
-}
+    ReusableStringStream::~ReusableStringStream() {
+        static_cast<std::ostringstream*>( m_oss )->str("");
+        m_oss->clear();
+        Singleton<StringStreams>::getMutable().release( m_index );
+    }
 
-auto ReusableStringStream::str() const -> std::string {
-    return static_cast<std::ostringstream*>( m_oss )->str();
-}
+    auto ReusableStringStream::str() const -> std::string {
+        return static_cast<std::ostringstream*>( m_oss )->str();
+    }
 
-///////////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
 
 #ifndef CATCH_CONFIG_NOSTDOUT // If you #define this you must implement these functions
-std::ostream& cout() { return std::cout; }
-std::ostream& cerr() { return std::cerr; }
-std::ostream& clog() { return std::clog; }
+    std::ostream& cout() { return std::cout; }
+    std::ostream& cerr() { return std::cerr; }
+    std::ostream& clog() { return std::clog; }
 #endif
 }
 // end catch_stream.cpp
@@ -13706,95 +13808,95 @@ std::ostream& clog() { return std::clog; }
 
 namespace Catch {
 
-namespace {
-char toLowerCh(char c) {
-    return static_cast<char>( std::tolower( static_cast<unsigned char>(c) ) );
-}
-}
-
-bool startsWith( std::string const& s, std::string const& prefix ) {
-    return s.size() >= prefix.size() && std::equal(prefix.begin(), prefix.end(), s.begin());
-}
-bool startsWith( std::string const& s, char prefix ) {
-    return !s.empty() && s[0] == prefix;
-}
-bool endsWith( std::string const& s, std::string const& suffix ) {
-    return s.size() >= suffix.size() && std::equal(suffix.rbegin(), suffix.rend(), s.rbegin());
-}
-bool endsWith( std::string const& s, char suffix ) {
-    return !s.empty() && s[s.size()-1] == suffix;
-}
-bool contains( std::string const& s, std::string const& infix ) {
-    return s.find( infix ) != std::string::npos;
-}
-void toLowerInPlace( std::string& s ) {
-    std::transform( s.begin(), s.end(), s.begin(), toLowerCh );
-}
-std::string toLower( std::string const& s ) {
-    std::string lc = s;
-    toLowerInPlace( lc );
-    return lc;
-}
-std::string trim( std::string const& str ) {
-    static char const* whitespaceChars = "\n\r\t ";
-    std::string::size_type start = str.find_first_not_of( whitespaceChars );
-    std::string::size_type end = str.find_last_not_of( whitespaceChars );
-
-    return start != std::string::npos ? str.substr( start, 1+end-start ) : std::string();
-}
-
-StringRef trim(StringRef ref) {
-    const auto is_ws = [](char c) {
-        return c == ' ' || c == '\t' || c == '\n' || c == '\r';
-    };
-    size_t real_begin = 0;
-    while (real_begin < ref.size() && is_ws(ref[real_begin])) { ++real_begin; }
-    size_t real_end = ref.size();
-    while (real_end > real_begin && is_ws(ref[real_end - 1])) { --real_end; }
-
-    return ref.substr(real_begin, real_end - real_begin);
-}
-
-bool replaceInPlace( std::string& str, std::string const& replaceThis, std::string const& withThis ) {
-    bool replaced = false;
-    std::size_t i = str.find( replaceThis );
-    while( i != std::string::npos ) {
-        replaced = true;
-        str = str.substr( 0, i ) + withThis + str.substr( i+replaceThis.size() );
-        if( i < str.size()-withThis.size() )
-            i = str.find( replaceThis, i+withThis.size() );
-        else
-            i = std::string::npos;
-    }
-    return replaced;
-}
-
-std::vector<StringRef> splitStringRef( StringRef str, char delimiter ) {
-    std::vector<StringRef> subStrings;
-    std::size_t start = 0;
-    for(std::size_t pos = 0; pos < str.size(); ++pos ) {
-        if( str[pos] == delimiter ) {
-            if( pos - start > 1 )
-                subStrings.push_back( str.substr( start, pos-start ) );
-            start = pos+1;
+    namespace {
+        char toLowerCh(char c) {
+            return static_cast<char>( std::tolower( static_cast<unsigned char>(c) ) );
         }
     }
-    if( start < str.size() )
-        subStrings.push_back( str.substr( start, str.size()-start ) );
-    return subStrings;
-}
 
-pluralise::pluralise( std::size_t count, std::string const& label )
+    bool startsWith( std::string const& s, std::string const& prefix ) {
+        return s.size() >= prefix.size() && std::equal(prefix.begin(), prefix.end(), s.begin());
+    }
+    bool startsWith( std::string const& s, char prefix ) {
+        return !s.empty() && s[0] == prefix;
+    }
+    bool endsWith( std::string const& s, std::string const& suffix ) {
+        return s.size() >= suffix.size() && std::equal(suffix.rbegin(), suffix.rend(), s.rbegin());
+    }
+    bool endsWith( std::string const& s, char suffix ) {
+        return !s.empty() && s[s.size()-1] == suffix;
+    }
+    bool contains( std::string const& s, std::string const& infix ) {
+        return s.find( infix ) != std::string::npos;
+    }
+    void toLowerInPlace( std::string& s ) {
+        std::transform( s.begin(), s.end(), s.begin(), toLowerCh );
+    }
+    std::string toLower( std::string const& s ) {
+        std::string lc = s;
+        toLowerInPlace( lc );
+        return lc;
+    }
+    std::string trim( std::string const& str ) {
+        static char const* whitespaceChars = "\n\r\t ";
+        std::string::size_type start = str.find_first_not_of( whitespaceChars );
+        std::string::size_type end = str.find_last_not_of( whitespaceChars );
+
+        return start != std::string::npos ? str.substr( start, 1+end-start ) : std::string();
+    }
+
+    StringRef trim(StringRef ref) {
+        const auto is_ws = [](char c) {
+            return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+        };
+        size_t real_begin = 0;
+        while (real_begin < ref.size() && is_ws(ref[real_begin])) { ++real_begin; }
+        size_t real_end = ref.size();
+        while (real_end > real_begin && is_ws(ref[real_end - 1])) { --real_end; }
+
+        return ref.substr(real_begin, real_end - real_begin);
+    }
+
+    bool replaceInPlace( std::string& str, std::string const& replaceThis, std::string const& withThis ) {
+        bool replaced = false;
+        std::size_t i = str.find( replaceThis );
+        while( i != std::string::npos ) {
+            replaced = true;
+            str = str.substr( 0, i ) + withThis + str.substr( i+replaceThis.size() );
+            if( i < str.size()-withThis.size() )
+                i = str.find( replaceThis, i+withThis.size() );
+            else
+                i = std::string::npos;
+        }
+        return replaced;
+    }
+
+    std::vector<StringRef> splitStringRef( StringRef str, char delimiter ) {
+        std::vector<StringRef> subStrings;
+        std::size_t start = 0;
+        for(std::size_t pos = 0; pos < str.size(); ++pos ) {
+            if( str[pos] == delimiter ) {
+                if( pos - start > 1 )
+                    subStrings.push_back( str.substr( start, pos-start ) );
+                start = pos+1;
+            }
+        }
+        if( start < str.size() )
+            subStrings.push_back( str.substr( start, str.size()-start ) );
+        return subStrings;
+    }
+
+    pluralise::pluralise( std::size_t count, std::string const& label )
     :   m_count( count ),
         m_label( label )
-{}
+    {}
 
-std::ostream& operator << ( std::ostream& os, pluralise const& pluraliser ) {
-    os << pluraliser.m_count << ' ' << pluraliser.m_label;
-    if( pluraliser.m_count != 1 )
-        os << 's';
-    return os;
-}
+    std::ostream& operator << ( std::ostream& os, pluralise const& pluraliser ) {
+        os << pluraliser.m_count << ' ' << pluraliser.m_label;
+        if( pluraliser.m_count != 1 )
+            os << 's';
+        return os;
+    }
 
 }
 // end catch_string_manip.cpp
@@ -13806,59 +13908,59 @@ std::ostream& operator << ( std::ostream& os, pluralise const& pluraliser ) {
 #include <cstdint>
 
 namespace Catch {
-StringRef::StringRef( char const* rawChars ) noexcept
+    StringRef::StringRef( char const* rawChars ) noexcept
     : StringRef( rawChars, static_cast<StringRef::size_type>(std::strlen(rawChars) ) )
-{}
+    {}
 
-auto StringRef::c_str() const -> char const* {
-    CATCH_ENFORCE(isNullTerminated(), "Called StringRef::c_str() on a non-null-terminated instance");
-    return m_start;
-}
-auto StringRef::data() const noexcept -> char const* {
-    return m_start;
-}
-
-auto StringRef::substr( size_type start, size_type size ) const noexcept -> StringRef {
-    if (start < m_size) {
-        return StringRef(m_start + start, (std::min)(m_size - start, size));
-    } else {
-        return StringRef();
+    auto StringRef::c_str() const -> char const* {
+        CATCH_ENFORCE(isNullTerminated(), "Called StringRef::c_str() on a non-null-terminated instance");
+        return m_start;
     }
-}
-auto StringRef::operator == ( StringRef const& other ) const noexcept -> bool {
-    return m_size == other.m_size
-        && (std::memcmp( m_start, other.m_start, m_size ) == 0);
-}
+    auto StringRef::data() const noexcept -> char const* {
+        return m_start;
+    }
 
-auto operator << ( std::ostream& os, StringRef const& str ) -> std::ostream& {
-    return os.write(str.data(), str.size());
-}
+    auto StringRef::substr( size_type start, size_type size ) const noexcept -> StringRef {
+        if (start < m_size) {
+            return StringRef(m_start + start, (std::min)(m_size - start, size));
+        } else {
+            return StringRef();
+        }
+    }
+    auto StringRef::operator == ( StringRef const& other ) const noexcept -> bool {
+        return m_size == other.m_size
+            && (std::memcmp( m_start, other.m_start, m_size ) == 0);
+    }
 
-auto operator+=( std::string& lhs, StringRef const& rhs ) -> std::string& {
-    lhs.append(rhs.data(), rhs.size());
-    return lhs;
-}
+    auto operator << ( std::ostream& os, StringRef const& str ) -> std::ostream& {
+        return os.write(str.data(), str.size());
+    }
+
+    auto operator+=( std::string& lhs, StringRef const& rhs ) -> std::string& {
+        lhs.append(rhs.data(), rhs.size());
+        return lhs;
+    }
 
 } // namespace Catch
 // end catch_stringref.cpp
 // start catch_tag_alias.cpp
 
 namespace Catch {
-TagAlias::TagAlias(std::string const & _tag, SourceLineInfo _lineInfo): tag(_tag), lineInfo(_lineInfo) {}
+    TagAlias::TagAlias(std::string const & _tag, SourceLineInfo _lineInfo): tag(_tag), lineInfo(_lineInfo) {}
 }
 // end catch_tag_alias.cpp
 // start catch_tag_alias_autoregistrar.cpp
 
 namespace Catch {
 
-RegistrarForTagAliases::RegistrarForTagAliases(char const* alias, char const* tag, SourceLineInfo const& lineInfo) {
-    CATCH_TRY {
-        getMutableRegistryHub().registerTagAlias(alias, tag, lineInfo);
-    } CATCH_CATCH_ALL {
-        // Do not throw when constructing global objects, instead register the exception to be processed later
-        getMutableRegistryHub().registerStartupException();
+    RegistrarForTagAliases::RegistrarForTagAliases(char const* alias, char const* tag, SourceLineInfo const& lineInfo) {
+        CATCH_TRY {
+            getMutableRegistryHub().registerTagAlias(alias, tag, lineInfo);
+        } CATCH_CATCH_ALL {
+            // Do not throw when constructing global objects, instead register the exception to be processed later
+            getMutableRegistryHub().registerStartupException();
+        }
     }
-}
 
 }
 // end catch_tag_alias_autoregistrar.cpp
@@ -13868,44 +13970,44 @@ RegistrarForTagAliases::RegistrarForTagAliases(char const* alias, char const* ta
 
 namespace Catch {
 
-TagAliasRegistry::~TagAliasRegistry() {}
+    TagAliasRegistry::~TagAliasRegistry() {}
 
-TagAlias const* TagAliasRegistry::find( std::string const& alias ) const {
-    auto it = m_registry.find( alias );
-    if( it != m_registry.end() )
-        return &(it->second);
-    else
-        return nullptr;
-}
-
-std::string TagAliasRegistry::expandAliases( std::string const& unexpandedTestSpec ) const {
-    std::string expandedTestSpec = unexpandedTestSpec;
-    for( auto const& registryKvp : m_registry ) {
-        std::size_t pos = expandedTestSpec.find( registryKvp.first );
-        if( pos != std::string::npos ) {
-            expandedTestSpec =  expandedTestSpec.substr( 0, pos ) +
-                registryKvp.second.tag +
-                expandedTestSpec.substr( pos + registryKvp.first.size() );
-        }
+    TagAlias const* TagAliasRegistry::find( std::string const& alias ) const {
+        auto it = m_registry.find( alias );
+        if( it != m_registry.end() )
+            return &(it->second);
+        else
+            return nullptr;
     }
-    return expandedTestSpec;
-}
 
-void TagAliasRegistry::add( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo ) {
-    CATCH_ENFORCE( startsWith(alias, "[@") && endsWith(alias, ']'),
-                   "error: tag alias, '" << alias << "' is not of the form [@alias name].\n" << lineInfo );
+    std::string TagAliasRegistry::expandAliases( std::string const& unexpandedTestSpec ) const {
+        std::string expandedTestSpec = unexpandedTestSpec;
+        for( auto const& registryKvp : m_registry ) {
+            std::size_t pos = expandedTestSpec.find( registryKvp.first );
+            if( pos != std::string::npos ) {
+                expandedTestSpec =  expandedTestSpec.substr( 0, pos ) +
+                                    registryKvp.second.tag +
+                                    expandedTestSpec.substr( pos + registryKvp.first.size() );
+            }
+        }
+        return expandedTestSpec;
+    }
 
-    CATCH_ENFORCE( m_registry.insert(std::make_pair(alias, TagAlias(tag, lineInfo))).second,
-                   "error: tag alias, '" << alias << "' already registered.\n"
-                                         << "\tFirst seen at: " << find(alias)->lineInfo << "\n"
-                                         << "\tRedefined at: " << lineInfo );
-}
+    void TagAliasRegistry::add( std::string const& alias, std::string const& tag, SourceLineInfo const& lineInfo ) {
+        CATCH_ENFORCE( startsWith(alias, "[@") && endsWith(alias, ']'),
+                      "error: tag alias, '" << alias << "' is not of the form [@alias name].\n" << lineInfo );
 
-ITagAliasRegistry::~ITagAliasRegistry() {}
+        CATCH_ENFORCE( m_registry.insert(std::make_pair(alias, TagAlias(tag, lineInfo))).second,
+                      "error: tag alias, '" << alias << "' already registered.\n"
+                      << "\tFirst seen at: " << find(alias)->lineInfo << "\n"
+                      << "\tRedefined at: " << lineInfo );
+    }
 
-ITagAliasRegistry const& ITagAliasRegistry::get() {
-    return getRegistryHub().getTagAliasRegistry();
-}
+    ITagAliasRegistry::~ITagAliasRegistry() {}
+
+    ITagAliasRegistry const& ITagAliasRegistry::get() {
+        return getRegistryHub().getTagAliasRegistry();
+    }
 
 } // end namespace Catch
 // end catch_tag_alias_registry.cpp
@@ -13918,167 +14020,167 @@ ITagAliasRegistry const& ITagAliasRegistry::get() {
 
 namespace Catch {
 
-namespace {
-TestCaseInfo::SpecialProperties parseSpecialTag( std::string const& tag ) {
-    if( startsWith( tag, '.' ) ||
-        tag == "!hide" )
-        return TestCaseInfo::IsHidden;
-    else if( tag == "!throws" )
-        return TestCaseInfo::Throws;
-    else if( tag == "!shouldfail" )
-        return TestCaseInfo::ShouldFail;
-    else if( tag == "!mayfail" )
-        return TestCaseInfo::MayFail;
-    else if( tag == "!nonportable" )
-        return TestCaseInfo::NonPortable;
-    else if( tag == "!benchmark" )
-        return static_cast<TestCaseInfo::SpecialProperties>( TestCaseInfo::Benchmark | TestCaseInfo::IsHidden );
-    else
-        return TestCaseInfo::None;
-}
-bool isReservedTag( std::string const& tag ) {
-    return parseSpecialTag( tag ) == TestCaseInfo::None && tag.size() > 0 && !std::isalnum( static_cast<unsigned char>(tag[0]) );
-}
-void enforceNotReservedTag( std::string const& tag, SourceLineInfo const& _lineInfo ) {
-    CATCH_ENFORCE( !isReservedTag(tag),
-                   "Tag name: [" << tag << "] is not allowed.\n"
-                                 << "Tag names starting with non alphanumeric characters are reserved\n"
-                                 << _lineInfo );
-}
-}
-
-TestCase makeTestCase(  ITestInvoker* _testCase,
-                        std::string const& _className,
-                        NameAndTags const& nameAndTags,
-                        SourceLineInfo const& _lineInfo )
-{
-    bool isHidden = false;
-
-    // Parse out tags
-    std::vector<std::string> tags;
-    std::string desc, tag;
-    bool inTag = false;
-    for (char c : nameAndTags.tags) {
-        if( !inTag ) {
-            if( c == '[' )
-                inTag = true;
+    namespace {
+        TestCaseInfo::SpecialProperties parseSpecialTag( std::string const& tag ) {
+            if( startsWith( tag, '.' ) ||
+                tag == "!hide" )
+                return TestCaseInfo::IsHidden;
+            else if( tag == "!throws" )
+                return TestCaseInfo::Throws;
+            else if( tag == "!shouldfail" )
+                return TestCaseInfo::ShouldFail;
+            else if( tag == "!mayfail" )
+                return TestCaseInfo::MayFail;
+            else if( tag == "!nonportable" )
+                return TestCaseInfo::NonPortable;
+            else if( tag == "!benchmark" )
+                return static_cast<TestCaseInfo::SpecialProperties>( TestCaseInfo::Benchmark | TestCaseInfo::IsHidden );
             else
-                desc += c;
+                return TestCaseInfo::None;
         }
-        else {
-            if( c == ']' ) {
-                TestCaseInfo::SpecialProperties prop = parseSpecialTag( tag );
-                if( ( prop & TestCaseInfo::IsHidden ) != 0 )
-                    isHidden = true;
-                else if( prop == TestCaseInfo::None )
-                    enforceNotReservedTag( tag, _lineInfo );
-
-                // Merged hide tags like `[.approvals]` should be added as
-                // `[.][approvals]`. The `[.]` is added at later point, so
-                // we only strip the prefix
-                if (startsWith(tag, '.') && tag.size() > 1) {
-                    tag.erase(0, 1);
-                }
-                tags.push_back( tag );
-                tag.clear();
-                inTag = false;
-            }
-            else
-                tag += c;
+        bool isReservedTag( std::string const& tag ) {
+            return parseSpecialTag( tag ) == TestCaseInfo::None && tag.size() > 0 && !std::isalnum( static_cast<unsigned char>(tag[0]) );
+        }
+        void enforceNotReservedTag( std::string const& tag, SourceLineInfo const& _lineInfo ) {
+            CATCH_ENFORCE( !isReservedTag(tag),
+                          "Tag name: [" << tag << "] is not allowed.\n"
+                          << "Tag names starting with non alphanumeric characters are reserved\n"
+                          << _lineInfo );
         }
     }
-    if( isHidden ) {
-        // Add all "hidden" tags to make them behave identically
-        tags.insert( tags.end(), { ".", "!hide" } );
-    }
 
-    TestCaseInfo info( static_cast<std::string>(nameAndTags.name), _className, desc, tags, _lineInfo );
-    return TestCase( _testCase, std::move(info) );
-}
-
-void setTags( TestCaseInfo& testCaseInfo, std::vector<std::string> tags ) {
-    std::sort(begin(tags), end(tags));
-    tags.erase(std::unique(begin(tags), end(tags)), end(tags));
-    testCaseInfo.lcaseTags.clear();
-
-    for( auto const& tag : tags ) {
-        std::string lcaseTag = toLower( tag );
-        testCaseInfo.properties = static_cast<TestCaseInfo::SpecialProperties>( testCaseInfo.properties | parseSpecialTag( lcaseTag ) );
-        testCaseInfo.lcaseTags.push_back( lcaseTag );
-    }
-    testCaseInfo.tags = std::move(tags);
-}
-
-TestCaseInfo::TestCaseInfo( std::string const& _name,
+    TestCase makeTestCase(  ITestInvoker* _testCase,
                             std::string const& _className,
-                            std::string const& _description,
-                            std::vector<std::string> const& _tags,
+                            NameAndTags const& nameAndTags,
                             SourceLineInfo const& _lineInfo )
+    {
+        bool isHidden = false;
+
+        // Parse out tags
+        std::vector<std::string> tags;
+        std::string desc, tag;
+        bool inTag = false;
+        for (char c : nameAndTags.tags) {
+            if( !inTag ) {
+                if( c == '[' )
+                    inTag = true;
+                else
+                    desc += c;
+            }
+            else {
+                if( c == ']' ) {
+                    TestCaseInfo::SpecialProperties prop = parseSpecialTag( tag );
+                    if( ( prop & TestCaseInfo::IsHidden ) != 0 )
+                        isHidden = true;
+                    else if( prop == TestCaseInfo::None )
+                        enforceNotReservedTag( tag, _lineInfo );
+
+                    // Merged hide tags like `[.approvals]` should be added as
+                    // `[.][approvals]`. The `[.]` is added at later point, so
+                    // we only strip the prefix
+                    if (startsWith(tag, '.') && tag.size() > 1) {
+                        tag.erase(0, 1);
+                    }
+                    tags.push_back( tag );
+                    tag.clear();
+                    inTag = false;
+                }
+                else
+                    tag += c;
+            }
+        }
+        if( isHidden ) {
+            // Add all "hidden" tags to make them behave identically
+            tags.insert( tags.end(), { ".", "!hide" } );
+        }
+
+        TestCaseInfo info( static_cast<std::string>(nameAndTags.name), _className, desc, tags, _lineInfo );
+        return TestCase( _testCase, std::move(info) );
+    }
+
+    void setTags( TestCaseInfo& testCaseInfo, std::vector<std::string> tags ) {
+        std::sort(begin(tags), end(tags));
+        tags.erase(std::unique(begin(tags), end(tags)), end(tags));
+        testCaseInfo.lcaseTags.clear();
+
+        for( auto const& tag : tags ) {
+            std::string lcaseTag = toLower( tag );
+            testCaseInfo.properties = static_cast<TestCaseInfo::SpecialProperties>( testCaseInfo.properties | parseSpecialTag( lcaseTag ) );
+            testCaseInfo.lcaseTags.push_back( lcaseTag );
+        }
+        testCaseInfo.tags = std::move(tags);
+    }
+
+    TestCaseInfo::TestCaseInfo( std::string const& _name,
+                                std::string const& _className,
+                                std::string const& _description,
+                                std::vector<std::string> const& _tags,
+                                SourceLineInfo const& _lineInfo )
     :   name( _name ),
         className( _className ),
         description( _description ),
         lineInfo( _lineInfo ),
         properties( None )
-{
-    setTags( *this, _tags );
-}
-
-bool TestCaseInfo::isHidden() const {
-    return ( properties & IsHidden ) != 0;
-}
-bool TestCaseInfo::throws() const {
-    return ( properties & Throws ) != 0;
-}
-bool TestCaseInfo::okToFail() const {
-    return ( properties & (ShouldFail | MayFail ) ) != 0;
-}
-bool TestCaseInfo::expectedToFail() const {
-    return ( properties & (ShouldFail ) ) != 0;
-}
-
-std::string TestCaseInfo::tagsAsString() const {
-    std::string ret;
-    // '[' and ']' per tag
-    std::size_t full_size = 2 * tags.size();
-    for (const auto& tag : tags) {
-        full_size += tag.size();
-    }
-    ret.reserve(full_size);
-    for (const auto& tag : tags) {
-        ret.push_back('[');
-        ret.append(tag);
-        ret.push_back(']');
+    {
+        setTags( *this, _tags );
     }
 
-    return ret;
-}
+    bool TestCaseInfo::isHidden() const {
+        return ( properties & IsHidden ) != 0;
+    }
+    bool TestCaseInfo::throws() const {
+        return ( properties & Throws ) != 0;
+    }
+    bool TestCaseInfo::okToFail() const {
+        return ( properties & (ShouldFail | MayFail ) ) != 0;
+    }
+    bool TestCaseInfo::expectedToFail() const {
+        return ( properties & (ShouldFail ) ) != 0;
+    }
 
-TestCase::TestCase( ITestInvoker* testCase, TestCaseInfo&& info ) : TestCaseInfo( std::move(info) ), test( testCase ) {}
+    std::string TestCaseInfo::tagsAsString() const {
+        std::string ret;
+        // '[' and ']' per tag
+        std::size_t full_size = 2 * tags.size();
+        for (const auto& tag : tags) {
+            full_size += tag.size();
+        }
+        ret.reserve(full_size);
+        for (const auto& tag : tags) {
+            ret.push_back('[');
+            ret.append(tag);
+            ret.push_back(']');
+        }
 
-TestCase TestCase::withName( std::string const& _newName ) const {
-    TestCase other( *this );
-    other.name = _newName;
-    return other;
-}
+        return ret;
+    }
 
-void TestCase::invoke() const {
-    test->invoke();
-}
+    TestCase::TestCase( ITestInvoker* testCase, TestCaseInfo&& info ) : TestCaseInfo( std::move(info) ), test( testCase ) {}
 
-bool TestCase::operator == ( TestCase const& other ) const {
-    return  test.get() == other.test.get() &&
-        name == other.name &&
-        className == other.className;
-}
+    TestCase TestCase::withName( std::string const& _newName ) const {
+        TestCase other( *this );
+        other.name = _newName;
+        return other;
+    }
 
-bool TestCase::operator < ( TestCase const& other ) const {
-    return name < other.name;
-}
+    void TestCase::invoke() const {
+        test->invoke();
+    }
 
-TestCaseInfo const& TestCase::getTestCaseInfo() const
-{
-    return *this;
-}
+    bool TestCase::operator == ( TestCase const& other ) const {
+        return  test.get() == other.test.get() &&
+                name == other.name &&
+                className == other.className;
+    }
+
+    bool TestCase::operator < ( TestCase const& other ) const {
+        return name < other.name;
+    }
+
+    TestCaseInfo const& TestCase::getTestCaseInfo() const
+    {
+        return *this;
+    }
 
 } // end namespace Catch
 // end catch_test_case_info.cpp
@@ -14089,151 +14191,155 @@ TestCaseInfo const& TestCase::getTestCaseInfo() const
 
 namespace Catch {
 
-namespace {
-struct TestHasher {
-    explicit TestHasher(Catch::SimplePcg32& rng) {
-        basis = rng();
-        basis <<= 32;
-        basis |= rng();
-    }
+    namespace {
+        struct TestHasher {
+            using hash_t = uint64_t;
 
-    uint64_t basis;
+            explicit TestHasher( hash_t hashSuffix ):
+                m_hashSuffix{ hashSuffix } {}
 
-    uint64_t operator()(TestCase const& t) const {
-        // Modified FNV-1a hash
-        static constexpr uint64_t prime = 1099511628211;
-        uint64_t hash = basis;
-        for (const char c : t.name) {
-            hash ^= c;
-            hash *= prime;
-        }
-        return hash;
-    }
-};
-} // end unnamed namespace
-
-std::vector<TestCase> sortTests( IConfig const& config, std::vector<TestCase> const& unsortedTestCases ) {
-    switch( config.runOrder() ) {
-        case RunTests::InDeclarationOrder:
-            // already in declaration order
-            break;
-
-        case RunTests::InLexicographicalOrder: {
-            std::vector<TestCase> sorted = unsortedTestCases;
-            std::sort( sorted.begin(), sorted.end() );
-            return sorted;
-        }
-
-        case RunTests::InRandomOrder: {
-            seedRng( config );
-            TestHasher h( rng() );
-
-            using hashedTest = std::pair<uint64_t, TestCase const*>;
-            std::vector<hashedTest> indexed_tests;
-            indexed_tests.reserve( unsortedTestCases.size() );
-
-            for (auto const& testCase : unsortedTestCases) {
-                indexed_tests.emplace_back(h(testCase), &testCase);
+            uint32_t operator()( TestCase const& t ) const {
+                // FNV-1a hash with multiplication fold.
+                const hash_t prime = 1099511628211u;
+                hash_t hash = 14695981039346656037u;
+                for ( const char c : t.name ) {
+                    hash ^= c;
+                    hash *= prime;
+                }
+                hash ^= m_hashSuffix;
+                hash *= prime;
+                const uint32_t low{ static_cast<uint32_t>( hash ) };
+                const uint32_t high{ static_cast<uint32_t>( hash >> 32 ) };
+                return low * high;
             }
 
-            std::sort(indexed_tests.begin(), indexed_tests.end(),
-                      [](hashedTest const& lhs, hashedTest const& rhs) {
+        private:
+            hash_t m_hashSuffix;
+        };
+    } // end unnamed namespace
+
+    std::vector<TestCase> sortTests( IConfig const& config, std::vector<TestCase> const& unsortedTestCases ) {
+        switch( config.runOrder() ) {
+            case RunTests::InDeclarationOrder:
+                // already in declaration order
+                break;
+
+            case RunTests::InLexicographicalOrder: {
+                std::vector<TestCase> sorted = unsortedTestCases;
+                std::sort( sorted.begin(), sorted.end() );
+                return sorted;
+            }
+
+            case RunTests::InRandomOrder: {
+                seedRng( config );
+                TestHasher h{ config.rngSeed() };
+
+                using hashedTest = std::pair<TestHasher::hash_t, TestCase const*>;
+                std::vector<hashedTest> indexed_tests;
+                indexed_tests.reserve( unsortedTestCases.size() );
+
+                for (auto const& testCase : unsortedTestCases) {
+                    indexed_tests.emplace_back(h(testCase), &testCase);
+                }
+
+                std::sort(indexed_tests.begin(), indexed_tests.end(),
+                          [](hashedTest const& lhs, hashedTest const& rhs) {
                           if (lhs.first == rhs.first) {
                               return lhs.second->name < rhs.second->name;
                           }
                           return lhs.first < rhs.first;
-                      });
+                });
 
-            std::vector<TestCase> sorted;
-            sorted.reserve( indexed_tests.size() );
+                std::vector<TestCase> sorted;
+                sorted.reserve( indexed_tests.size() );
 
-            for (auto const& hashed : indexed_tests) {
-                sorted.emplace_back(*hashed.second);
+                for (auto const& hashed : indexed_tests) {
+                    sorted.emplace_back(*hashed.second);
+                }
+
+                return sorted;
             }
+        }
+        return unsortedTestCases;
+    }
 
-            return sorted;
+    bool isThrowSafe( TestCase const& testCase, IConfig const& config ) {
+        return !testCase.throws() || config.allowThrows();
+    }
+
+    bool matchTest( TestCase const& testCase, TestSpec const& testSpec, IConfig const& config ) {
+        return testSpec.matches( testCase ) && isThrowSafe( testCase, config );
+    }
+
+    void enforceNoDuplicateTestCases( std::vector<TestCase> const& functions ) {
+        std::set<TestCase> seenFunctions;
+        for( auto const& function : functions ) {
+            auto prev = seenFunctions.insert( function );
+            CATCH_ENFORCE( prev.second,
+                    "error: TEST_CASE( \"" << function.name << "\" ) already defined.\n"
+                    << "\tFirst seen at " << prev.first->getTestCaseInfo().lineInfo << "\n"
+                    << "\tRedefined at " << function.getTestCaseInfo().lineInfo );
         }
     }
-    return unsortedTestCases;
-}
 
-bool isThrowSafe( TestCase const& testCase, IConfig const& config ) {
-    return !testCase.throws() || config.allowThrows();
-}
-
-bool matchTest( TestCase const& testCase, TestSpec const& testSpec, IConfig const& config ) {
-    return testSpec.matches( testCase ) && isThrowSafe( testCase, config );
-}
-
-void enforceNoDuplicateTestCases( std::vector<TestCase> const& functions ) {
-    std::set<TestCase> seenFunctions;
-    for( auto const& function : functions ) {
-        auto prev = seenFunctions.insert( function );
-        CATCH_ENFORCE( prev.second,
-                       "error: TEST_CASE( \"" << function.name << "\" ) already defined.\n"
-                                              << "\tFirst seen at " << prev.first->getTestCaseInfo().lineInfo << "\n"
-                                              << "\tRedefined at " << function.getTestCaseInfo().lineInfo );
-    }
-}
-
-std::vector<TestCase> filterTests( std::vector<TestCase> const& testCases, TestSpec const& testSpec, IConfig const& config ) {
-    std::vector<TestCase> filtered;
-    filtered.reserve( testCases.size() );
-    for (auto const& testCase : testCases) {
-        if ((!testSpec.hasFilters() && !testCase.isHidden()) ||
-            (testSpec.hasFilters() && matchTest(testCase, testSpec, config))) {
-            filtered.push_back(testCase);
+    std::vector<TestCase> filterTests( std::vector<TestCase> const& testCases, TestSpec const& testSpec, IConfig const& config ) {
+        std::vector<TestCase> filtered;
+        filtered.reserve( testCases.size() );
+        for (auto const& testCase : testCases) {
+            if ((!testSpec.hasFilters() && !testCase.isHidden()) ||
+                (testSpec.hasFilters() && matchTest(testCase, testSpec, config))) {
+                filtered.push_back(testCase);
+            }
         }
+        return filtered;
     }
-    return filtered;
-}
-std::vector<TestCase> const& getAllTestCasesSorted( IConfig const& config ) {
-    return getRegistryHub().getTestCaseRegistry().getAllTestsSorted( config );
-}
-
-void TestRegistry::registerTest( TestCase const& testCase ) {
-    std::string name = testCase.getTestCaseInfo().name;
-    if( name.empty() ) {
-        ReusableStringStream rss;
-        rss << "Anonymous test case " << ++m_unnamedCount;
-        return registerTest( testCase.withName( rss.str() ) );
+    std::vector<TestCase> const& getAllTestCasesSorted( IConfig const& config ) {
+        return getRegistryHub().getTestCaseRegistry().getAllTestsSorted( config );
     }
-    m_functions.push_back( testCase );
-}
 
-std::vector<TestCase> const& TestRegistry::getAllTests() const {
-    return m_functions;
-}
-std::vector<TestCase> const& TestRegistry::getAllTestsSorted( IConfig const& config ) const {
-    if( m_sortedFunctions.empty() )
-        enforceNoDuplicateTestCases( m_functions );
-
-    if(  m_currentSortOrder != config.runOrder() || m_sortedFunctions.empty() ) {
-        m_sortedFunctions = sortTests( config, m_functions );
-        m_currentSortOrder = config.runOrder();
+    void TestRegistry::registerTest( TestCase const& testCase ) {
+        std::string name = testCase.getTestCaseInfo().name;
+        if( name.empty() ) {
+            ReusableStringStream rss;
+            rss << "Anonymous test case " << ++m_unnamedCount;
+            return registerTest( testCase.withName( rss.str() ) );
+        }
+        m_functions.push_back( testCase );
     }
-    return m_sortedFunctions;
-}
 
-///////////////////////////////////////////////////////////////////////////
-TestInvokerAsFunction::TestInvokerAsFunction( void(*testAsFunction)() ) noexcept : m_testAsFunction( testAsFunction ) {}
-
-void TestInvokerAsFunction::invoke() const {
-    m_testAsFunction();
-}
-
-std::string extractClassName( StringRef const& classOrQualifiedMethodName ) {
-    std::string className(classOrQualifiedMethodName);
-    if( startsWith( className, '&' ) )
-    {
-        std::size_t lastColons = className.rfind( "::" );
-        std::size_t penultimateColons = className.rfind( "::", lastColons-1 );
-        if( penultimateColons == std::string::npos )
-            penultimateColons = 1;
-        className = className.substr( penultimateColons, lastColons-penultimateColons );
+    std::vector<TestCase> const& TestRegistry::getAllTests() const {
+        return m_functions;
     }
-    return className;
-}
+    std::vector<TestCase> const& TestRegistry::getAllTestsSorted( IConfig const& config ) const {
+        if( m_sortedFunctions.empty() )
+            enforceNoDuplicateTestCases( m_functions );
+
+        if(  m_currentSortOrder != config.runOrder() || m_sortedFunctions.empty() ) {
+            m_sortedFunctions = sortTests( config, m_functions );
+            m_currentSortOrder = config.runOrder();
+        }
+        return m_sortedFunctions;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    TestInvokerAsFunction::TestInvokerAsFunction( void(*testAsFunction)() ) noexcept : m_testAsFunction( testAsFunction ) {}
+
+    void TestInvokerAsFunction::invoke() const {
+        m_testAsFunction();
+    }
+
+    std::string extractClassName( StringRef const& classOrQualifiedMethodName ) {
+        std::string className(classOrQualifiedMethodName);
+        if( startsWith( className, '&' ) )
+        {
+            std::size_t lastColons = className.rfind( "::" );
+            std::size_t penultimateColons = className.rfind( "::", lastColons-1 );
+            if( penultimateColons == std::string::npos )
+                penultimateColons = 1;
+            className = className.substr( penultimateColons, lastColons-penultimateColons );
+        }
+        return className;
+    }
 
 } // end namespace Catch
 // end catch_test_case_registry_impl.cpp
@@ -14253,210 +14359,218 @@ std::string extractClassName( StringRef const& classOrQualifiedMethodName ) {
 namespace Catch {
 namespace TestCaseTracking {
 
-NameAndLocation::NameAndLocation( std::string const& _name, SourceLineInfo const& _location )
+    NameAndLocation::NameAndLocation( std::string const& _name, SourceLineInfo const& _location )
     :   name( _name ),
         location( _location )
-{}
+    {}
 
-ITracker::~ITracker() = default;
+    ITracker::~ITracker() = default;
 
-ITracker& TrackerContext::startRun() {
-    m_rootTracker = std::make_shared<SectionTracker>( NameAndLocation( "{root}", CATCH_INTERNAL_LINEINFO ), *this, nullptr );
-    m_currentTracker = nullptr;
-    m_runState = Executing;
-    return *m_rootTracker;
-}
+    ITracker& TrackerContext::startRun() {
+        m_rootTracker = std::make_shared<SectionTracker>( NameAndLocation( "{root}", CATCH_INTERNAL_LINEINFO ), *this, nullptr );
+        m_currentTracker = nullptr;
+        m_runState = Executing;
+        return *m_rootTracker;
+    }
 
-void TrackerContext::endRun() {
-    m_rootTracker.reset();
-    m_currentTracker = nullptr;
-    m_runState = NotStarted;
-}
+    void TrackerContext::endRun() {
+        m_rootTracker.reset();
+        m_currentTracker = nullptr;
+        m_runState = NotStarted;
+    }
 
-void TrackerContext::startCycle() {
-    m_currentTracker = m_rootTracker.get();
-    m_runState = Executing;
-}
-void TrackerContext::completeCycle() {
-    m_runState = CompletedCycle;
-}
+    void TrackerContext::startCycle() {
+        m_currentTracker = m_rootTracker.get();
+        m_runState = Executing;
+    }
+    void TrackerContext::completeCycle() {
+        m_runState = CompletedCycle;
+    }
 
-bool TrackerContext::completedCycle() const {
-    return m_runState == CompletedCycle;
-}
-ITracker& TrackerContext::currentTracker() {
-    return *m_currentTracker;
-}
-void TrackerContext::setCurrentTracker( ITracker* tracker ) {
-    m_currentTracker = tracker;
-}
+    bool TrackerContext::completedCycle() const {
+        return m_runState == CompletedCycle;
+    }
+    ITracker& TrackerContext::currentTracker() {
+        return *m_currentTracker;
+    }
+    void TrackerContext::setCurrentTracker( ITracker* tracker ) {
+        m_currentTracker = tracker;
+    }
 
-TrackerBase::TrackerBase( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent ):
-    ITracker(nameAndLocation),
-    m_ctx( ctx ),
-    m_parent( parent )
-{}
+    TrackerBase::TrackerBase( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent ):
+        ITracker(nameAndLocation),
+        m_ctx( ctx ),
+        m_parent( parent )
+    {}
 
-bool TrackerBase::isComplete() const {
-    return m_runState == CompletedSuccessfully || m_runState == Failed;
-}
-bool TrackerBase::isSuccessfullyCompleted() const {
-    return m_runState == CompletedSuccessfully;
-}
-bool TrackerBase::isOpen() const {
-    return m_runState != NotStarted && !isComplete();
-}
-bool TrackerBase::hasChildren() const {
-    return !m_children.empty();
-}
+    bool TrackerBase::isComplete() const {
+        return m_runState == CompletedSuccessfully || m_runState == Failed;
+    }
+    bool TrackerBase::isSuccessfullyCompleted() const {
+        return m_runState == CompletedSuccessfully;
+    }
+    bool TrackerBase::isOpen() const {
+        return m_runState != NotStarted && !isComplete();
+    }
+    bool TrackerBase::hasChildren() const {
+        return !m_children.empty();
+    }
 
-void TrackerBase::addChild( ITrackerPtr const& child ) {
-    m_children.push_back( child );
-}
+    void TrackerBase::addChild( ITrackerPtr const& child ) {
+        m_children.push_back( child );
+    }
 
-ITrackerPtr TrackerBase::findChild( NameAndLocation const& nameAndLocation ) {
-    auto it = std::find_if( m_children.begin(), m_children.end(),
-                            [&nameAndLocation]( ITrackerPtr const& tracker ){
-                                return
-                                    tracker->nameAndLocation().location == nameAndLocation.location &&
-                                        tracker->nameAndLocation().name == nameAndLocation.name;
-                            } );
-    return( it != m_children.end() )
-          ? *it
-          : nullptr;
-}
-ITracker& TrackerBase::parent() {
-    assert( m_parent ); // Should always be non-null except for root
-    return *m_parent;
-}
+    ITrackerPtr TrackerBase::findChild( NameAndLocation const& nameAndLocation ) {
+        auto it = std::find_if( m_children.begin(), m_children.end(),
+            [&nameAndLocation]( ITrackerPtr const& tracker ){
+                return
+                    tracker->nameAndLocation().location == nameAndLocation.location &&
+                    tracker->nameAndLocation().name == nameAndLocation.name;
+            } );
+        return( it != m_children.end() )
+            ? *it
+            : nullptr;
+    }
+    ITracker& TrackerBase::parent() {
+        assert( m_parent ); // Should always be non-null except for root
+        return *m_parent;
+    }
 
-void TrackerBase::openChild() {
-    if( m_runState != ExecutingChildren ) {
-        m_runState = ExecutingChildren;
+    void TrackerBase::openChild() {
+        if( m_runState != ExecutingChildren ) {
+            m_runState = ExecutingChildren;
+            if( m_parent )
+                m_parent->openChild();
+        }
+    }
+
+    bool TrackerBase::isSectionTracker() const { return false; }
+    bool TrackerBase::isGeneratorTracker() const { return false; }
+
+    void TrackerBase::open() {
+        m_runState = Executing;
+        moveToThis();
         if( m_parent )
             m_parent->openChild();
     }
-}
 
-bool TrackerBase::isSectionTracker() const { return false; }
-bool TrackerBase::isGeneratorTracker() const { return false; }
+    void TrackerBase::close() {
 
-void TrackerBase::open() {
-    m_runState = Executing;
-    moveToThis();
-    if( m_parent )
-        m_parent->openChild();
-}
+        // Close any still open children (e.g. generators)
+        while( &m_ctx.currentTracker() != this )
+            m_ctx.currentTracker().close();
 
-void TrackerBase::close() {
+        switch( m_runState ) {
+            case NeedsAnotherRun:
+                break;
 
-    // Close any still open children (e.g. generators)
-    while( &m_ctx.currentTracker() != this )
-        m_ctx.currentTracker().close();
-
-    switch( m_runState ) {
-        case NeedsAnotherRun:
-            break;
-
-        case Executing:
-            m_runState = CompletedSuccessfully;
-            break;
-        case ExecutingChildren:
-            if( std::all_of(m_children.begin(), m_children.end(), [](ITrackerPtr const& t){ return t->isComplete(); }) )
+            case Executing:
                 m_runState = CompletedSuccessfully;
-            break;
+                break;
+            case ExecutingChildren:
+                if( std::all_of(m_children.begin(), m_children.end(), [](ITrackerPtr const& t){ return t->isComplete(); }) )
+                    m_runState = CompletedSuccessfully;
+                break;
 
-        case NotStarted:
-        case CompletedSuccessfully:
-        case Failed:
-            CATCH_INTERNAL_ERROR( "Illogical state: " << m_runState );
+            case NotStarted:
+            case CompletedSuccessfully:
+            case Failed:
+                CATCH_INTERNAL_ERROR( "Illogical state: " << m_runState );
 
-        default:
-            CATCH_INTERNAL_ERROR( "Unknown state: " << m_runState );
+            default:
+                CATCH_INTERNAL_ERROR( "Unknown state: " << m_runState );
+        }
+        moveToParent();
+        m_ctx.completeCycle();
     }
-    moveToParent();
-    m_ctx.completeCycle();
-}
-void TrackerBase::fail() {
-    m_runState = Failed;
-    if( m_parent )
-        m_parent->markAsNeedingAnotherRun();
-    moveToParent();
-    m_ctx.completeCycle();
-}
-void TrackerBase::markAsNeedingAnotherRun() {
-    m_runState = NeedsAnotherRun;
-}
+    void TrackerBase::fail() {
+        m_runState = Failed;
+        if( m_parent )
+            m_parent->markAsNeedingAnotherRun();
+        moveToParent();
+        m_ctx.completeCycle();
+    }
+    void TrackerBase::markAsNeedingAnotherRun() {
+        m_runState = NeedsAnotherRun;
+    }
 
-void TrackerBase::moveToParent() {
-    assert( m_parent );
-    m_ctx.setCurrentTracker( m_parent );
-}
-void TrackerBase::moveToThis() {
-    m_ctx.setCurrentTracker( this );
-}
+    void TrackerBase::moveToParent() {
+        assert( m_parent );
+        m_ctx.setCurrentTracker( m_parent );
+    }
+    void TrackerBase::moveToThis() {
+        m_ctx.setCurrentTracker( this );
+    }
 
-SectionTracker::SectionTracker( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent )
+    SectionTracker::SectionTracker( NameAndLocation const& nameAndLocation, TrackerContext& ctx, ITracker* parent )
     :   TrackerBase( nameAndLocation, ctx, parent ),
         m_trimmed_name(trim(nameAndLocation.name))
-{
-    if( parent ) {
-        while( !parent->isSectionTracker() )
-            parent = &parent->parent();
+    {
+        if( parent ) {
+            while( !parent->isSectionTracker() )
+                parent = &parent->parent();
 
-        SectionTracker& parentSection = static_cast<SectionTracker&>( *parent );
-        addNextFilters( parentSection.m_filters );
+            SectionTracker& parentSection = static_cast<SectionTracker&>( *parent );
+            addNextFilters( parentSection.m_filters );
+        }
     }
-}
 
-bool SectionTracker::isComplete() const {
-    bool complete = true;
+    bool SectionTracker::isComplete() const {
+        bool complete = true;
 
-    if (m_filters.empty()
-        || m_filters[0] == ""
-        || std::find(m_filters.begin(), m_filters.end(), m_trimmed_name) != m_filters.end()) {
-        complete = TrackerBase::isComplete();
+        if (m_filters.empty()
+            || m_filters[0] == ""
+            || std::find(m_filters.begin(), m_filters.end(), m_trimmed_name) != m_filters.end()) {
+            complete = TrackerBase::isComplete();
+        }
+        return complete;
     }
-    return complete;
-}
 
-bool SectionTracker::isSectionTracker() const { return true; }
+    bool SectionTracker::isSectionTracker() const { return true; }
 
-SectionTracker& SectionTracker::acquire( TrackerContext& ctx, NameAndLocation const& nameAndLocation ) {
-    std::shared_ptr<SectionTracker> section;
+    SectionTracker& SectionTracker::acquire( TrackerContext& ctx, NameAndLocation const& nameAndLocation ) {
+        std::shared_ptr<SectionTracker> section;
 
-    ITracker& currentTracker = ctx.currentTracker();
-    if( ITrackerPtr childTracker = currentTracker.findChild( nameAndLocation ) ) {
-        assert( childTracker );
-        assert( childTracker->isSectionTracker() );
-        section = std::static_pointer_cast<SectionTracker>( childTracker );
+        ITracker& currentTracker = ctx.currentTracker();
+        if( ITrackerPtr childTracker = currentTracker.findChild( nameAndLocation ) ) {
+            assert( childTracker );
+            assert( childTracker->isSectionTracker() );
+            section = std::static_pointer_cast<SectionTracker>( childTracker );
+        }
+        else {
+            section = std::make_shared<SectionTracker>( nameAndLocation, ctx, &currentTracker );
+            currentTracker.addChild( section );
+        }
+        if( !ctx.completedCycle() )
+            section->tryOpen();
+        return *section;
     }
-    else {
-        section = std::make_shared<SectionTracker>( nameAndLocation, ctx, &currentTracker );
-        currentTracker.addChild( section );
-    }
-    if( !ctx.completedCycle() )
-        section->tryOpen();
-    return *section;
-}
 
-void SectionTracker::tryOpen() {
-    if( !isComplete() )
-        open();
-}
-
-void SectionTracker::addInitialFilters( std::vector<std::string> const& filters ) {
-    if( !filters.empty() ) {
-        m_filters.reserve( m_filters.size() + filters.size() + 2 );
-        m_filters.emplace_back(""); // Root - should never be consulted
-        m_filters.emplace_back(""); // Test Case - not a section filter
-        m_filters.insert( m_filters.end(), filters.begin(), filters.end() );
+    void SectionTracker::tryOpen() {
+        if( !isComplete() )
+            open();
     }
-}
-void SectionTracker::addNextFilters( std::vector<std::string> const& filters ) {
-    if( filters.size() > 1 )
-        m_filters.insert( m_filters.end(), filters.begin()+1, filters.end() );
-}
+
+    void SectionTracker::addInitialFilters( std::vector<std::string> const& filters ) {
+        if( !filters.empty() ) {
+            m_filters.reserve( m_filters.size() + filters.size() + 2 );
+            m_filters.emplace_back(""); // Root - should never be consulted
+            m_filters.emplace_back(""); // Test Case - not a section filter
+            m_filters.insert( m_filters.end(), filters.begin(), filters.end() );
+        }
+    }
+    void SectionTracker::addNextFilters( std::vector<std::string> const& filters ) {
+        if( filters.size() > 1 )
+            m_filters.insert( m_filters.end(), filters.begin()+1, filters.end() );
+    }
+
+    std::vector<std::string> const& SectionTracker::getFilters() const {
+        return m_filters;
+    }
+
+    std::string const& SectionTracker::trimmedName() const {
+        return m_trimmed_name;
+    }
 
 } // namespace TestCaseTracking
 
@@ -14474,28 +14588,28 @@ using TestCaseTracking::SectionTracker;
 
 namespace Catch {
 
-auto makeTestInvoker( void(*testAsFunction)() ) noexcept -> ITestInvoker* {
-    return new(std::nothrow) TestInvokerAsFunction( testAsFunction );
-}
-
-NameAndTags::NameAndTags( StringRef const& name_ , StringRef const& tags_ ) noexcept : name( name_ ), tags( tags_ ) {}
-
-AutoReg::AutoReg( ITestInvoker* invoker, SourceLineInfo const& lineInfo, StringRef const& classOrMethod, NameAndTags const& nameAndTags ) noexcept {
-    CATCH_TRY {
-        getMutableRegistryHub()
-            .registerTest(
-                makeTestCase(
-                    invoker,
-                    extractClassName( classOrMethod ),
-                    nameAndTags,
-                    lineInfo));
-    } CATCH_CATCH_ALL {
-        // Do not throw when constructing global objects, instead register the exception to be processed later
-        getMutableRegistryHub().registerStartupException();
+    auto makeTestInvoker( void(*testAsFunction)() ) noexcept -> ITestInvoker* {
+        return new(std::nothrow) TestInvokerAsFunction( testAsFunction );
     }
-}
 
-AutoReg::~AutoReg() = default;
+    NameAndTags::NameAndTags( StringRef const& name_ , StringRef const& tags_ ) noexcept : name( name_ ), tags( tags_ ) {}
+
+    AutoReg::AutoReg( ITestInvoker* invoker, SourceLineInfo const& lineInfo, StringRef const& classOrMethod, NameAndTags const& nameAndTags ) noexcept {
+        CATCH_TRY {
+            getMutableRegistryHub()
+                    .registerTest(
+                        makeTestCase(
+                            invoker,
+                            extractClassName( classOrMethod ),
+                            nameAndTags,
+                            lineInfo));
+        } CATCH_CATCH_ALL {
+            // Do not throw when constructing global objects, instead register the exception to be processed later
+            getMutableRegistryHub().registerStartupException();
+        }
+    }
+
+    AutoReg::~AutoReg() = default;
 }
 // end catch_test_registry.cpp
 // start catch_test_spec.cpp
@@ -14507,80 +14621,80 @@ AutoReg::~AutoReg() = default;
 
 namespace Catch {
 
-TestSpec::Pattern::Pattern( std::string const& name )
+    TestSpec::Pattern::Pattern( std::string const& name )
     : m_name( name )
-{}
+    {}
 
-TestSpec::Pattern::~Pattern() = default;
+    TestSpec::Pattern::~Pattern() = default;
 
-std::string const& TestSpec::Pattern::name() const {
-    return m_name;
-}
+    std::string const& TestSpec::Pattern::name() const {
+        return m_name;
+    }
 
-TestSpec::NamePattern::NamePattern( std::string const& name, std::string const& filterString )
+    TestSpec::NamePattern::NamePattern( std::string const& name, std::string const& filterString )
     : Pattern( filterString )
     , m_wildcardPattern( toLower( name ), CaseSensitive::No )
-{}
+    {}
 
-bool TestSpec::NamePattern::matches( TestCaseInfo const& testCase ) const {
-    return m_wildcardPattern.matches( testCase.name );
-}
+    bool TestSpec::NamePattern::matches( TestCaseInfo const& testCase ) const {
+        return m_wildcardPattern.matches( testCase.name );
+    }
 
-TestSpec::TagPattern::TagPattern( std::string const& tag, std::string const& filterString )
+    TestSpec::TagPattern::TagPattern( std::string const& tag, std::string const& filterString )
     : Pattern( filterString )
     , m_tag( toLower( tag ) )
-{}
+    {}
 
-bool TestSpec::TagPattern::matches( TestCaseInfo const& testCase ) const {
-    return std::find(begin(testCase.lcaseTags),
-                     end(testCase.lcaseTags),
-                     m_tag) != end(testCase.lcaseTags);
-}
+    bool TestSpec::TagPattern::matches( TestCaseInfo const& testCase ) const {
+        return std::find(begin(testCase.lcaseTags),
+                         end(testCase.lcaseTags),
+                         m_tag) != end(testCase.lcaseTags);
+    }
 
-TestSpec::ExcludedPattern::ExcludedPattern( PatternPtr const& underlyingPattern )
+    TestSpec::ExcludedPattern::ExcludedPattern( PatternPtr const& underlyingPattern )
     : Pattern( underlyingPattern->name() )
     , m_underlyingPattern( underlyingPattern )
-{}
+    {}
 
-bool TestSpec::ExcludedPattern::matches( TestCaseInfo const& testCase ) const {
-    return !m_underlyingPattern->matches( testCase );
-}
+    bool TestSpec::ExcludedPattern::matches( TestCaseInfo const& testCase ) const {
+        return !m_underlyingPattern->matches( testCase );
+    }
 
-bool TestSpec::Filter::matches( TestCaseInfo const& testCase ) const {
-    return std::all_of( m_patterns.begin(), m_patterns.end(), [&]( PatternPtr const& p ){ return p->matches( testCase ); } );
-}
+    bool TestSpec::Filter::matches( TestCaseInfo const& testCase ) const {
+        return std::all_of( m_patterns.begin(), m_patterns.end(), [&]( PatternPtr const& p ){ return p->matches( testCase ); } );
+    }
 
-std::string TestSpec::Filter::name() const {
-    std::string name;
-    for( auto const& p : m_patterns )
-        name += p->name();
-    return name;
-}
+    std::string TestSpec::Filter::name() const {
+        std::string name;
+        for( auto const& p : m_patterns )
+            name += p->name();
+        return name;
+    }
 
-bool TestSpec::hasFilters() const {
-    return !m_filters.empty();
-}
+    bool TestSpec::hasFilters() const {
+        return !m_filters.empty();
+    }
 
-bool TestSpec::matches( TestCaseInfo const& testCase ) const {
-    return std::any_of( m_filters.begin(), m_filters.end(), [&]( Filter const& f ){ return f.matches( testCase ); } );
-}
+    bool TestSpec::matches( TestCaseInfo const& testCase ) const {
+        return std::any_of( m_filters.begin(), m_filters.end(), [&]( Filter const& f ){ return f.matches( testCase ); } );
+    }
 
-TestSpec::Matches TestSpec::matchesByFilter( std::vector<TestCase> const& testCases, IConfig const& config ) const
-{
-    Matches matches( m_filters.size() );
-    std::transform( m_filters.begin(), m_filters.end(), matches.begin(), [&]( Filter const& filter ){
-        std::vector<TestCase const*> currentMatches;
-        for( auto const& test : testCases )
-            if( isThrowSafe( test, config ) && filter.matches( test ) )
-                currentMatches.emplace_back( &test );
-        return FilterMatch{ filter.name(), currentMatches };
-    } );
-    return matches;
-}
+    TestSpec::Matches TestSpec::matchesByFilter( std::vector<TestCase> const& testCases, IConfig const& config ) const
+    {
+        Matches matches( m_filters.size() );
+        std::transform( m_filters.begin(), m_filters.end(), matches.begin(), [&]( Filter const& filter ){
+            std::vector<TestCase const*> currentMatches;
+            for( auto const& test : testCases )
+                if( isThrowSafe( test, config ) && filter.matches( test ) )
+                    currentMatches.emplace_back( &test );
+            return FilterMatch{ filter.name(), currentMatches };
+        } );
+        return matches;
+    }
 
-const TestSpec::vectorStrings& TestSpec::getInvalidArgs() const{
-    return  (m_invalidArgs);
-}
+    const TestSpec::vectorStrings& TestSpec::getInvalidArgs() const{
+        return  (m_invalidArgs);
+    }
 
 }
 // end catch_test_spec.cpp
@@ -14588,40 +14702,40 @@ const TestSpec::vectorStrings& TestSpec::getInvalidArgs() const{
 
 namespace Catch {
 
-TestSpecParser::TestSpecParser( ITagAliasRegistry const& tagAliases ) : m_tagAliases( &tagAliases ) {}
+    TestSpecParser::TestSpecParser( ITagAliasRegistry const& tagAliases ) : m_tagAliases( &tagAliases ) {}
 
-TestSpecParser& TestSpecParser::parse( std::string const& arg ) {
-    m_mode = None;
-    m_exclusion = false;
-    m_arg = m_tagAliases->expandAliases( arg );
-    m_escapeChars.clear();
-    m_substring.reserve(m_arg.size());
-    m_patternName.reserve(m_arg.size());
-    m_realPatternPos = 0;
+    TestSpecParser& TestSpecParser::parse( std::string const& arg ) {
+        m_mode = None;
+        m_exclusion = false;
+        m_arg = m_tagAliases->expandAliases( arg );
+        m_escapeChars.clear();
+        m_substring.reserve(m_arg.size());
+        m_patternName.reserve(m_arg.size());
+        m_realPatternPos = 0;
 
-    for( m_pos = 0; m_pos < m_arg.size(); ++m_pos )
-        //if visitChar fails
-        if( !visitChar( m_arg[m_pos] ) ){
-            m_testSpec.m_invalidArgs.push_back(arg);
-            break;
-        }
-    endMode();
-    return *this;
-}
-TestSpec TestSpecParser::testSpec() {
-    addFilter();
-    return m_testSpec;
-}
-bool TestSpecParser::visitChar( char c ) {
-    if( (m_mode != EscapedName) && (c == '\\') ) {
-        escape();
-        addCharToPattern(c);
-        return true;
-    }else if((m_mode != EscapedName) && (c == ',') )  {
-        return separate();
+        for( m_pos = 0; m_pos < m_arg.size(); ++m_pos )
+          //if visitChar fails
+           if( !visitChar( m_arg[m_pos] ) ){
+               m_testSpec.m_invalidArgs.push_back(arg);
+               break;
+           }
+        endMode();
+        return *this;
     }
+    TestSpec TestSpecParser::testSpec() {
+        addFilter();
+        return m_testSpec;
+    }
+    bool TestSpecParser::visitChar( char c ) {
+        if( (m_mode != EscapedName) && (c == '\\') ) {
+            escape();
+            addCharToPattern(c);
+            return true;
+        }else if((m_mode != EscapedName) && (c == ',') )  {
+            return separate();
+        }
 
-    switch( m_mode ) {
+        switch( m_mode ) {
         case None:
             if( processNoneChar( c ) )
                 return true;
@@ -14639,19 +14753,19 @@ bool TestSpecParser::visitChar( char c ) {
             if( processOtherChar( c ) )
                 return true;
             break;
-    }
+        }
 
-    m_substring += c;
-    if( !isControlChar( c ) ) {
-        m_patternName += c;
-        m_realPatternPos++;
+        m_substring += c;
+        if( !isControlChar( c ) ) {
+            m_patternName += c;
+            m_realPatternPos++;
+        }
+        return true;
     }
-    return true;
-}
-// Two of the processing methods return true to signal the caller to return
-// without adding the given character to the current pattern strings
-bool TestSpecParser::processNoneChar( char c ) {
-    switch( c ) {
+    // Two of the processing methods return true to signal the caller to return
+    // without adding the given character to the current pattern strings
+    bool TestSpecParser::processNoneChar( char c ) {
+        switch( c ) {
         case ' ':
             return true;
         case '~':
@@ -14666,29 +14780,29 @@ bool TestSpecParser::processNoneChar( char c ) {
         default:
             startNewMode( Name );
             return false;
+        }
     }
-}
-void TestSpecParser::processNameChar( char c ) {
-    if( c == '[' ) {
-        if( m_substring == "exclude:" )
-            m_exclusion = true;
-        else
-            endMode();
-        startNewMode( Tag );
+    void TestSpecParser::processNameChar( char c ) {
+        if( c == '[' ) {
+            if( m_substring == "exclude:" )
+                m_exclusion = true;
+            else
+                endMode();
+            startNewMode( Tag );
+        }
     }
-}
-bool TestSpecParser::processOtherChar( char c ) {
-    if( !isControlChar( c ) )
-        return false;
-    m_substring += c;
-    endMode();
-    return true;
-}
-void TestSpecParser::startNewMode( Mode mode ) {
-    m_mode = mode;
-}
-void TestSpecParser::endMode() {
-    switch( m_mode ) {
+    bool TestSpecParser::processOtherChar( char c ) {
+        if( !isControlChar( c ) )
+            return false;
+        m_substring += c;
+        endMode();
+        return true;
+    }
+    void TestSpecParser::startNewMode( Mode mode ) {
+        m_mode = mode;
+    }
+    void TestSpecParser::endMode() {
+        switch( m_mode ) {
         case Name:
         case QuotedName:
             return addNamePattern();
@@ -14700,120 +14814,120 @@ void TestSpecParser::endMode() {
         case None:
         default:
             return startNewMode( None );
+        }
     }
-}
-void TestSpecParser::escape() {
-    saveLastMode();
-    m_mode = EscapedName;
-    m_escapeChars.push_back(m_realPatternPos);
-}
-bool TestSpecParser::isControlChar( char c ) const {
-    switch( m_mode ) {
-        default:
-            return false;
-        case None:
-            return c == '~';
-        case Name:
-            return c == '[';
-        case EscapedName:
-            return true;
-        case QuotedName:
-            return c == '"';
-        case Tag:
-            return c == '[' || c == ']';
+    void TestSpecParser::escape() {
+        saveLastMode();
+        m_mode = EscapedName;
+        m_escapeChars.push_back(m_realPatternPos);
     }
-}
-
-void TestSpecParser::addFilter() {
-    if( !m_currentFilter.m_patterns.empty() ) {
-        m_testSpec.m_filters.push_back( m_currentFilter );
-        m_currentFilter = TestSpec::Filter();
+    bool TestSpecParser::isControlChar( char c ) const {
+        switch( m_mode ) {
+            default:
+                return false;
+            case None:
+                return c == '~';
+            case Name:
+                return c == '[';
+            case EscapedName:
+                return true;
+            case QuotedName:
+                return c == '"';
+            case Tag:
+                return c == '[' || c == ']';
+        }
     }
-}
 
-void TestSpecParser::saveLastMode() {
-    lastMode = m_mode;
-}
+    void TestSpecParser::addFilter() {
+        if( !m_currentFilter.m_patterns.empty() ) {
+            m_testSpec.m_filters.push_back( m_currentFilter );
+            m_currentFilter = TestSpec::Filter();
+        }
+    }
 
-void TestSpecParser::revertBackToLastMode() {
-    m_mode = lastMode;
-}
+    void TestSpecParser::saveLastMode() {
+      lastMode = m_mode;
+    }
 
-bool TestSpecParser::separate() {
-    if( (m_mode==QuotedName) || (m_mode==Tag) ){
-        //invalid argument, signal failure to previous scope.
-        m_mode = None;
-        m_pos = m_arg.size();
-        m_substring.clear();
+    void TestSpecParser::revertBackToLastMode() {
+      m_mode = lastMode;
+    }
+
+    bool TestSpecParser::separate() {
+      if( (m_mode==QuotedName) || (m_mode==Tag) ){
+         //invalid argument, signal failure to previous scope.
+         m_mode = None;
+         m_pos = m_arg.size();
+         m_substring.clear();
+         m_patternName.clear();
+         m_realPatternPos = 0;
+         return false;
+      }
+      endMode();
+      addFilter();
+      return true; //success
+    }
+
+    std::string TestSpecParser::preprocessPattern() {
+        std::string token = m_patternName;
+        for (std::size_t i = 0; i < m_escapeChars.size(); ++i)
+            token = token.substr(0, m_escapeChars[i] - i) + token.substr(m_escapeChars[i] - i + 1);
+        m_escapeChars.clear();
+        if (startsWith(token, "exclude:")) {
+            m_exclusion = true;
+            token = token.substr(8);
+        }
+
         m_patternName.clear();
         m_realPatternPos = 0;
-        return false;
-    }
-    endMode();
-    addFilter();
-    return true; //success
-}
 
-std::string TestSpecParser::preprocessPattern() {
-    std::string token = m_patternName;
-    for (std::size_t i = 0; i < m_escapeChars.size(); ++i)
-        token = token.substr(0, m_escapeChars[i] - i) + token.substr(m_escapeChars[i] - i + 1);
-    m_escapeChars.clear();
-    if (startsWith(token, "exclude:")) {
-        m_exclusion = true;
-        token = token.substr(8);
+        return token;
     }
 
-    m_patternName.clear();
-    m_realPatternPos = 0;
+    void TestSpecParser::addNamePattern() {
+        auto token = preprocessPattern();
 
-    return token;
-}
-
-void TestSpecParser::addNamePattern() {
-    auto token = preprocessPattern();
-
-    if (!token.empty()) {
-        TestSpec::PatternPtr pattern = std::make_shared<TestSpec::NamePattern>(token, m_substring);
-        if (m_exclusion)
-            pattern = std::make_shared<TestSpec::ExcludedPattern>(pattern);
-        m_currentFilter.m_patterns.push_back(pattern);
+        if (!token.empty()) {
+            TestSpec::PatternPtr pattern = std::make_shared<TestSpec::NamePattern>(token, m_substring);
+            if (m_exclusion)
+                pattern = std::make_shared<TestSpec::ExcludedPattern>(pattern);
+            m_currentFilter.m_patterns.push_back(pattern);
+        }
+        m_substring.clear();
+        m_exclusion = false;
+        m_mode = None;
     }
-    m_substring.clear();
-    m_exclusion = false;
-    m_mode = None;
-}
 
-void TestSpecParser::addTagPattern() {
-    auto token = preprocessPattern();
+    void TestSpecParser::addTagPattern() {
+        auto token = preprocessPattern();
 
-    if (!token.empty()) {
-        // If the tag pattern is the "hide and tag" shorthand (e.g. [.foo])
-        // we have to create a separate hide tag and shorten the real one
-        if (token.size() > 1 && token[0] == '.') {
-            token.erase(token.begin());
-            TestSpec::PatternPtr pattern = std::make_shared<TestSpec::TagPattern>(".", m_substring);
+        if (!token.empty()) {
+            // If the tag pattern is the "hide and tag" shorthand (e.g. [.foo])
+            // we have to create a separate hide tag and shorten the real one
+            if (token.size() > 1 && token[0] == '.') {
+                token.erase(token.begin());
+                TestSpec::PatternPtr pattern = std::make_shared<TestSpec::TagPattern>(".", m_substring);
+                if (m_exclusion) {
+                    pattern = std::make_shared<TestSpec::ExcludedPattern>(pattern);
+                }
+                m_currentFilter.m_patterns.push_back(pattern);
+            }
+
+            TestSpec::PatternPtr pattern = std::make_shared<TestSpec::TagPattern>(token, m_substring);
+
             if (m_exclusion) {
                 pattern = std::make_shared<TestSpec::ExcludedPattern>(pattern);
             }
             m_currentFilter.m_patterns.push_back(pattern);
         }
-
-        TestSpec::PatternPtr pattern = std::make_shared<TestSpec::TagPattern>(token, m_substring);
-
-        if (m_exclusion) {
-            pattern = std::make_shared<TestSpec::ExcludedPattern>(pattern);
-        }
-        m_currentFilter.m_patterns.push_back(pattern);
+        m_substring.clear();
+        m_exclusion = false;
+        m_mode = None;
     }
-    m_substring.clear();
-    m_exclusion = false;
-    m_mode = None;
-}
 
-TestSpec parseTestSpec( std::string const& arg ) {
-    return TestSpecParser( ITagAliasRegistry::get() ).parse( arg ).testSpec();
-}
+    TestSpec parseTestSpec( std::string const& arg ) {
+        return TestSpecParser( ITagAliasRegistry::get() ).parse( arg ).testSpec();
+    }
 
 } // namespace Catch
 // end catch_test_spec_parser.cpp
@@ -14825,61 +14939,61 @@ static const uint64_t nanosecondsInSecond = 1000000000;
 
 namespace Catch {
 
-auto getCurrentNanosecondsSinceEpoch() -> uint64_t {
-    return std::chrono::duration_cast<std::chrono::nanoseconds>( std::chrono::high_resolution_clock::now().time_since_epoch() ).count();
-}
-
-namespace {
-auto estimateClockResolution() -> uint64_t {
-    uint64_t sum = 0;
-    static const uint64_t iterations = 1000000;
-
-    auto startTime = getCurrentNanosecondsSinceEpoch();
-
-    for( std::size_t i = 0; i < iterations; ++i ) {
-
-        uint64_t ticks;
-        uint64_t baseTicks = getCurrentNanosecondsSinceEpoch();
-        do {
-            ticks = getCurrentNanosecondsSinceEpoch();
-        } while( ticks == baseTicks );
-
-        auto delta = ticks - baseTicks;
-        sum += delta;
-
-        // If we have been calibrating for over 3 seconds -- the clock
-        // is terrible and we should move on.
-        // TBD: How to signal that the measured resolution is probably wrong?
-        if (ticks > startTime + 3 * nanosecondsInSecond) {
-            return sum / ( i + 1u );
-        }
+    auto getCurrentNanosecondsSinceEpoch() -> uint64_t {
+        return std::chrono::duration_cast<std::chrono::nanoseconds>( std::chrono::high_resolution_clock::now().time_since_epoch() ).count();
     }
 
-    // We're just taking the mean, here. To do better we could take the std. dev and exclude outliers
-    // - and potentially do more iterations if there's a high variance.
-    return sum/iterations;
-}
-}
-auto getEstimatedClockResolution() -> uint64_t {
-    static auto s_resolution = estimateClockResolution();
-    return s_resolution;
-}
+    namespace {
+        auto estimateClockResolution() -> uint64_t {
+            uint64_t sum = 0;
+            static const uint64_t iterations = 1000000;
 
-void Timer::start() {
-    m_nanoseconds = getCurrentNanosecondsSinceEpoch();
-}
-auto Timer::getElapsedNanoseconds() const -> uint64_t {
-    return getCurrentNanosecondsSinceEpoch() - m_nanoseconds;
-}
-auto Timer::getElapsedMicroseconds() const -> uint64_t {
-    return getElapsedNanoseconds()/1000;
-}
-auto Timer::getElapsedMilliseconds() const -> unsigned int {
-    return static_cast<unsigned int>(getElapsedMicroseconds()/1000);
-}
-auto Timer::getElapsedSeconds() const -> double {
-    return getElapsedMicroseconds()/1000000.0;
-}
+            auto startTime = getCurrentNanosecondsSinceEpoch();
+
+            for( std::size_t i = 0; i < iterations; ++i ) {
+
+                uint64_t ticks;
+                uint64_t baseTicks = getCurrentNanosecondsSinceEpoch();
+                do {
+                    ticks = getCurrentNanosecondsSinceEpoch();
+                } while( ticks == baseTicks );
+
+                auto delta = ticks - baseTicks;
+                sum += delta;
+
+                // If we have been calibrating for over 3 seconds -- the clock
+                // is terrible and we should move on.
+                // TBD: How to signal that the measured resolution is probably wrong?
+                if (ticks > startTime + 3 * nanosecondsInSecond) {
+                    return sum / ( i + 1u );
+                }
+            }
+
+            // We're just taking the mean, here. To do better we could take the std. dev and exclude outliers
+            // - and potentially do more iterations if there's a high variance.
+            return sum/iterations;
+        }
+    }
+    auto getEstimatedClockResolution() -> uint64_t {
+        static auto s_resolution = estimateClockResolution();
+        return s_resolution;
+    }
+
+    void Timer::start() {
+       m_nanoseconds = getCurrentNanosecondsSinceEpoch();
+    }
+    auto Timer::getElapsedNanoseconds() const -> uint64_t {
+        return getCurrentNanosecondsSinceEpoch() - m_nanoseconds;
+    }
+    auto Timer::getElapsedMicroseconds() const -> uint64_t {
+        return getElapsedNanoseconds()/1000;
+    }
+    auto Timer::getElapsedMilliseconds() const -> unsigned int {
+        return static_cast<unsigned int>(getElapsedMicroseconds()/1000);
+    }
+    auto Timer::getElapsedSeconds() const -> double {
+        return getElapsedMicroseconds()/1000000.0;
+    }
 
 } // namespace Catch
 // end catch_timer.cpp
@@ -14903,39 +15017,39 @@ namespace Catch {
 
 namespace Detail {
 
-const std::string unprintableString = "{?}";
+    const std::string unprintableString = "{?}";
 
-namespace {
-const int hexThreshold = 255;
+    namespace {
+        const int hexThreshold = 255;
 
-struct Endianness {
-    enum Arch { Big, Little };
+        struct Endianness {
+            enum Arch { Big, Little };
 
-    static Arch which() {
-        int one = 1;
-        // If the lowest byte we read is non-zero, we can assume
-        // that little endian format is used.
-        auto value = *reinterpret_cast<char*>(&one);
-        return value ? Little : Big;
-    }
-};
-}
-
-std::string rawMemoryToString( const void *object, std::size_t size ) {
-    // Reverse order for little endian architectures
-    int i = 0, end = static_cast<int>( size ), inc = 1;
-    if( Endianness::which() == Endianness::Little ) {
-        i = end-1;
-        end = inc = -1;
+            static Arch which() {
+                int one = 1;
+                // If the lowest byte we read is non-zero, we can assume
+                // that little endian format is used.
+                auto value = *reinterpret_cast<char*>(&one);
+                return value ? Little : Big;
+            }
+        };
     }
 
-    unsigned char const *bytes = static_cast<unsigned char const *>(object);
-    ReusableStringStream rss;
-    rss << "0x" << std::setfill('0') << std::hex;
-    for( ; i != end; i += inc )
-        rss << std::setw(2) << static_cast<unsigned>(bytes[i]);
-    return rss.str();
-}
+    std::string rawMemoryToString( const void *object, std::size_t size ) {
+        // Reverse order for little endian architectures
+        int i = 0, end = static_cast<int>( size ), inc = 1;
+        if( Endianness::which() == Endianness::Little ) {
+            i = end-1;
+            end = inc = -1;
+        }
+
+        unsigned char const *bytes = static_cast<unsigned char const *>(object);
+        ReusableStringStream rss;
+        rss << "0x" << std::setfill('0') << std::hex;
+        for( ; i != end; i += inc )
+             rss << std::setw(2) << static_cast<unsigned>(bytes[i]);
+       return rss.str();
+    }
 }
 
 template<typename T>
@@ -14972,15 +15086,15 @@ std::string StringMaker<std::string>::convert(const std::string& str) {
     std::string s("\"");
     for (char c : str) {
         switch (c) {
-            case '\n':
-                s.append("\\n");
-                break;
-            case '\t':
-                s.append("\\t");
-                break;
-            default:
-                s.push_back(c);
-                break;
+        case '\n':
+            s.append("\\n");
+            break;
+        case '\t':
+            s.append("\\t");
+            break;
+        default:
+            s.push_back(c);
+            break;
         }
     }
     s.append("\"");
@@ -15041,7 +15155,7 @@ std::string StringMaker<wchar_t *>::convert(wchar_t * str) {
 #endif
 
 #if defined(CATCH_CONFIG_CPP17_BYTE)
-    #include <cstddef>
+#include <cstddef>
 std::string StringMaker<std::byte>::convert(std::byte value) {
     return ::Catch::Detail::stringify(std::to_integer<unsigned long long>(value));
 }
@@ -15139,71 +15253,106 @@ std::string ratio_string<std::milli>::symbol() { return "m"; }
 
 namespace Catch {
 
-Counts Counts::operator - ( Counts const& other ) const {
-    Counts diff;
-    diff.passed = passed - other.passed;
-    diff.failed = failed - other.failed;
-    diff.failedButOk = failedButOk - other.failedButOk;
-    return diff;
-}
+    Counts Counts::operator - ( Counts const& other ) const {
+        Counts diff;
+        diff.passed = passed - other.passed;
+        diff.failed = failed - other.failed;
+        diff.failedButOk = failedButOk - other.failedButOk;
+        return diff;
+    }
 
-Counts& Counts::operator += ( Counts const& other ) {
-    passed += other.passed;
-    failed += other.failed;
-    failedButOk += other.failedButOk;
-    return *this;
-}
+    Counts& Counts::operator += ( Counts const& other ) {
+        passed += other.passed;
+        failed += other.failed;
+        failedButOk += other.failedButOk;
+        return *this;
+    }
 
-std::size_t Counts::total() const {
-    return passed + failed + failedButOk;
-}
-bool Counts::allPassed() const {
-    return failed == 0 && failedButOk == 0;
-}
-bool Counts::allOk() const {
-    return failed == 0;
-}
+    std::size_t Counts::total() const {
+        return passed + failed + failedButOk;
+    }
+    bool Counts::allPassed() const {
+        return failed == 0 && failedButOk == 0;
+    }
+    bool Counts::allOk() const {
+        return failed == 0;
+    }
 
-Totals Totals::operator - ( Totals const& other ) const {
-    Totals diff;
-    diff.assertions = assertions - other.assertions;
-    diff.testCases = testCases - other.testCases;
-    return diff;
-}
+    Totals Totals::operator - ( Totals const& other ) const {
+        Totals diff;
+        diff.assertions = assertions - other.assertions;
+        diff.testCases = testCases - other.testCases;
+        return diff;
+    }
 
-Totals& Totals::operator += ( Totals const& other ) {
-    assertions += other.assertions;
-    testCases += other.testCases;
-    return *this;
-}
+    Totals& Totals::operator += ( Totals const& other ) {
+        assertions += other.assertions;
+        testCases += other.testCases;
+        return *this;
+    }
 
-Totals Totals::delta( Totals const& prevTotals ) const {
-    Totals diff = *this - prevTotals;
-    if( diff.assertions.failed > 0 )
-        ++diff.testCases.failed;
-    else if( diff.assertions.failedButOk > 0 )
-        ++diff.testCases.failedButOk;
-    else
-        ++diff.testCases.passed;
-    return diff;
-}
+    Totals Totals::delta( Totals const& prevTotals ) const {
+        Totals diff = *this - prevTotals;
+        if( diff.assertions.failed > 0 )
+            ++diff.testCases.failed;
+        else if( diff.assertions.failedButOk > 0 )
+            ++diff.testCases.failedButOk;
+        else
+            ++diff.testCases.passed;
+        return diff;
+    }
 
 }
 // end catch_totals.cpp
 // start catch_uncaught_exceptions.cpp
 
+// start catch_config_uncaught_exceptions.hpp
+
+//              Copyright Catch2 Authors
+// Distributed under the Boost Software License, Version 1.0.
+//   (See accompanying file LICENSE_1_0.txt or copy at
+//        https://www.boost.org/LICENSE_1_0.txt)
+
+// SPDX-License-Identifier: BSL-1.0
+
+#ifndef CATCH_CONFIG_UNCAUGHT_EXCEPTIONS_HPP
+#define CATCH_CONFIG_UNCAUGHT_EXCEPTIONS_HPP
+
+#if defined(_MSC_VER)
+#  if _MSC_VER >= 1900 // Visual Studio 2015 or newer
+#    define CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
+#  endif
+#endif
+
+#include <exception>
+
+#if defined(__cpp_lib_uncaught_exceptions) \
+    && !defined(CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS)
+
+#  define CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
+#endif // __cpp_lib_uncaught_exceptions
+
+#if defined(CATCH_INTERNAL_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS) \
+    && !defined(CATCH_CONFIG_NO_CPP17_UNCAUGHT_EXCEPTIONS) \
+    && !defined(CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS)
+
+#  define CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS
+#endif
+
+#endif // CATCH_CONFIG_UNCAUGHT_EXCEPTIONS_HPP
+// end catch_config_uncaught_exceptions.hpp
 #include <exception>
 
 namespace Catch {
-bool uncaught_exceptions() {
+    bool uncaught_exceptions() {
 #if defined(CATCH_CONFIG_DISABLE_EXCEPTIONS)
-    return false;
+        return false;
 #elif defined(CATCH_CONFIG_CPP17_UNCAUGHT_EXCEPTIONS)
-    return std::uncaught_exceptions() > 0;
+        return std::uncaught_exceptions() > 0;
 #else
-    return std::uncaught_exception();
+        return std::uncaught_exception();
 #endif
-}
+  }
 } // end namespace Catch
 // end catch_uncaught_exceptions.cpp
 // start catch_version.cpp
@@ -15212,35 +15361,35 @@ bool uncaught_exceptions() {
 
 namespace Catch {
 
-Version::Version
-    (   unsigned int _majorVersion,
-        unsigned int _minorVersion,
-        unsigned int _patchNumber,
-        char const * const _branchName,
-        unsigned int _buildNumber )
+    Version::Version
+        (   unsigned int _majorVersion,
+            unsigned int _minorVersion,
+            unsigned int _patchNumber,
+            char const * const _branchName,
+            unsigned int _buildNumber )
     :   majorVersion( _majorVersion ),
         minorVersion( _minorVersion ),
         patchNumber( _patchNumber ),
         branchName( _branchName ),
         buildNumber( _buildNumber )
-{}
+    {}
 
-std::ostream& operator << ( std::ostream& os, Version const& version ) {
-    os  << version.majorVersion << '.'
-        << version.minorVersion << '.'
-        << version.patchNumber;
-    // branchName is never null -> 0th char is \0 if it is empty
-    if (version.branchName[0]) {
-        os << '-' << version.branchName
-           << '.' << version.buildNumber;
+    std::ostream& operator << ( std::ostream& os, Version const& version ) {
+        os  << version.majorVersion << '.'
+            << version.minorVersion << '.'
+            << version.patchNumber;
+        // branchName is never null -> 0th char is \0 if it is empty
+        if (version.branchName[0]) {
+            os << '-' << version.branchName
+               << '.' << version.buildNumber;
+        }
+        return os;
     }
-    return os;
-}
 
-Version const& libraryVersion() {
-    static Version version( 2, 13, 0, "", 0 );
-    return version;
-}
+    Version const& libraryVersion() {
+        static Version version( 2, 13, 8, "", 0 );
+        return version;
+    }
 
 }
 // end catch_version.cpp
@@ -15248,39 +15397,39 @@ Version const& libraryVersion() {
 
 namespace Catch {
 
-WildcardPattern::WildcardPattern( std::string const& pattern,
-                                  CaseSensitive::Choice caseSensitivity )
+    WildcardPattern::WildcardPattern( std::string const& pattern,
+                                      CaseSensitive::Choice caseSensitivity )
     :   m_caseSensitivity( caseSensitivity ),
         m_pattern( normaliseString( pattern ) )
-{
-    if( startsWith( m_pattern, '*' ) ) {
-        m_pattern = m_pattern.substr( 1 );
-        m_wildcard = WildcardAtStart;
+    {
+        if( startsWith( m_pattern, '*' ) ) {
+            m_pattern = m_pattern.substr( 1 );
+            m_wildcard = WildcardAtStart;
+        }
+        if( endsWith( m_pattern, '*' ) ) {
+            m_pattern = m_pattern.substr( 0, m_pattern.size()-1 );
+            m_wildcard = static_cast<WildcardPosition>( m_wildcard | WildcardAtEnd );
+        }
     }
-    if( endsWith( m_pattern, '*' ) ) {
-        m_pattern = m_pattern.substr( 0, m_pattern.size()-1 );
-        m_wildcard = static_cast<WildcardPosition>( m_wildcard | WildcardAtEnd );
-    }
-}
 
-bool WildcardPattern::matches( std::string const& str ) const {
-    switch( m_wildcard ) {
-        case NoWildcard:
-            return m_pattern == normaliseString( str );
-        case WildcardAtStart:
-            return endsWith( normaliseString( str ), m_pattern );
-        case WildcardAtEnd:
-            return startsWith( normaliseString( str ), m_pattern );
-        case WildcardAtBothEnds:
-            return contains( normaliseString( str ), m_pattern );
-        default:
-            CATCH_INTERNAL_ERROR( "Unknown enum" );
+    bool WildcardPattern::matches( std::string const& str ) const {
+        switch( m_wildcard ) {
+            case NoWildcard:
+                return m_pattern == normaliseString( str );
+            case WildcardAtStart:
+                return endsWith( normaliseString( str ), m_pattern );
+            case WildcardAtEnd:
+                return startsWith( normaliseString( str ), m_pattern );
+            case WildcardAtBothEnds:
+                return contains( normaliseString( str ), m_pattern );
+            default:
+                CATCH_INTERNAL_ERROR( "Unknown enum" );
+        }
     }
-}
 
-std::string WildcardPattern::normaliseString( std::string const& str ) const {
-    return trim( m_caseSensitivity == CaseSensitive::No ? toLower( str ) : str );
-}
+    std::string WildcardPattern::normaliseString( std::string const& str ) const {
+        return trim( m_caseSensitivity == CaseSensitive::No ? toLower( str ) : str );
+    }
 }
 // end catch_wildcard_pattern.cpp
 // start catch_xmlwriter.cpp
@@ -15292,76 +15441,76 @@ namespace Catch {
 
 namespace {
 
-size_t trailingBytes(unsigned char c) {
-    if ((c & 0xE0) == 0xC0) {
-        return 2;
+    size_t trailingBytes(unsigned char c) {
+        if ((c & 0xE0) == 0xC0) {
+            return 2;
+        }
+        if ((c & 0xF0) == 0xE0) {
+            return 3;
+        }
+        if ((c & 0xF8) == 0xF0) {
+            return 4;
+        }
+        CATCH_INTERNAL_ERROR("Invalid multibyte utf-8 start byte encountered");
     }
-    if ((c & 0xF0) == 0xE0) {
-        return 3;
-    }
-    if ((c & 0xF8) == 0xF0) {
-        return 4;
-    }
-    CATCH_INTERNAL_ERROR("Invalid multibyte utf-8 start byte encountered");
-}
 
-uint32_t headerValue(unsigned char c) {
-    if ((c & 0xE0) == 0xC0) {
-        return c & 0x1F;
+    uint32_t headerValue(unsigned char c) {
+        if ((c & 0xE0) == 0xC0) {
+            return c & 0x1F;
+        }
+        if ((c & 0xF0) == 0xE0) {
+            return c & 0x0F;
+        }
+        if ((c & 0xF8) == 0xF0) {
+            return c & 0x07;
+        }
+        CATCH_INTERNAL_ERROR("Invalid multibyte utf-8 start byte encountered");
     }
-    if ((c & 0xF0) == 0xE0) {
-        return c & 0x0F;
+
+    void hexEscapeChar(std::ostream& os, unsigned char c) {
+        std::ios_base::fmtflags f(os.flags());
+        os << "\\x"
+            << std::uppercase << std::hex << std::setfill('0') << std::setw(2)
+            << static_cast<int>(c);
+        os.flags(f);
     }
-    if ((c & 0xF8) == 0xF0) {
-        return c & 0x07;
+
+    bool shouldNewline(XmlFormatting fmt) {
+        return !!(static_cast<std::underlying_type<XmlFormatting>::type>(fmt & XmlFormatting::Newline));
     }
-    CATCH_INTERNAL_ERROR("Invalid multibyte utf-8 start byte encountered");
-}
 
-void hexEscapeChar(std::ostream& os, unsigned char c) {
-    std::ios_base::fmtflags f(os.flags());
-    os << "\\x"
-       << std::uppercase << std::hex << std::setfill('0') << std::setw(2)
-       << static_cast<int>(c);
-    os.flags(f);
-}
-
-bool shouldNewline(XmlFormatting fmt) {
-    return !!(static_cast<std::underlying_type<XmlFormatting>::type>(fmt & XmlFormatting::Newline));
-}
-
-bool shouldIndent(XmlFormatting fmt) {
-    return !!(static_cast<std::underlying_type<XmlFormatting>::type>(fmt & XmlFormatting::Indent));
-}
+    bool shouldIndent(XmlFormatting fmt) {
+        return !!(static_cast<std::underlying_type<XmlFormatting>::type>(fmt & XmlFormatting::Indent));
+    }
 
 } // anonymous namespace
 
-XmlFormatting operator | (XmlFormatting lhs, XmlFormatting rhs) {
-    return static_cast<XmlFormatting>(
-        static_cast<std::underlying_type<XmlFormatting>::type>(lhs) |
+    XmlFormatting operator | (XmlFormatting lhs, XmlFormatting rhs) {
+        return static_cast<XmlFormatting>(
+            static_cast<std::underlying_type<XmlFormatting>::type>(lhs) |
             static_cast<std::underlying_type<XmlFormatting>::type>(rhs)
-    );
-}
+        );
+    }
 
-XmlFormatting operator & (XmlFormatting lhs, XmlFormatting rhs) {
-    return static_cast<XmlFormatting>(
-        static_cast<std::underlying_type<XmlFormatting>::type>(lhs) &
+    XmlFormatting operator & (XmlFormatting lhs, XmlFormatting rhs) {
+        return static_cast<XmlFormatting>(
+            static_cast<std::underlying_type<XmlFormatting>::type>(lhs) &
             static_cast<std::underlying_type<XmlFormatting>::type>(rhs)
-    );
-}
+        );
+    }
 
-XmlEncode::XmlEncode( std::string const& str, ForWhat forWhat )
+    XmlEncode::XmlEncode( std::string const& str, ForWhat forWhat )
     :   m_str( str ),
         m_forWhat( forWhat )
-{}
+    {}
 
-void XmlEncode::encodeTo( std::ostream& os ) const {
-    // Apostrophe escaping not necessary if we always use " to write attributes
-    // (see: http://www.w3.org/TR/xml/#syntax)
+    void XmlEncode::encodeTo( std::ostream& os ) const {
+        // Apostrophe escaping not necessary if we always use " to write attributes
+        // (see: http://www.w3.org/TR/xml/#syntax)
 
-    for( std::size_t idx = 0; idx < m_str.size(); ++ idx ) {
-        unsigned char c = m_str[idx];
-        switch (c) {
+        for( std::size_t idx = 0; idx < m_str.size(); ++ idx ) {
+            unsigned char c = m_str[idx];
+            switch (c) {
             case '<':   os << "&lt;"; break;
             case '&':   os << "&amp;"; break;
 
@@ -15428,12 +15577,12 @@ void XmlEncode::encodeTo( std::ostream& os ) const {
                 if (
                     // Wrong bit pattern of following bytes
                     (!valid) ||
-                        // Overlong encodings
-                        (value < 0x80) ||
-                        (0x80 <= value && value < 0x800   && encBytes > 2) ||
-                        (0x800 < value && value < 0x10000 && encBytes > 3) ||
-                        // Encoded value out of range
-                        (value >= 0x110000)
+                    // Overlong encodings
+                    (value < 0x80) ||
+                    (0x80 <= value && value < 0x800   && encBytes > 2) ||
+                    (0x800 < value && value < 0x10000 && encBytes > 3) ||
+                    // Encoded value out of range
+                    (value >= 0x110000)
                     ) {
                     hexEscapeChar(os, c);
                     break;
@@ -15445,166 +15594,166 @@ void XmlEncode::encodeTo( std::ostream& os ) const {
                 }
                 idx += encBytes - 1;
                 break;
+            }
         }
     }
-}
 
-std::ostream& operator << ( std::ostream& os, XmlEncode const& xmlEncode ) {
-    xmlEncode.encodeTo( os );
-    return os;
-}
+    std::ostream& operator << ( std::ostream& os, XmlEncode const& xmlEncode ) {
+        xmlEncode.encodeTo( os );
+        return os;
+    }
 
-XmlWriter::ScopedElement::ScopedElement( XmlWriter* writer, XmlFormatting fmt )
+    XmlWriter::ScopedElement::ScopedElement( XmlWriter* writer, XmlFormatting fmt )
     :   m_writer( writer ),
         m_fmt(fmt)
-{}
+    {}
 
-XmlWriter::ScopedElement::ScopedElement( ScopedElement&& other ) noexcept
+    XmlWriter::ScopedElement::ScopedElement( ScopedElement&& other ) noexcept
     :   m_writer( other.m_writer ),
         m_fmt(other.m_fmt)
-{
-    other.m_writer = nullptr;
-    other.m_fmt = XmlFormatting::None;
-}
-XmlWriter::ScopedElement& XmlWriter::ScopedElement::operator=( ScopedElement&& other ) noexcept {
-    if ( m_writer ) {
-        m_writer->endElement();
+    {
+        other.m_writer = nullptr;
+        other.m_fmt = XmlFormatting::None;
     }
-    m_writer = other.m_writer;
-    other.m_writer = nullptr;
-    m_fmt = other.m_fmt;
-    other.m_fmt = XmlFormatting::None;
-    return *this;
-}
-
-XmlWriter::ScopedElement::~ScopedElement() {
-    if (m_writer) {
-        m_writer->endElement(m_fmt);
+    XmlWriter::ScopedElement& XmlWriter::ScopedElement::operator=( ScopedElement&& other ) noexcept {
+        if ( m_writer ) {
+            m_writer->endElement();
+        }
+        m_writer = other.m_writer;
+        other.m_writer = nullptr;
+        m_fmt = other.m_fmt;
+        other.m_fmt = XmlFormatting::None;
+        return *this;
     }
-}
 
-XmlWriter::ScopedElement& XmlWriter::ScopedElement::writeText( std::string const& text, XmlFormatting fmt ) {
-    m_writer->writeText( text, fmt );
-    return *this;
-}
-
-XmlWriter::XmlWriter( std::ostream& os ) : m_os( os )
-{
-    writeDeclaration();
-}
-
-XmlWriter::~XmlWriter() {
-    while (!m_tags.empty()) {
-        endElement();
+    XmlWriter::ScopedElement::~ScopedElement() {
+        if (m_writer) {
+            m_writer->endElement(m_fmt);
+        }
     }
-    newlineIfNecessary();
-}
 
-XmlWriter& XmlWriter::startElement( std::string const& name, XmlFormatting fmt ) {
-    ensureTagClosed();
-    newlineIfNecessary();
-    if (shouldIndent(fmt)) {
-        m_os << m_indent;
-        m_indent += "  ";
+    XmlWriter::ScopedElement& XmlWriter::ScopedElement::writeText( std::string const& text, XmlFormatting fmt ) {
+        m_writer->writeText( text, fmt );
+        return *this;
     }
-    m_os << '<' << name;
-    m_tags.push_back( name );
-    m_tagIsOpen = true;
-    applyFormatting(fmt);
-    return *this;
-}
 
-XmlWriter::ScopedElement XmlWriter::scopedElement( std::string const& name, XmlFormatting fmt ) {
-    ScopedElement scoped( this, fmt );
-    startElement( name, fmt );
-    return scoped;
-}
+    XmlWriter::XmlWriter( std::ostream& os ) : m_os( os )
+    {
+        writeDeclaration();
+    }
 
-XmlWriter& XmlWriter::endElement(XmlFormatting fmt) {
-    m_indent = m_indent.substr(0, m_indent.size() - 2);
+    XmlWriter::~XmlWriter() {
+        while (!m_tags.empty()) {
+            endElement();
+        }
+        newlineIfNecessary();
+    }
 
-    if( m_tagIsOpen ) {
-        m_os << "/>";
-        m_tagIsOpen = false;
-    } else {
+    XmlWriter& XmlWriter::startElement( std::string const& name, XmlFormatting fmt ) {
+        ensureTagClosed();
         newlineIfNecessary();
         if (shouldIndent(fmt)) {
             m_os << m_indent;
+            m_indent += "  ";
         }
-        m_os << "</" << m_tags.back() << ">";
+        m_os << '<' << name;
+        m_tags.push_back( name );
+        m_tagIsOpen = true;
+        applyFormatting(fmt);
+        return *this;
     }
-    m_os << std::flush;
-    applyFormatting(fmt);
-    m_tags.pop_back();
-    return *this;
-}
 
-XmlWriter& XmlWriter::writeAttribute( std::string const& name, std::string const& attribute ) {
-    if( !name.empty() && !attribute.empty() )
-        m_os << ' ' << name << "=\"" << XmlEncode( attribute, XmlEncode::ForAttributes ) << '"';
-    return *this;
-}
+    XmlWriter::ScopedElement XmlWriter::scopedElement( std::string const& name, XmlFormatting fmt ) {
+        ScopedElement scoped( this, fmt );
+        startElement( name, fmt );
+        return scoped;
+    }
 
-XmlWriter& XmlWriter::writeAttribute( std::string const& name, bool attribute ) {
-    m_os << ' ' << name << "=\"" << ( attribute ? "true" : "false" ) << '"';
-    return *this;
-}
+    XmlWriter& XmlWriter::endElement(XmlFormatting fmt) {
+        m_indent = m_indent.substr(0, m_indent.size() - 2);
 
-XmlWriter& XmlWriter::writeText( std::string const& text, XmlFormatting fmt) {
-    if( !text.empty() ){
-        bool tagWasOpen = m_tagIsOpen;
+        if( m_tagIsOpen ) {
+            m_os << "/>";
+            m_tagIsOpen = false;
+        } else {
+            newlineIfNecessary();
+            if (shouldIndent(fmt)) {
+                m_os << m_indent;
+            }
+            m_os << "</" << m_tags.back() << ">";
+        }
+        m_os << std::flush;
+        applyFormatting(fmt);
+        m_tags.pop_back();
+        return *this;
+    }
+
+    XmlWriter& XmlWriter::writeAttribute( std::string const& name, std::string const& attribute ) {
+        if( !name.empty() && !attribute.empty() )
+            m_os << ' ' << name << "=\"" << XmlEncode( attribute, XmlEncode::ForAttributes ) << '"';
+        return *this;
+    }
+
+    XmlWriter& XmlWriter::writeAttribute( std::string const& name, bool attribute ) {
+        m_os << ' ' << name << "=\"" << ( attribute ? "true" : "false" ) << '"';
+        return *this;
+    }
+
+    XmlWriter& XmlWriter::writeText( std::string const& text, XmlFormatting fmt) {
+        if( !text.empty() ){
+            bool tagWasOpen = m_tagIsOpen;
+            ensureTagClosed();
+            if (tagWasOpen && shouldIndent(fmt)) {
+                m_os << m_indent;
+            }
+            m_os << XmlEncode( text );
+            applyFormatting(fmt);
+        }
+        return *this;
+    }
+
+    XmlWriter& XmlWriter::writeComment( std::string const& text, XmlFormatting fmt) {
         ensureTagClosed();
-        if (tagWasOpen && shouldIndent(fmt)) {
+        if (shouldIndent(fmt)) {
             m_os << m_indent;
         }
-        m_os << XmlEncode( text );
+        m_os << "<!--" << text << "-->";
         applyFormatting(fmt);
+        return *this;
     }
-    return *this;
-}
 
-XmlWriter& XmlWriter::writeComment( std::string const& text, XmlFormatting fmt) {
-    ensureTagClosed();
-    if (shouldIndent(fmt)) {
-        m_os << m_indent;
+    void XmlWriter::writeStylesheetRef( std::string const& url ) {
+        m_os << "<?xml-stylesheet type=\"text/xsl\" href=\"" << url << "\"?>\n";
     }
-    m_os << "<!--" << text << "-->";
-    applyFormatting(fmt);
-    return *this;
-}
 
-void XmlWriter::writeStylesheetRef( std::string const& url ) {
-    m_os << "<?xml-stylesheet type=\"text/xsl\" href=\"" << url << "\"?>\n";
-}
-
-XmlWriter& XmlWriter::writeBlankLine() {
-    ensureTagClosed();
-    m_os << '\n';
-    return *this;
-}
-
-void XmlWriter::ensureTagClosed() {
-    if( m_tagIsOpen ) {
-        m_os << '>' << std::flush;
-        newlineIfNecessary();
-        m_tagIsOpen = false;
+    XmlWriter& XmlWriter::writeBlankLine() {
+        ensureTagClosed();
+        m_os << '\n';
+        return *this;
     }
-}
 
-void XmlWriter::applyFormatting(XmlFormatting fmt) {
-    m_needsNewline = shouldNewline(fmt);
-}
-
-void XmlWriter::writeDeclaration() {
-    m_os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
-}
-
-void XmlWriter::newlineIfNecessary() {
-    if( m_needsNewline ) {
-        m_os << std::endl;
-        m_needsNewline = false;
+    void XmlWriter::ensureTagClosed() {
+        if( m_tagIsOpen ) {
+            m_os << '>' << std::flush;
+            newlineIfNecessary();
+            m_tagIsOpen = false;
+        }
     }
-}
+
+    void XmlWriter::applyFormatting(XmlFormatting fmt) {
+        m_needsNewline = shouldNewline(fmt);
+    }
+
+    void XmlWriter::writeDeclaration() {
+        m_os << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+    }
+
+    void XmlWriter::newlineIfNecessary() {
+        if( m_needsNewline ) {
+            m_os << std::endl;
+            m_needsNewline = false;
+        }
+    }
 }
 // end catch_xmlwriter.cpp
 // start catch_reporter_bases.cpp
@@ -15616,68 +15765,68 @@ void XmlWriter::newlineIfNecessary() {
 #include <memory>
 
 namespace Catch {
-void prepareExpandedExpression(AssertionResult& result) {
-    result.getExpandedExpression();
-}
-
-// Because formatting using c++ streams is stateful, drop down to C is required
-// Alternatively we could use stringstream, but its performance is... not good.
-std::string getFormattedDuration( double duration ) {
-    // Max exponent + 1 is required to represent the whole part
-    // + 1 for decimal point
-    // + 3 for the 3 decimal places
-    // + 1 for null terminator
-    const std::size_t maxDoubleSize = DBL_MAX_10_EXP + 1 + 1 + 3 + 1;
-    char buffer[maxDoubleSize];
-
-    // Save previous errno, to prevent sprintf from overwriting it
-    ErrnoGuard guard;
-#ifdef _MSC_VER
-    sprintf_s(buffer, "%.3f", duration);
-#else
-    std::sprintf(buffer, "%.3f", duration);
-#endif
-    return std::string(buffer);
-}
-
-bool shouldShowDuration( IConfig const& config, double duration ) {
-    if ( config.showDurations() == ShowDurations::Always ) {
-        return true;
+    void prepareExpandedExpression(AssertionResult& result) {
+        result.getExpandedExpression();
     }
-    if ( config.showDurations() == ShowDurations::Never ) {
+
+    // Because formatting using c++ streams is stateful, drop down to C is required
+    // Alternatively we could use stringstream, but its performance is... not good.
+    std::string getFormattedDuration( double duration ) {
+        // Max exponent + 1 is required to represent the whole part
+        // + 1 for decimal point
+        // + 3 for the 3 decimal places
+        // + 1 for null terminator
+        const std::size_t maxDoubleSize = DBL_MAX_10_EXP + 1 + 1 + 3 + 1;
+        char buffer[maxDoubleSize];
+
+        // Save previous errno, to prevent sprintf from overwriting it
+        ErrnoGuard guard;
+#ifdef _MSC_VER
+        sprintf_s(buffer, "%.3f", duration);
+#else
+        std::sprintf(buffer, "%.3f", duration);
+#endif
+        return std::string(buffer);
+    }
+
+    bool shouldShowDuration( IConfig const& config, double duration ) {
+        if ( config.showDurations() == ShowDurations::Always ) {
+            return true;
+        }
+        if ( config.showDurations() == ShowDurations::Never ) {
+            return false;
+        }
+        const double min = config.minDuration();
+        return min >= 0 && duration >= min;
+    }
+
+    std::string serializeFilters( std::vector<std::string> const& container ) {
+        ReusableStringStream oss;
+        bool first = true;
+        for (auto&& filter : container)
+        {
+            if (!first)
+                oss << ' ';
+            else
+                first = false;
+
+            oss << filter;
+        }
+        return oss.str();
+    }
+
+    TestEventListenerBase::TestEventListenerBase(ReporterConfig const & _config)
+        :StreamingReporterBase(_config) {}
+
+    std::set<Verbosity> TestEventListenerBase::getSupportedVerbosities() {
+        return { Verbosity::Quiet, Verbosity::Normal, Verbosity::High };
+    }
+
+    void TestEventListenerBase::assertionStarting(AssertionInfo const &) {}
+
+    bool TestEventListenerBase::assertionEnded(AssertionStats const &) {
         return false;
     }
-    const double min = config.minDuration();
-    return min >= 0 && duration >= min;
-}
-
-std::string serializeFilters( std::vector<std::string> const& container ) {
-    ReusableStringStream oss;
-    bool first = true;
-    for (auto&& filter : container)
-    {
-        if (!first)
-            oss << ' ';
-        else
-            first = false;
-
-        oss << filter;
-    }
-    return oss.str();
-}
-
-TestEventListenerBase::TestEventListenerBase(ReporterConfig const & _config)
-    :StreamingReporterBase(_config) {}
-
-std::set<Verbosity> TestEventListenerBase::getSupportedVerbosities() {
-    return { Verbosity::Quiet, Verbosity::Normal, Verbosity::High };
-}
-
-void TestEventListenerBase::assertionStarting(AssertionInfo const &) {}
-
-bool TestEventListenerBase::assertionEnded(AssertionStats const &) {
-    return false;
-}
 
 } // end namespace Catch
 // end catch_reporter_bases.cpp
@@ -15686,20 +15835,20 @@ bool TestEventListenerBase::assertionEnded(AssertionStats const &) {
 namespace {
 
 #ifdef CATCH_PLATFORM_MAC
-const char* failedString() { return "FAILED"; }
+    const char* failedString() { return "FAILED"; }
     const char* passedString() { return "PASSED"; }
 #else
-const char* failedString() { return "failed"; }
-const char* passedString() { return "passed"; }
+    const char* failedString() { return "failed"; }
+    const char* passedString() { return "passed"; }
 #endif
 
-// Colour::LightGrey
-Catch::Colour::Code dimColour() { return Catch::Colour::FileName; }
+    // Colour::LightGrey
+    Catch::Colour::Code dimColour() { return Catch::Colour::FileName; }
 
-std::string bothOrAll( std::size_t count ) {
-    return count == 1 ? std::string() :
-           count == 2 ? "both " : "all " ;
-}
+    std::string bothOrAll( std::size_t count ) {
+        return count == 1 ? std::string() :
+               count == 2 ? "both " : "all " ;
+    }
 
 } // anon namespace
 
@@ -15722,7 +15871,7 @@ void printTotals(std::ostream& out, const Totals& totals) {
         out <<
             "Failed " << bothOrAll(totals.testCases.failed)
             << pluralise(totals.testCases.failed, "test case") << ", "
-                                                                  "failed " << qualify_assertions_failed <<
+            "failed " << qualify_assertions_failed <<
             pluralise(totals.assertions.failed, "assertion") << '.';
     } else if (totals.assertions.total() == 0) {
         out <<
@@ -15733,7 +15882,7 @@ void printTotals(std::ostream& out, const Totals& totals) {
         Colour colour(Colour::ResultError);
         out <<
             "Failed " << pluralise(totals.testCases.failed, "test case") << ", "
-                                                                            "failed " << pluralise(totals.assertions.failed, "assertion") << '.';
+            "failed " << pluralise(totals.assertions.failed, "assertion") << '.';
     } else {
         Colour colour(Colour::ResultSuccess);
         out <<
@@ -15761,65 +15910,65 @@ public:
         itMessage = messages.begin();
 
         switch (result.getResultType()) {
-            case ResultWas::Ok:
-                printResultType(Colour::ResultSuccess, passedString());
-                printOriginalExpression();
-                printReconstructedExpression();
-                if (!result.hasExpression())
-                    printRemainingMessages(Colour::None);
-                else
-                    printRemainingMessages();
-                break;
-            case ResultWas::ExpressionFailed:
-                if (result.isOk())
-                    printResultType(Colour::ResultSuccess, failedString() + std::string(" - but was ok"));
-                else
-                    printResultType(Colour::Error, failedString());
-                printOriginalExpression();
-                printReconstructedExpression();
-                printRemainingMessages();
-                break;
-            case ResultWas::ThrewException:
-                printResultType(Colour::Error, failedString());
-                printIssue("unexpected exception with message:");
-                printMessage();
-                printExpressionWas();
-                printRemainingMessages();
-                break;
-            case ResultWas::FatalErrorCondition:
-                printResultType(Colour::Error, failedString());
-                printIssue("fatal error condition with message:");
-                printMessage();
-                printExpressionWas();
-                printRemainingMessages();
-                break;
-            case ResultWas::DidntThrowException:
-                printResultType(Colour::Error, failedString());
-                printIssue("expected exception, got none");
-                printExpressionWas();
-                printRemainingMessages();
-                break;
-            case ResultWas::Info:
-                printResultType(Colour::None, "info");
-                printMessage();
-                printRemainingMessages();
-                break;
-            case ResultWas::Warning:
-                printResultType(Colour::None, "warning");
-                printMessage();
-                printRemainingMessages();
-                break;
-            case ResultWas::ExplicitFailure:
-                printResultType(Colour::Error, failedString());
-                printIssue("explicitly");
+        case ResultWas::Ok:
+            printResultType(Colour::ResultSuccess, passedString());
+            printOriginalExpression();
+            printReconstructedExpression();
+            if (!result.hasExpression())
                 printRemainingMessages(Colour::None);
-                break;
-                // These cases are here to prevent compiler warnings
-            case ResultWas::Unknown:
-            case ResultWas::FailureBit:
-            case ResultWas::Exception:
-                printResultType(Colour::Error, "** internal error **");
-                break;
+            else
+                printRemainingMessages();
+            break;
+        case ResultWas::ExpressionFailed:
+            if (result.isOk())
+                printResultType(Colour::ResultSuccess, failedString() + std::string(" - but was ok"));
+            else
+                printResultType(Colour::Error, failedString());
+            printOriginalExpression();
+            printReconstructedExpression();
+            printRemainingMessages();
+            break;
+        case ResultWas::ThrewException:
+            printResultType(Colour::Error, failedString());
+            printIssue("unexpected exception with message:");
+            printMessage();
+            printExpressionWas();
+            printRemainingMessages();
+            break;
+        case ResultWas::FatalErrorCondition:
+            printResultType(Colour::Error, failedString());
+            printIssue("fatal error condition with message:");
+            printMessage();
+            printExpressionWas();
+            printRemainingMessages();
+            break;
+        case ResultWas::DidntThrowException:
+            printResultType(Colour::Error, failedString());
+            printIssue("expected exception, got none");
+            printExpressionWas();
+            printRemainingMessages();
+            break;
+        case ResultWas::Info:
+            printResultType(Colour::None, "info");
+            printMessage();
+            printRemainingMessages();
+            break;
+        case ResultWas::Warning:
+            printResultType(Colour::None, "warning");
+            printMessage();
+            printRemainingMessages();
+            break;
+        case ResultWas::ExplicitFailure:
+            printResultType(Colour::Error, failedString());
+            printIssue("explicitly");
+            printRemainingMessages(Colour::None);
+            break;
+            // These cases are here to prevent compiler warnings
+        case ResultWas::Unknown:
+        case ResultWas::FailureBit:
+        case ResultWas::Exception:
+            printResultType(Colour::Error, "** internal error **");
+            break;
         }
     }
 
@@ -15913,51 +16062,51 @@ private:
 
 } // anon namespace
 
-std::string CompactReporter::getDescription() {
-    return "Reports test results on a single line, suitable for IDEs";
-}
+        std::string CompactReporter::getDescription() {
+            return "Reports test results on a single line, suitable for IDEs";
+        }
 
-void CompactReporter::noMatchingTestCases( std::string const& spec ) {
-    stream << "No test cases matched '" << spec << '\'' << std::endl;
-}
+        void CompactReporter::noMatchingTestCases( std::string const& spec ) {
+            stream << "No test cases matched '" << spec << '\'' << std::endl;
+        }
 
-void CompactReporter::assertionStarting( AssertionInfo const& ) {}
+        void CompactReporter::assertionStarting( AssertionInfo const& ) {}
 
-bool CompactReporter::assertionEnded( AssertionStats const& _assertionStats ) {
-    AssertionResult const& result = _assertionStats.assertionResult;
+        bool CompactReporter::assertionEnded( AssertionStats const& _assertionStats ) {
+            AssertionResult const& result = _assertionStats.assertionResult;
 
-    bool printInfoMessages = true;
+            bool printInfoMessages = true;
 
-    // Drop out if result was successful and we're not printing those
-    if( !m_config->includeSuccessfulResults() && result.isOk() ) {
-        if( result.getResultType() != ResultWas::Warning )
-            return false;
-        printInfoMessages = false;
-    }
+            // Drop out if result was successful and we're not printing those
+            if( !m_config->includeSuccessfulResults() && result.isOk() ) {
+                if( result.getResultType() != ResultWas::Warning )
+                    return false;
+                printInfoMessages = false;
+            }
 
-    AssertionPrinter printer( stream, _assertionStats, printInfoMessages );
-    printer.print();
+            AssertionPrinter printer( stream, _assertionStats, printInfoMessages );
+            printer.print();
 
-    stream << std::endl;
-    return true;
-}
+            stream << std::endl;
+            return true;
+        }
 
-void CompactReporter::sectionEnded(SectionStats const& _sectionStats) {
-    double dur = _sectionStats.durationInSeconds;
-    if ( shouldShowDuration( *m_config, dur ) ) {
-        stream << getFormattedDuration( dur ) << " s: " << _sectionStats.sectionInfo.name << std::endl;
-    }
-}
+        void CompactReporter::sectionEnded(SectionStats const& _sectionStats) {
+            double dur = _sectionStats.durationInSeconds;
+            if ( shouldShowDuration( *m_config, dur ) ) {
+                stream << getFormattedDuration( dur ) << " s: " << _sectionStats.sectionInfo.name << std::endl;
+            }
+        }
 
-void CompactReporter::testRunEnded( TestRunStats const& _testRunStats ) {
-    printTotals( stream, _testRunStats.totals );
-    stream << '\n' << std::endl;
-    StreamingReporterBase::testRunEnded( _testRunStats );
-}
+        void CompactReporter::testRunEnded( TestRunStats const& _testRunStats ) {
+            printTotals( stream, _testRunStats.totals );
+            stream << '\n' << std::endl;
+            StreamingReporterBase::testRunEnded( _testRunStats );
+        }
 
-CompactReporter::~CompactReporter() {}
+        CompactReporter::~CompactReporter() {}
 
-CATCH_REGISTER_REPORTER( "compact", CompactReporter )
+    CATCH_REGISTER_REPORTER( "compact", CompactReporter )
 
 } // end namespace Catch
 // end catch_reporter_compact.cpp
@@ -15989,75 +16138,75 @@ public:
     ConsoleAssertionPrinter(ConsoleAssertionPrinter const&) = delete;
     ConsoleAssertionPrinter(std::ostream& _stream, AssertionStats const& _stats, bool _printInfoMessages)
         : stream(_stream),
-          stats(_stats),
-          result(_stats.assertionResult),
-          colour(Colour::None),
-          message(result.getMessage()),
-          messages(_stats.infoMessages),
-          printInfoMessages(_printInfoMessages) {
+        stats(_stats),
+        result(_stats.assertionResult),
+        colour(Colour::None),
+        message(result.getMessage()),
+        messages(_stats.infoMessages),
+        printInfoMessages(_printInfoMessages) {
         switch (result.getResultType()) {
-            case ResultWas::Ok:
+        case ResultWas::Ok:
+            colour = Colour::Success;
+            passOrFail = "PASSED";
+            //if( result.hasMessage() )
+            if (_stats.infoMessages.size() == 1)
+                messageLabel = "with message";
+            if (_stats.infoMessages.size() > 1)
+                messageLabel = "with messages";
+            break;
+        case ResultWas::ExpressionFailed:
+            if (result.isOk()) {
                 colour = Colour::Success;
-                passOrFail = "PASSED";
-                //if( result.hasMessage() )
-                if (_stats.infoMessages.size() == 1)
-                    messageLabel = "with message";
-                if (_stats.infoMessages.size() > 1)
-                    messageLabel = "with messages";
-                break;
-            case ResultWas::ExpressionFailed:
-                if (result.isOk()) {
-                    colour = Colour::Success;
-                    passOrFail = "FAILED - but was ok";
-                } else {
-                    colour = Colour::Error;
-                    passOrFail = "FAILED";
-                }
-                if (_stats.infoMessages.size() == 1)
-                    messageLabel = "with message";
-                if (_stats.infoMessages.size() > 1)
-                    messageLabel = "with messages";
-                break;
-            case ResultWas::ThrewException:
+                passOrFail = "FAILED - but was ok";
+            } else {
                 colour = Colour::Error;
                 passOrFail = "FAILED";
-                messageLabel = "due to unexpected exception with ";
-                if (_stats.infoMessages.size() == 1)
-                    messageLabel += "message";
-                if (_stats.infoMessages.size() > 1)
-                    messageLabel += "messages";
-                break;
-            case ResultWas::FatalErrorCondition:
-                colour = Colour::Error;
-                passOrFail = "FAILED";
-                messageLabel = "due to a fatal error condition";
-                break;
-            case ResultWas::DidntThrowException:
-                colour = Colour::Error;
-                passOrFail = "FAILED";
-                messageLabel = "because no exception was thrown where one was expected";
-                break;
-            case ResultWas::Info:
-                messageLabel = "info";
-                break;
-            case ResultWas::Warning:
-                messageLabel = "warning";
-                break;
-            case ResultWas::ExplicitFailure:
-                passOrFail = "FAILED";
-                colour = Colour::Error;
-                if (_stats.infoMessages.size() == 1)
-                    messageLabel = "explicitly with message";
-                if (_stats.infoMessages.size() > 1)
-                    messageLabel = "explicitly with messages";
-                break;
-                // These cases are here to prevent compiler warnings
-            case ResultWas::Unknown:
-            case ResultWas::FailureBit:
-            case ResultWas::Exception:
-                passOrFail = "** internal error **";
-                colour = Colour::Error;
-                break;
+            }
+            if (_stats.infoMessages.size() == 1)
+                messageLabel = "with message";
+            if (_stats.infoMessages.size() > 1)
+                messageLabel = "with messages";
+            break;
+        case ResultWas::ThrewException:
+            colour = Colour::Error;
+            passOrFail = "FAILED";
+            messageLabel = "due to unexpected exception with ";
+            if (_stats.infoMessages.size() == 1)
+                messageLabel += "message";
+            if (_stats.infoMessages.size() > 1)
+                messageLabel += "messages";
+            break;
+        case ResultWas::FatalErrorCondition:
+            colour = Colour::Error;
+            passOrFail = "FAILED";
+            messageLabel = "due to a fatal error condition";
+            break;
+        case ResultWas::DidntThrowException:
+            colour = Colour::Error;
+            passOrFail = "FAILED";
+            messageLabel = "because no exception was thrown where one was expected";
+            break;
+        case ResultWas::Info:
+            messageLabel = "info";
+            break;
+        case ResultWas::Warning:
+            messageLabel = "warning";
+            break;
+        case ResultWas::ExplicitFailure:
+            passOrFail = "FAILED";
+            colour = Colour::Error;
+            if (_stats.infoMessages.size() == 1)
+                messageLabel = "explicitly with message";
+            if (_stats.infoMessages.size() > 1)
+                messageLabel = "explicitly with messages";
+            break;
+            // These cases are here to prevent compiler warnings
+        case ResultWas::Unknown:
+        case ResultWas::FailureBit:
+        case ResultWas::Exception:
+            passOrFail = "** internal error **";
+            colour = Colour::Error;
+            break;
         }
     }
 
@@ -16163,7 +16312,7 @@ class Duration {
 public:
     explicit Duration(double inNanoseconds, Unit units = Unit::Auto)
         : m_inNanoseconds(inNanoseconds),
-          m_units(units) {
+        m_units(units) {
         if (m_units == Unit::Auto) {
             if (m_inNanoseconds < s_nanosecondsInAMicrosecond)
                 m_units = Unit::Nanoseconds;
@@ -16181,32 +16330,32 @@ public:
 
     auto value() const -> double {
         switch (m_units) {
-            case Unit::Microseconds:
-                return m_inNanoseconds / static_cast<double>(s_nanosecondsInAMicrosecond);
-            case Unit::Milliseconds:
-                return m_inNanoseconds / static_cast<double>(s_nanosecondsInAMillisecond);
-            case Unit::Seconds:
-                return m_inNanoseconds / static_cast<double>(s_nanosecondsInASecond);
-            case Unit::Minutes:
-                return m_inNanoseconds / static_cast<double>(s_nanosecondsInAMinute);
-            default:
-                return m_inNanoseconds;
+        case Unit::Microseconds:
+            return m_inNanoseconds / static_cast<double>(s_nanosecondsInAMicrosecond);
+        case Unit::Milliseconds:
+            return m_inNanoseconds / static_cast<double>(s_nanosecondsInAMillisecond);
+        case Unit::Seconds:
+            return m_inNanoseconds / static_cast<double>(s_nanosecondsInASecond);
+        case Unit::Minutes:
+            return m_inNanoseconds / static_cast<double>(s_nanosecondsInAMinute);
+        default:
+            return m_inNanoseconds;
         }
     }
     auto unitsAsString() const -> std::string {
         switch (m_units) {
-            case Unit::Nanoseconds:
-                return "ns";
-            case Unit::Microseconds:
-                return "us";
-            case Unit::Milliseconds:
-                return "ms";
-            case Unit::Seconds:
-                return "s";
-            case Unit::Minutes:
-                return "m";
-            default:
-                return "** internal error **";
+        case Unit::Nanoseconds:
+            return "ns";
+        case Unit::Microseconds:
+            return "us";
+        case Unit::Milliseconds:
+            return "ms";
+        case Unit::Seconds:
+            return "s";
+        case Unit::Minutes:
+            return "m";
+        default:
+            return "** internal error **";
         }
 
     }
@@ -16225,8 +16374,8 @@ class TablePrinter {
 
 public:
     TablePrinter( std::ostream& os, std::vector<ColumnInfo> columnInfos )
-        :   m_os( os ),
-            m_columnInfos( std::move( columnInfos ) ) {}
+    :   m_os( os ),
+        m_columnInfos( std::move( columnInfos ) ) {}
 
     auto columnInfos() const -> std::vector<ColumnInfo> const& {
         return m_columnInfos;
@@ -16237,13 +16386,13 @@ public:
             m_isOpen = true;
             *this << RowBreak();
 
-            Columns headerCols;
-            Spacer spacer(2);
-            for (auto const& info : m_columnInfos) {
-                headerCols += Column(info.name).width(static_cast<std::size_t>(info.width - 2));
-                headerCols += spacer;
-            }
-            m_os << headerCols << '\n';
+			Columns headerCols;
+			Spacer spacer(2);
+			for (auto const& info : m_columnInfos) {
+				headerCols += Column(info.name).width(static_cast<std::size_t>(info.width - 2));
+				headerCols += spacer;
+			}
+			m_os << headerCols << '\n';
 
             m_os << Catch::getLineOfChars<'-'>() << '\n';
         }
@@ -16275,8 +16424,8 @@ public:
 
         auto colInfo = tp.m_columnInfos[tp.m_currentColumn];
         auto padding = (strSize + 1 < static_cast<std::size_t>(colInfo.width))
-                       ? std::string(colInfo.width - (strSize + 1), ' ')
-                       : std::string();
+            ? std::string(colInfo.width - (strSize + 1), ' ')
+            : std::string();
         if (colInfo.justification == ColumnInfo::Left)
             tp.m_os << colStr << padding << ' ';
         else
@@ -16295,27 +16444,27 @@ public:
 
 ConsoleReporter::ConsoleReporter(ReporterConfig const& config)
     : StreamingReporterBase(config),
-      m_tablePrinter(new TablePrinter(config.stream(),
-                                      [&config]() -> std::vector<ColumnInfo> {
-                                          if (config.fullConfig()->benchmarkNoAnalysis())
-                                          {
-                                              return{
-                                                  { "benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 43, ColumnInfo::Left },
-                                                  { "     samples", 14, ColumnInfo::Right },
-                                                  { "  iterations", 14, ColumnInfo::Right },
-                                                  { "        mean", 14, ColumnInfo::Right }
-                                              };
-                                          }
-                                          else
-                                          {
-                                              return{
-                                                  { "benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 43, ColumnInfo::Left },
-                                                  { "samples      mean       std dev", 14, ColumnInfo::Right },
-                                                  { "iterations   low mean   low std dev", 14, ColumnInfo::Right },
-                                                  { "estimated    high mean  high std dev", 14, ColumnInfo::Right }
-                                              };
-                                          }
-                                      }())) {}
+    m_tablePrinter(new TablePrinter(config.stream(),
+        [&config]() -> std::vector<ColumnInfo> {
+        if (config.fullConfig()->benchmarkNoAnalysis())
+        {
+            return{
+                { "benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 43, ColumnInfo::Left },
+                { "     samples", 14, ColumnInfo::Right },
+                { "  iterations", 14, ColumnInfo::Right },
+                { "        mean", 14, ColumnInfo::Right }
+            };
+        }
+        else
+        {
+            return{
+                { "benchmark name", CATCH_CONFIG_CONSOLE_WIDTH - 43, ColumnInfo::Left },
+                { "samples      mean       std dev", 14, ColumnInfo::Right },
+                { "iterations   low mean   low std dev", 14, ColumnInfo::Right },
+                { "estimated    high mean  high std dev", 14, ColumnInfo::Right }
+            };
+        }
+    }())) {}
 ConsoleReporter::~ConsoleReporter() = default;
 
 std::string ConsoleReporter::getDescription() {
@@ -16470,8 +16619,8 @@ void ConsoleReporter::lazyPrintRunInfo() {
     stream << '\n' << getLineOfChars<'~'>() << '\n';
     Colour colour(Colour::SecondaryText);
     stream << currentTestRunInfo->name
-           << " is a Catch v" << libraryVersion() << " host application.\n"
-           << "Run with -? for options\n\n";
+        << " is a Catch v" << libraryVersion() << " host application.\n"
+        << "Run with -? for options\n\n";
 
     if (m_config->rngSeed() != 0)
         stream << "Randomness seeded to: " << m_config->rngSeed() << "\n\n";
@@ -16493,7 +16642,7 @@ void ConsoleReporter::printTestCaseAndSectionHeader() {
 
         auto
             it = m_sectionStack.begin() + 1, // Skip first section (test case)
-        itEnd = m_sectionStack.end();
+            itEnd = m_sectionStack.end();
         for (; it != itEnd; ++it)
             printHeaderString(it->name, 2);
     }
@@ -16532,8 +16681,8 @@ void ConsoleReporter::printHeaderString(std::string const& _string, std::size_t 
 struct SummaryColumn {
 
     SummaryColumn( std::string _label, Colour::Code _colour )
-        :   label( std::move( _label ) ),
-            colour( _colour ) {}
+    :   label( std::move( _label ) ),
+        colour( _colour ) {}
     SummaryColumn addRow( std::size_t count ) {
         ReusableStringStream rss;
         rss << count;
@@ -16560,24 +16709,24 @@ void ConsoleReporter::printTotals( Totals const& totals ) {
     } else if (totals.assertions.total() > 0 && totals.testCases.allPassed()) {
         stream << Colour(Colour::ResultSuccess) << "All tests passed";
         stream << " ("
-               << pluralise(totals.assertions.passed, "assertion") << " in "
-               << pluralise(totals.testCases.passed, "test case") << ')'
-               << '\n';
+            << pluralise(totals.assertions.passed, "assertion") << " in "
+            << pluralise(totals.testCases.passed, "test case") << ')'
+            << '\n';
     } else {
 
         std::vector<SummaryColumn> columns;
         columns.push_back(SummaryColumn("", Colour::None)
-                              .addRow(totals.testCases.total())
-                              .addRow(totals.assertions.total()));
+                          .addRow(totals.testCases.total())
+                          .addRow(totals.assertions.total()));
         columns.push_back(SummaryColumn("passed", Colour::Success)
-                              .addRow(totals.testCases.passed)
-                              .addRow(totals.assertions.passed));
+                          .addRow(totals.testCases.passed)
+                          .addRow(totals.assertions.passed));
         columns.push_back(SummaryColumn("failed", Colour::ResultError)
-                              .addRow(totals.testCases.failed)
-                              .addRow(totals.assertions.failed));
+                          .addRow(totals.testCases.failed)
+                          .addRow(totals.assertions.failed));
         columns.push_back(SummaryColumn("failed as expected", Colour::ResultExpectedFailure)
-                              .addRow(totals.testCases.failedButOk)
-                              .addRow(totals.assertions.failedButOk));
+                          .addRow(totals.testCases.failedButOk)
+                          .addRow(totals.assertions.failedButOk));
 
         printSummaryRow("test cases", columns, 0);
         printSummaryRow("assertions", columns, 1);
@@ -16595,7 +16744,7 @@ void ConsoleReporter::printSummaryRow(std::string const& label, std::vector<Summ
         } else if (value != "0") {
             stream << Colour(Colour::LightGrey) << " | ";
             stream << Colour(col.colour)
-                   << value << ' ' << col.label;
+                << value << ' ' << col.label;
         }
     }
     stream << '\n';
@@ -16651,265 +16800,283 @@ CATCH_REGISTER_REPORTER("console", ConsoleReporter)
 #include <sstream>
 #include <ctime>
 #include <algorithm>
+#include <iomanip>
 
 namespace Catch {
 
-namespace {
-std::string getCurrentTimestamp() {
-    // Beware, this is not reentrant because of backward compatibility issues
-    // Also, UTC only, again because of backward compatibility (%z is C++11)
-    time_t rawtime;
-    std::time(&rawtime);
-    auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");
+    namespace {
+        std::string getCurrentTimestamp() {
+            // Beware, this is not reentrant because of backward compatibility issues
+            // Also, UTC only, again because of backward compatibility (%z is C++11)
+            time_t rawtime;
+            std::time(&rawtime);
+            auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");
 
 #ifdef _MSC_VER
-    std::tm timeInfo = {};
+            std::tm timeInfo = {};
             gmtime_s(&timeInfo, &rawtime);
 #else
-    std::tm* timeInfo;
-    timeInfo = std::gmtime(&rawtime);
+            std::tm* timeInfo;
+            timeInfo = std::gmtime(&rawtime);
 #endif
 
-    char timeStamp[timeStampSize];
-    const char * const fmt = "%Y-%m-%dT%H:%M:%SZ";
+            char timeStamp[timeStampSize];
+            const char * const fmt = "%Y-%m-%dT%H:%M:%SZ";
 
 #ifdef _MSC_VER
-    std::strftime(timeStamp, timeStampSize, fmt, &timeInfo);
+            std::strftime(timeStamp, timeStampSize, fmt, &timeInfo);
 #else
-    std::strftime(timeStamp, timeStampSize, fmt, timeInfo);
+            std::strftime(timeStamp, timeStampSize, fmt, timeInfo);
 #endif
-    return std::string(timeStamp);
-}
-
-std::string fileNameTag(const std::vector<std::string> &tags) {
-    auto it = std::find_if(begin(tags),
-                           end(tags),
-                           [] (std::string const& tag) {return tag.front() == '#'; });
-    if (it != tags.end())
-        return it->substr(1);
-    return std::string();
-}
-} // anonymous namespace
-
-JunitReporter::JunitReporter( ReporterConfig const& _config )
-    :   CumulativeReporterBase( _config ),
-        xml( _config.stream() )
-{
-    m_reporterPrefs.shouldRedirectStdOut = true;
-    m_reporterPrefs.shouldReportAllAssertions = true;
-}
-
-JunitReporter::~JunitReporter() {}
-
-std::string JunitReporter::getDescription() {
-    return "Reports test results in an XML format that looks like Ant's junitreport target";
-}
-
-void JunitReporter::noMatchingTestCases( std::string const& /*spec*/ ) {}
-
-void JunitReporter::testRunStarting( TestRunInfo const& runInfo )  {
-    CumulativeReporterBase::testRunStarting( runInfo );
-    xml.startElement( "testsuites" );
-}
-
-void JunitReporter::testGroupStarting( GroupInfo const& groupInfo ) {
-    suiteTimer.start();
-    stdOutForSuite.clear();
-    stdErrForSuite.clear();
-    unexpectedExceptions = 0;
-    CumulativeReporterBase::testGroupStarting( groupInfo );
-}
-
-void JunitReporter::testCaseStarting( TestCaseInfo const& testCaseInfo ) {
-    m_okToFail = testCaseInfo.okToFail();
-}
-
-bool JunitReporter::assertionEnded( AssertionStats const& assertionStats ) {
-    if( assertionStats.assertionResult.getResultType() == ResultWas::ThrewException && !m_okToFail )
-        unexpectedExceptions++;
-    return CumulativeReporterBase::assertionEnded( assertionStats );
-}
-
-void JunitReporter::testCaseEnded( TestCaseStats const& testCaseStats ) {
-    stdOutForSuite += testCaseStats.stdOut;
-    stdErrForSuite += testCaseStats.stdErr;
-    CumulativeReporterBase::testCaseEnded( testCaseStats );
-}
-
-void JunitReporter::testGroupEnded( TestGroupStats const& testGroupStats ) {
-    double suiteTime = suiteTimer.getElapsedSeconds();
-    CumulativeReporterBase::testGroupEnded( testGroupStats );
-    writeGroup( *m_testGroups.back(), suiteTime );
-}
-
-void JunitReporter::testRunEndedCumulative() {
-    xml.endElement();
-}
-
-void JunitReporter::writeGroup( TestGroupNode const& groupNode, double suiteTime ) {
-    XmlWriter::ScopedElement e = xml.scopedElement( "testsuite" );
-
-    TestGroupStats const& stats = groupNode.value;
-    xml.writeAttribute( "name", stats.groupInfo.name );
-    xml.writeAttribute( "errors", unexpectedExceptions );
-    xml.writeAttribute( "failures", stats.totals.assertions.failed-unexpectedExceptions );
-    xml.writeAttribute( "tests", stats.totals.assertions.total() );
-    xml.writeAttribute( "hostname", "tbd" ); // !TBD
-    if( m_config->showDurations() == ShowDurations::Never )
-        xml.writeAttribute( "time", "" );
-    else
-        xml.writeAttribute( "time", suiteTime );
-    xml.writeAttribute( "timestamp", getCurrentTimestamp() );
-
-    // Write properties if there are any
-    if (m_config->hasTestFilters() || m_config->rngSeed() != 0) {
-        auto properties = xml.scopedElement("properties");
-        if (m_config->hasTestFilters()) {
-            xml.scopedElement("property")
-                .writeAttribute("name", "filters")
-                .writeAttribute("value", serializeFilters(m_config->getTestsOrTags()));
+            return std::string(timeStamp, timeStampSize-1);
         }
-        if (m_config->rngSeed() != 0) {
-            xml.scopedElement("property")
-                .writeAttribute("name", "random-seed")
-                .writeAttribute("value", m_config->rngSeed());
+
+        std::string fileNameTag(const std::vector<std::string> &tags) {
+            auto it = std::find_if(begin(tags),
+                                   end(tags),
+                                   [] (std::string const& tag) {return tag.front() == '#'; });
+            if (it != tags.end())
+                return it->substr(1);
+            return std::string();
         }
+
+        // Formats the duration in seconds to 3 decimal places.
+        // This is done because some genius defined Maven Surefire schema
+        // in a way that only accepts 3 decimal places, and tools like
+        // Jenkins use that schema for validation JUnit reporter output.
+        std::string formatDuration( double seconds ) {
+            ReusableStringStream rss;
+            rss << std::fixed << std::setprecision( 3 ) << seconds;
+            return rss.str();
+        }
+
+    } // anonymous namespace
+
+    JunitReporter::JunitReporter( ReporterConfig const& _config )
+        :   CumulativeReporterBase( _config ),
+            xml( _config.stream() )
+        {
+            m_reporterPrefs.shouldRedirectStdOut = true;
+            m_reporterPrefs.shouldReportAllAssertions = true;
+        }
+
+    JunitReporter::~JunitReporter() {}
+
+    std::string JunitReporter::getDescription() {
+        return "Reports test results in an XML format that looks like Ant's junitreport target";
     }
 
-    // Write test cases
-    for( auto const& child : groupNode.children )
-        writeTestCase( *child );
+    void JunitReporter::noMatchingTestCases( std::string const& /*spec*/ ) {}
 
-    xml.scopedElement( "system-out" ).writeText( trim( stdOutForSuite ), XmlFormatting::Newline );
-    xml.scopedElement( "system-err" ).writeText( trim( stdErrForSuite ), XmlFormatting::Newline );
-}
-
-void JunitReporter::writeTestCase( TestCaseNode const& testCaseNode ) {
-    TestCaseStats const& stats = testCaseNode.value;
-
-    // All test cases have exactly one section - which represents the
-    // test case itself. That section may have 0-n nested sections
-    assert( testCaseNode.children.size() == 1 );
-    SectionNode const& rootSection = *testCaseNode.children.front();
-
-    std::string className = stats.testInfo.className;
-
-    if( className.empty() ) {
-        className = fileNameTag(stats.testInfo.tags);
-        if ( className.empty() )
-            className = "global";
+    void JunitReporter::testRunStarting( TestRunInfo const& runInfo )  {
+        CumulativeReporterBase::testRunStarting( runInfo );
+        xml.startElement( "testsuites" );
     }
 
-    if ( !m_config->name().empty() )
-        className = m_config->name() + "." + className;
-
-    writeSection( className, "", rootSection );
-}
-
-void JunitReporter::writeSection(  std::string const& className,
-                                   std::string const& rootName,
-                                   SectionNode const& sectionNode ) {
-    std::string name = trim( sectionNode.stats.sectionInfo.name );
-    if( !rootName.empty() )
-        name = rootName + '/' + name;
-
-    if( !sectionNode.assertions.empty() ||
-        !sectionNode.stdOut.empty() ||
-        !sectionNode.stdErr.empty() ) {
-        XmlWriter::ScopedElement e = xml.scopedElement( "testcase" );
-        if( className.empty() ) {
-            xml.writeAttribute( "classname", name );
-            xml.writeAttribute( "name", "root" );
-        }
-        else {
-            xml.writeAttribute( "classname", className );
-            xml.writeAttribute( "name", name );
-        }
-        xml.writeAttribute( "time", ::Catch::Detail::stringify( sectionNode.stats.durationInSeconds ) );
-        // This is not ideal, but it should be enough to mimic gtest's
-        // junit output.
-        // Ideally the JUnit reporter would also handle `skipTest`
-        // events and write those out appropriately.
-        xml.writeAttribute( "status", "run" );
-
-        writeAssertions( sectionNode );
-
-        if( !sectionNode.stdOut.empty() )
-            xml.scopedElement( "system-out" ).writeText( trim( sectionNode.stdOut ), XmlFormatting::Newline );
-        if( !sectionNode.stdErr.empty() )
-            xml.scopedElement( "system-err" ).writeText( trim( sectionNode.stdErr ), XmlFormatting::Newline );
+    void JunitReporter::testGroupStarting( GroupInfo const& groupInfo ) {
+        suiteTimer.start();
+        stdOutForSuite.clear();
+        stdErrForSuite.clear();
+        unexpectedExceptions = 0;
+        CumulativeReporterBase::testGroupStarting( groupInfo );
     }
-    for( auto const& childNode : sectionNode.childSections )
-        if( className.empty() )
-            writeSection( name, "", *childNode );
+
+    void JunitReporter::testCaseStarting( TestCaseInfo const& testCaseInfo ) {
+        m_okToFail = testCaseInfo.okToFail();
+    }
+
+    bool JunitReporter::assertionEnded( AssertionStats const& assertionStats ) {
+        if( assertionStats.assertionResult.getResultType() == ResultWas::ThrewException && !m_okToFail )
+            unexpectedExceptions++;
+        return CumulativeReporterBase::assertionEnded( assertionStats );
+    }
+
+    void JunitReporter::testCaseEnded( TestCaseStats const& testCaseStats ) {
+        stdOutForSuite += testCaseStats.stdOut;
+        stdErrForSuite += testCaseStats.stdErr;
+        CumulativeReporterBase::testCaseEnded( testCaseStats );
+    }
+
+    void JunitReporter::testGroupEnded( TestGroupStats const& testGroupStats ) {
+        double suiteTime = suiteTimer.getElapsedSeconds();
+        CumulativeReporterBase::testGroupEnded( testGroupStats );
+        writeGroup( *m_testGroups.back(), suiteTime );
+    }
+
+    void JunitReporter::testRunEndedCumulative() {
+        xml.endElement();
+    }
+
+    void JunitReporter::writeGroup( TestGroupNode const& groupNode, double suiteTime ) {
+        XmlWriter::ScopedElement e = xml.scopedElement( "testsuite" );
+
+        TestGroupStats const& stats = groupNode.value;
+        xml.writeAttribute( "name", stats.groupInfo.name );
+        xml.writeAttribute( "errors", unexpectedExceptions );
+        xml.writeAttribute( "failures", stats.totals.assertions.failed-unexpectedExceptions );
+        xml.writeAttribute( "tests", stats.totals.assertions.total() );
+        xml.writeAttribute( "hostname", "tbd" ); // !TBD
+        if( m_config->showDurations() == ShowDurations::Never )
+            xml.writeAttribute( "time", "" );
         else
-            writeSection( className, name, *childNode );
-}
+            xml.writeAttribute( "time", formatDuration( suiteTime ) );
+        xml.writeAttribute( "timestamp", getCurrentTimestamp() );
 
-void JunitReporter::writeAssertions( SectionNode const& sectionNode ) {
-    for( auto const& assertion : sectionNode.assertions )
-        writeAssertion( assertion );
-}
+        // Write properties if there are any
+        if (m_config->hasTestFilters() || m_config->rngSeed() != 0) {
+            auto properties = xml.scopedElement("properties");
+            if (m_config->hasTestFilters()) {
+                xml.scopedElement("property")
+                    .writeAttribute("name", "filters")
+                    .writeAttribute("value", serializeFilters(m_config->getTestsOrTags()));
+            }
+            if (m_config->rngSeed() != 0) {
+                xml.scopedElement("property")
+                    .writeAttribute("name", "random-seed")
+                    .writeAttribute("value", m_config->rngSeed());
+            }
+        }
 
-void JunitReporter::writeAssertion( AssertionStats const& stats ) {
-    AssertionResult const& result = stats.assertionResult;
-    if( !result.isOk() ) {
-        std::string elementName;
-        switch( result.getResultType() ) {
-            case ResultWas::ThrewException:
-            case ResultWas::FatalErrorCondition:
-                elementName = "error";
-                break;
-            case ResultWas::ExplicitFailure:
-            case ResultWas::ExpressionFailed:
-            case ResultWas::DidntThrowException:
-                elementName = "failure";
-                break;
+        // Write test cases
+        for( auto const& child : groupNode.children )
+            writeTestCase( *child );
+
+        xml.scopedElement( "system-out" ).writeText( trim( stdOutForSuite ), XmlFormatting::Newline );
+        xml.scopedElement( "system-err" ).writeText( trim( stdErrForSuite ), XmlFormatting::Newline );
+    }
+
+    void JunitReporter::writeTestCase( TestCaseNode const& testCaseNode ) {
+        TestCaseStats const& stats = testCaseNode.value;
+
+        // All test cases have exactly one section - which represents the
+        // test case itself. That section may have 0-n nested sections
+        assert( testCaseNode.children.size() == 1 );
+        SectionNode const& rootSection = *testCaseNode.children.front();
+
+        std::string className = stats.testInfo.className;
+
+        if( className.empty() ) {
+            className = fileNameTag(stats.testInfo.tags);
+            if ( className.empty() )
+                className = "global";
+        }
+
+        if ( !m_config->name().empty() )
+            className = m_config->name() + "." + className;
+
+        writeSection( className, "", rootSection, stats.testInfo.okToFail() );
+    }
+
+    void JunitReporter::writeSection( std::string const& className,
+                                      std::string const& rootName,
+                                      SectionNode const& sectionNode,
+                                      bool testOkToFail) {
+        std::string name = trim( sectionNode.stats.sectionInfo.name );
+        if( !rootName.empty() )
+            name = rootName + '/' + name;
+
+        if( !sectionNode.assertions.empty() ||
+            !sectionNode.stdOut.empty() ||
+            !sectionNode.stdErr.empty() ) {
+            XmlWriter::ScopedElement e = xml.scopedElement( "testcase" );
+            if( className.empty() ) {
+                xml.writeAttribute( "classname", name );
+                xml.writeAttribute( "name", "root" );
+            }
+            else {
+                xml.writeAttribute( "classname", className );
+                xml.writeAttribute( "name", name );
+            }
+            xml.writeAttribute( "time", formatDuration( sectionNode.stats.durationInSeconds ) );
+            // This is not ideal, but it should be enough to mimic gtest's
+            // junit output.
+            // Ideally the JUnit reporter would also handle `skipTest`
+            // events and write those out appropriately.
+            xml.writeAttribute( "status", "run" );
+
+            if (sectionNode.stats.assertions.failedButOk) {
+                xml.scopedElement("skipped")
+                    .writeAttribute("message", "TEST_CASE tagged with !mayfail");
+            }
+
+            writeAssertions( sectionNode );
+
+            if( !sectionNode.stdOut.empty() )
+                xml.scopedElement( "system-out" ).writeText( trim( sectionNode.stdOut ), XmlFormatting::Newline );
+            if( !sectionNode.stdErr.empty() )
+                xml.scopedElement( "system-err" ).writeText( trim( sectionNode.stdErr ), XmlFormatting::Newline );
+        }
+        for( auto const& childNode : sectionNode.childSections )
+            if( className.empty() )
+                writeSection( name, "", *childNode, testOkToFail );
+            else
+                writeSection( className, name, *childNode, testOkToFail );
+    }
+
+    void JunitReporter::writeAssertions( SectionNode const& sectionNode ) {
+        for( auto const& assertion : sectionNode.assertions )
+            writeAssertion( assertion );
+    }
+
+    void JunitReporter::writeAssertion( AssertionStats const& stats ) {
+        AssertionResult const& result = stats.assertionResult;
+        if( !result.isOk() ) {
+            std::string elementName;
+            switch( result.getResultType() ) {
+                case ResultWas::ThrewException:
+                case ResultWas::FatalErrorCondition:
+                    elementName = "error";
+                    break;
+                case ResultWas::ExplicitFailure:
+                case ResultWas::ExpressionFailed:
+                case ResultWas::DidntThrowException:
+                    elementName = "failure";
+                    break;
 
                 // We should never see these here:
-            case ResultWas::Info:
-            case ResultWas::Warning:
-            case ResultWas::Ok:
-            case ResultWas::Unknown:
-            case ResultWas::FailureBit:
-            case ResultWas::Exception:
-                elementName = "internalError";
-                break;
-        }
+                case ResultWas::Info:
+                case ResultWas::Warning:
+                case ResultWas::Ok:
+                case ResultWas::Unknown:
+                case ResultWas::FailureBit:
+                case ResultWas::Exception:
+                    elementName = "internalError";
+                    break;
+            }
 
-        XmlWriter::ScopedElement e = xml.scopedElement( elementName );
+            XmlWriter::ScopedElement e = xml.scopedElement( elementName );
 
-        xml.writeAttribute( "message", result.getExpression() );
-        xml.writeAttribute( "type", result.getTestMacroName() );
+            xml.writeAttribute( "message", result.getExpression() );
+            xml.writeAttribute( "type", result.getTestMacroName() );
 
-        ReusableStringStream rss;
-        if (stats.totals.assertions.total() > 0) {
-            rss << "FAILED" << ":\n";
-            if (result.hasExpression()) {
-                rss << "  ";
-                rss << result.getExpressionInMacro();
+            ReusableStringStream rss;
+            if (stats.totals.assertions.total() > 0) {
+                rss << "FAILED" << ":\n";
+                if (result.hasExpression()) {
+                    rss << "  ";
+                    rss << result.getExpressionInMacro();
+                    rss << '\n';
+                }
+                if (result.hasExpandedExpression()) {
+                    rss << "with expansion:\n";
+                    rss << Column(result.getExpandedExpression()).indent(2) << '\n';
+                }
+            } else {
                 rss << '\n';
             }
-            if (result.hasExpandedExpression()) {
-                rss << "with expansion:\n";
-                rss << Column(result.getExpandedExpression()).indent(2) << '\n';
-            }
-        } else {
-            rss << '\n';
+
+            if( !result.getMessage().empty() )
+                rss << result.getMessage() << '\n';
+            for( auto const& msg : stats.infoMessages )
+                if( msg.type == ResultWas::Info )
+                    rss << msg.message << '\n';
+
+            rss << "at " << result.getSourceInfo();
+            xml.writeText( rss.str(), XmlFormatting::Newline );
         }
-
-        if( !result.getMessage().empty() )
-            rss << result.getMessage() << '\n';
-        for( auto const& msg : stats.infoMessages )
-            if( msg.type == ResultWas::Info )
-                rss << msg.message << '\n';
-
-        rss << "at " << result.getSourceInfo();
-        xml.writeText( rss.str(), XmlFormatting::Newline );
     }
-}
 
-CATCH_REGISTER_REPORTER( "junit", JunitReporter )
+    CATCH_REGISTER_REPORTER( "junit", JunitReporter )
 
 } // end namespace Catch
 // end catch_reporter_junit.cpp
@@ -16919,45 +17086,45 @@ CATCH_REGISTER_REPORTER( "junit", JunitReporter )
 
 namespace Catch {
 
-ListeningReporter::ListeningReporter() {
-    // We will assume that listeners will always want all assertions
-    m_preferences.shouldReportAllAssertions = true;
-}
-
-void ListeningReporter::addListener( IStreamingReporterPtr&& listener ) {
-    m_listeners.push_back( std::move( listener ) );
-}
-
-void ListeningReporter::addReporter(IStreamingReporterPtr&& reporter) {
-    assert(!m_reporter && "Listening reporter can wrap only 1 real reporter");
-    m_reporter = std::move( reporter );
-    m_preferences.shouldRedirectStdOut = m_reporter->getPreferences().shouldRedirectStdOut;
-}
-
-ReporterPreferences ListeningReporter::getPreferences() const {
-    return m_preferences;
-}
-
-std::set<Verbosity> ListeningReporter::getSupportedVerbosities() {
-    return std::set<Verbosity>{ };
-}
-
-void ListeningReporter::noMatchingTestCases( std::string const& spec ) {
-    for ( auto const& listener : m_listeners ) {
-        listener->noMatchingTestCases( spec );
+    ListeningReporter::ListeningReporter() {
+        // We will assume that listeners will always want all assertions
+        m_preferences.shouldReportAllAssertions = true;
     }
-    m_reporter->noMatchingTestCases( spec );
-}
 
-void ListeningReporter::reportInvalidArguments(std::string const&arg){
-    for ( auto const& listener : m_listeners ) {
-        listener->reportInvalidArguments( arg );
+    void ListeningReporter::addListener( IStreamingReporterPtr&& listener ) {
+        m_listeners.push_back( std::move( listener ) );
     }
-    m_reporter->reportInvalidArguments( arg );
-}
+
+    void ListeningReporter::addReporter(IStreamingReporterPtr&& reporter) {
+        assert(!m_reporter && "Listening reporter can wrap only 1 real reporter");
+        m_reporter = std::move( reporter );
+        m_preferences.shouldRedirectStdOut = m_reporter->getPreferences().shouldRedirectStdOut;
+    }
+
+    ReporterPreferences ListeningReporter::getPreferences() const {
+        return m_preferences;
+    }
+
+    std::set<Verbosity> ListeningReporter::getSupportedVerbosities() {
+        return std::set<Verbosity>{ };
+    }
+
+    void ListeningReporter::noMatchingTestCases( std::string const& spec ) {
+        for ( auto const& listener : m_listeners ) {
+            listener->noMatchingTestCases( spec );
+        }
+        m_reporter->noMatchingTestCases( spec );
+    }
+
+    void ListeningReporter::reportInvalidArguments(std::string const&arg){
+        for ( auto const& listener : m_listeners ) {
+            listener->reportInvalidArguments( arg );
+        }
+        m_reporter->reportInvalidArguments( arg );
+    }
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
-void ListeningReporter::benchmarkPreparing( std::string const& name ) {
+    void ListeningReporter::benchmarkPreparing( std::string const& name ) {
 		for (auto const& listener : m_listeners) {
 			listener->benchmarkPreparing(name);
 		}
@@ -16984,87 +17151,87 @@ void ListeningReporter::benchmarkPreparing( std::string const& name ) {
 	}
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-void ListeningReporter::testRunStarting( TestRunInfo const& testRunInfo ) {
-    for ( auto const& listener : m_listeners ) {
-        listener->testRunStarting( testRunInfo );
+    void ListeningReporter::testRunStarting( TestRunInfo const& testRunInfo ) {
+        for ( auto const& listener : m_listeners ) {
+            listener->testRunStarting( testRunInfo );
+        }
+        m_reporter->testRunStarting( testRunInfo );
     }
-    m_reporter->testRunStarting( testRunInfo );
-}
 
-void ListeningReporter::testGroupStarting( GroupInfo const& groupInfo ) {
-    for ( auto const& listener : m_listeners ) {
-        listener->testGroupStarting( groupInfo );
+    void ListeningReporter::testGroupStarting( GroupInfo const& groupInfo ) {
+        for ( auto const& listener : m_listeners ) {
+            listener->testGroupStarting( groupInfo );
+        }
+        m_reporter->testGroupStarting( groupInfo );
     }
-    m_reporter->testGroupStarting( groupInfo );
-}
 
-void ListeningReporter::testCaseStarting( TestCaseInfo const& testInfo ) {
-    for ( auto const& listener : m_listeners ) {
-        listener->testCaseStarting( testInfo );
+    void ListeningReporter::testCaseStarting( TestCaseInfo const& testInfo ) {
+        for ( auto const& listener : m_listeners ) {
+            listener->testCaseStarting( testInfo );
+        }
+        m_reporter->testCaseStarting( testInfo );
     }
-    m_reporter->testCaseStarting( testInfo );
-}
 
-void ListeningReporter::sectionStarting( SectionInfo const& sectionInfo ) {
-    for ( auto const& listener : m_listeners ) {
-        listener->sectionStarting( sectionInfo );
+    void ListeningReporter::sectionStarting( SectionInfo const& sectionInfo ) {
+        for ( auto const& listener : m_listeners ) {
+            listener->sectionStarting( sectionInfo );
+        }
+        m_reporter->sectionStarting( sectionInfo );
     }
-    m_reporter->sectionStarting( sectionInfo );
-}
 
-void ListeningReporter::assertionStarting( AssertionInfo const& assertionInfo ) {
-    for ( auto const& listener : m_listeners ) {
-        listener->assertionStarting( assertionInfo );
+    void ListeningReporter::assertionStarting( AssertionInfo const& assertionInfo ) {
+        for ( auto const& listener : m_listeners ) {
+            listener->assertionStarting( assertionInfo );
+        }
+        m_reporter->assertionStarting( assertionInfo );
     }
-    m_reporter->assertionStarting( assertionInfo );
-}
 
-// The return value indicates if the messages buffer should be cleared:
-bool ListeningReporter::assertionEnded( AssertionStats const& assertionStats ) {
-    for( auto const& listener : m_listeners ) {
-        static_cast<void>( listener->assertionEnded( assertionStats ) );
+    // The return value indicates if the messages buffer should be cleared:
+    bool ListeningReporter::assertionEnded( AssertionStats const& assertionStats ) {
+        for( auto const& listener : m_listeners ) {
+            static_cast<void>( listener->assertionEnded( assertionStats ) );
+        }
+        return m_reporter->assertionEnded( assertionStats );
     }
-    return m_reporter->assertionEnded( assertionStats );
-}
 
-void ListeningReporter::sectionEnded( SectionStats const& sectionStats ) {
-    for ( auto const& listener : m_listeners ) {
-        listener->sectionEnded( sectionStats );
+    void ListeningReporter::sectionEnded( SectionStats const& sectionStats ) {
+        for ( auto const& listener : m_listeners ) {
+            listener->sectionEnded( sectionStats );
+        }
+        m_reporter->sectionEnded( sectionStats );
     }
-    m_reporter->sectionEnded( sectionStats );
-}
 
-void ListeningReporter::testCaseEnded( TestCaseStats const& testCaseStats ) {
-    for ( auto const& listener : m_listeners ) {
-        listener->testCaseEnded( testCaseStats );
+    void ListeningReporter::testCaseEnded( TestCaseStats const& testCaseStats ) {
+        for ( auto const& listener : m_listeners ) {
+            listener->testCaseEnded( testCaseStats );
+        }
+        m_reporter->testCaseEnded( testCaseStats );
     }
-    m_reporter->testCaseEnded( testCaseStats );
-}
 
-void ListeningReporter::testGroupEnded( TestGroupStats const& testGroupStats ) {
-    for ( auto const& listener : m_listeners ) {
-        listener->testGroupEnded( testGroupStats );
+    void ListeningReporter::testGroupEnded( TestGroupStats const& testGroupStats ) {
+        for ( auto const& listener : m_listeners ) {
+            listener->testGroupEnded( testGroupStats );
+        }
+        m_reporter->testGroupEnded( testGroupStats );
     }
-    m_reporter->testGroupEnded( testGroupStats );
-}
 
-void ListeningReporter::testRunEnded( TestRunStats const& testRunStats ) {
-    for ( auto const& listener : m_listeners ) {
-        listener->testRunEnded( testRunStats );
+    void ListeningReporter::testRunEnded( TestRunStats const& testRunStats ) {
+        for ( auto const& listener : m_listeners ) {
+            listener->testRunEnded( testRunStats );
+        }
+        m_reporter->testRunEnded( testRunStats );
     }
-    m_reporter->testRunEnded( testRunStats );
-}
 
-void ListeningReporter::skipTest( TestCaseInfo const& testInfo ) {
-    for ( auto const& listener : m_listeners ) {
-        listener->skipTest( testInfo );
+    void ListeningReporter::skipTest( TestCaseInfo const& testInfo ) {
+        for ( auto const& listener : m_listeners ) {
+            listener->skipTest( testInfo );
+        }
+        m_reporter->skipTest( testInfo );
     }
-    m_reporter->skipTest( testInfo );
-}
 
-bool ListeningReporter::isMulti() const {
-    return true;
-}
+    bool ListeningReporter::isMulti() const {
+        return true;
+    }
 
 } // end namespace Catch
 // end catch_reporter_listening.cpp
@@ -17078,215 +17245,215 @@ bool ListeningReporter::isMulti() const {
 #endif
 
 namespace Catch {
-XmlReporter::XmlReporter( ReporterConfig const& _config )
+    XmlReporter::XmlReporter( ReporterConfig const& _config )
     :   StreamingReporterBase( _config ),
         m_xml(_config.stream())
-{
-    m_reporterPrefs.shouldRedirectStdOut = true;
-    m_reporterPrefs.shouldReportAllAssertions = true;
-}
+    {
+        m_reporterPrefs.shouldRedirectStdOut = true;
+        m_reporterPrefs.shouldReportAllAssertions = true;
+    }
 
-XmlReporter::~XmlReporter() = default;
+    XmlReporter::~XmlReporter() = default;
 
-std::string XmlReporter::getDescription() {
-    return "Reports test results as an XML document";
-}
+    std::string XmlReporter::getDescription() {
+        return "Reports test results as an XML document";
+    }
 
-std::string XmlReporter::getStylesheetRef() const {
-    return std::string();
-}
+    std::string XmlReporter::getStylesheetRef() const {
+        return std::string();
+    }
 
-void XmlReporter::writeSourceInfo( SourceLineInfo const& sourceInfo ) {
-    m_xml
-        .writeAttribute( "filename", sourceInfo.file )
-        .writeAttribute( "line", sourceInfo.line );
-}
+    void XmlReporter::writeSourceInfo( SourceLineInfo const& sourceInfo ) {
+        m_xml
+            .writeAttribute( "filename", sourceInfo.file )
+            .writeAttribute( "line", sourceInfo.line );
+    }
 
-void XmlReporter::noMatchingTestCases( std::string const& s ) {
-    StreamingReporterBase::noMatchingTestCases( s );
-}
+    void XmlReporter::noMatchingTestCases( std::string const& s ) {
+        StreamingReporterBase::noMatchingTestCases( s );
+    }
 
-void XmlReporter::testRunStarting( TestRunInfo const& testInfo ) {
-    StreamingReporterBase::testRunStarting( testInfo );
-    std::string stylesheetRef = getStylesheetRef();
-    if( !stylesheetRef.empty() )
-        m_xml.writeStylesheetRef( stylesheetRef );
-    m_xml.startElement( "Catch" );
-    if( !m_config->name().empty() )
-        m_xml.writeAttribute( "name", m_config->name() );
-    if (m_config->testSpec().hasFilters())
-        m_xml.writeAttribute( "filters", serializeFilters( m_config->getTestsOrTags() ) );
-    if( m_config->rngSeed() != 0 )
-        m_xml.scopedElement( "Randomness" )
-            .writeAttribute( "seed", m_config->rngSeed() );
-}
+    void XmlReporter::testRunStarting( TestRunInfo const& testInfo ) {
+        StreamingReporterBase::testRunStarting( testInfo );
+        std::string stylesheetRef = getStylesheetRef();
+        if( !stylesheetRef.empty() )
+            m_xml.writeStylesheetRef( stylesheetRef );
+        m_xml.startElement( "Catch" );
+        if( !m_config->name().empty() )
+            m_xml.writeAttribute( "name", m_config->name() );
+        if (m_config->testSpec().hasFilters())
+            m_xml.writeAttribute( "filters", serializeFilters( m_config->getTestsOrTags() ) );
+        if( m_config->rngSeed() != 0 )
+            m_xml.scopedElement( "Randomness" )
+                .writeAttribute( "seed", m_config->rngSeed() );
+    }
 
-void XmlReporter::testGroupStarting( GroupInfo const& groupInfo ) {
-    StreamingReporterBase::testGroupStarting( groupInfo );
-    m_xml.startElement( "Group" )
-        .writeAttribute( "name", groupInfo.name );
-}
+    void XmlReporter::testGroupStarting( GroupInfo const& groupInfo ) {
+        StreamingReporterBase::testGroupStarting( groupInfo );
+        m_xml.startElement( "Group" )
+            .writeAttribute( "name", groupInfo.name );
+    }
 
-void XmlReporter::testCaseStarting( TestCaseInfo const& testInfo ) {
-    StreamingReporterBase::testCaseStarting(testInfo);
-    m_xml.startElement( "TestCase" )
-        .writeAttribute( "name", trim( testInfo.name ) )
-        .writeAttribute( "description", testInfo.description )
-        .writeAttribute( "tags", testInfo.tagsAsString() );
+    void XmlReporter::testCaseStarting( TestCaseInfo const& testInfo ) {
+        StreamingReporterBase::testCaseStarting(testInfo);
+        m_xml.startElement( "TestCase" )
+            .writeAttribute( "name", trim( testInfo.name ) )
+            .writeAttribute( "description", testInfo.description )
+            .writeAttribute( "tags", testInfo.tagsAsString() );
 
-    writeSourceInfo( testInfo.lineInfo );
+        writeSourceInfo( testInfo.lineInfo );
 
-    if ( m_config->showDurations() == ShowDurations::Always )
-        m_testCaseTimer.start();
-    m_xml.ensureTagClosed();
-}
-
-void XmlReporter::sectionStarting( SectionInfo const& sectionInfo ) {
-    StreamingReporterBase::sectionStarting( sectionInfo );
-    if( m_sectionDepth++ > 0 ) {
-        m_xml.startElement( "Section" )
-            .writeAttribute( "name", trim( sectionInfo.name ) );
-        writeSourceInfo( sectionInfo.lineInfo );
+        if ( m_config->showDurations() == ShowDurations::Always )
+            m_testCaseTimer.start();
         m_xml.ensureTagClosed();
     }
-}
 
-void XmlReporter::assertionStarting( AssertionInfo const& ) { }
-
-bool XmlReporter::assertionEnded( AssertionStats const& assertionStats ) {
-
-    AssertionResult const& result = assertionStats.assertionResult;
-
-    bool includeResults = m_config->includeSuccessfulResults() || !result.isOk();
-
-    if( includeResults || result.getResultType() == ResultWas::Warning ) {
-        // Print any info messages in <Info> tags.
-        for( auto const& msg : assertionStats.infoMessages ) {
-            if( msg.type == ResultWas::Info && includeResults ) {
-                m_xml.scopedElement( "Info" )
-                    .writeText( msg.message );
-            } else if ( msg.type == ResultWas::Warning ) {
-                m_xml.scopedElement( "Warning" )
-                    .writeText( msg.message );
-            }
+    void XmlReporter::sectionStarting( SectionInfo const& sectionInfo ) {
+        StreamingReporterBase::sectionStarting( sectionInfo );
+        if( m_sectionDepth++ > 0 ) {
+            m_xml.startElement( "Section" )
+                .writeAttribute( "name", trim( sectionInfo.name ) );
+            writeSourceInfo( sectionInfo.lineInfo );
+            m_xml.ensureTagClosed();
         }
     }
 
-    // Drop out if result was successful but we're not printing them.
-    if( !includeResults && result.getResultType() != ResultWas::Warning )
+    void XmlReporter::assertionStarting( AssertionInfo const& ) { }
+
+    bool XmlReporter::assertionEnded( AssertionStats const& assertionStats ) {
+
+        AssertionResult const& result = assertionStats.assertionResult;
+
+        bool includeResults = m_config->includeSuccessfulResults() || !result.isOk();
+
+        if( includeResults || result.getResultType() == ResultWas::Warning ) {
+            // Print any info messages in <Info> tags.
+            for( auto const& msg : assertionStats.infoMessages ) {
+                if( msg.type == ResultWas::Info && includeResults ) {
+                    m_xml.scopedElement( "Info" )
+                            .writeText( msg.message );
+                } else if ( msg.type == ResultWas::Warning ) {
+                    m_xml.scopedElement( "Warning" )
+                            .writeText( msg.message );
+                }
+            }
+        }
+
+        // Drop out if result was successful but we're not printing them.
+        if( !includeResults && result.getResultType() != ResultWas::Warning )
+            return true;
+
+        // Print the expression if there is one.
+        if( result.hasExpression() ) {
+            m_xml.startElement( "Expression" )
+                .writeAttribute( "success", result.succeeded() )
+                .writeAttribute( "type", result.getTestMacroName() );
+
+            writeSourceInfo( result.getSourceInfo() );
+
+            m_xml.scopedElement( "Original" )
+                .writeText( result.getExpression() );
+            m_xml.scopedElement( "Expanded" )
+                .writeText( result.getExpandedExpression() );
+        }
+
+        // And... Print a result applicable to each result type.
+        switch( result.getResultType() ) {
+            case ResultWas::ThrewException:
+                m_xml.startElement( "Exception" );
+                writeSourceInfo( result.getSourceInfo() );
+                m_xml.writeText( result.getMessage() );
+                m_xml.endElement();
+                break;
+            case ResultWas::FatalErrorCondition:
+                m_xml.startElement( "FatalErrorCondition" );
+                writeSourceInfo( result.getSourceInfo() );
+                m_xml.writeText( result.getMessage() );
+                m_xml.endElement();
+                break;
+            case ResultWas::Info:
+                m_xml.scopedElement( "Info" )
+                    .writeText( result.getMessage() );
+                break;
+            case ResultWas::Warning:
+                // Warning will already have been written
+                break;
+            case ResultWas::ExplicitFailure:
+                m_xml.startElement( "Failure" );
+                writeSourceInfo( result.getSourceInfo() );
+                m_xml.writeText( result.getMessage() );
+                m_xml.endElement();
+                break;
+            default:
+                break;
+        }
+
+        if( result.hasExpression() )
+            m_xml.endElement();
+
         return true;
-
-    // Print the expression if there is one.
-    if( result.hasExpression() ) {
-        m_xml.startElement( "Expression" )
-            .writeAttribute( "success", result.succeeded() )
-            .writeAttribute( "type", result.getTestMacroName() );
-
-        writeSourceInfo( result.getSourceInfo() );
-
-        m_xml.scopedElement( "Original" )
-            .writeText( result.getExpression() );
-        m_xml.scopedElement( "Expanded" )
-            .writeText( result.getExpandedExpression() );
     }
 
-    // And... Print a result applicable to each result type.
-    switch( result.getResultType() ) {
-        case ResultWas::ThrewException:
-            m_xml.startElement( "Exception" );
-            writeSourceInfo( result.getSourceInfo() );
-            m_xml.writeText( result.getMessage() );
+    void XmlReporter::sectionEnded( SectionStats const& sectionStats ) {
+        StreamingReporterBase::sectionEnded( sectionStats );
+        if( --m_sectionDepth > 0 ) {
+            XmlWriter::ScopedElement e = m_xml.scopedElement( "OverallResults" );
+            e.writeAttribute( "successes", sectionStats.assertions.passed );
+            e.writeAttribute( "failures", sectionStats.assertions.failed );
+            e.writeAttribute( "expectedFailures", sectionStats.assertions.failedButOk );
+
+            if ( m_config->showDurations() == ShowDurations::Always )
+                e.writeAttribute( "durationInSeconds", sectionStats.durationInSeconds );
+
             m_xml.endElement();
-            break;
-        case ResultWas::FatalErrorCondition:
-            m_xml.startElement( "FatalErrorCondition" );
-            writeSourceInfo( result.getSourceInfo() );
-            m_xml.writeText( result.getMessage() );
-            m_xml.endElement();
-            break;
-        case ResultWas::Info:
-            m_xml.scopedElement( "Info" )
-                .writeText( result.getMessage() );
-            break;
-        case ResultWas::Warning:
-            // Warning will already have been written
-            break;
-        case ResultWas::ExplicitFailure:
-            m_xml.startElement( "Failure" );
-            writeSourceInfo( result.getSourceInfo() );
-            m_xml.writeText( result.getMessage() );
-            m_xml.endElement();
-            break;
-        default:
-            break;
+        }
     }
 
-    if( result.hasExpression() )
-        m_xml.endElement();
-
-    return true;
-}
-
-void XmlReporter::sectionEnded( SectionStats const& sectionStats ) {
-    StreamingReporterBase::sectionEnded( sectionStats );
-    if( --m_sectionDepth > 0 ) {
-        XmlWriter::ScopedElement e = m_xml.scopedElement( "OverallResults" );
-        e.writeAttribute( "successes", sectionStats.assertions.passed );
-        e.writeAttribute( "failures", sectionStats.assertions.failed );
-        e.writeAttribute( "expectedFailures", sectionStats.assertions.failedButOk );
+    void XmlReporter::testCaseEnded( TestCaseStats const& testCaseStats ) {
+        StreamingReporterBase::testCaseEnded( testCaseStats );
+        XmlWriter::ScopedElement e = m_xml.scopedElement( "OverallResult" );
+        e.writeAttribute( "success", testCaseStats.totals.assertions.allOk() );
 
         if ( m_config->showDurations() == ShowDurations::Always )
-            e.writeAttribute( "durationInSeconds", sectionStats.durationInSeconds );
+            e.writeAttribute( "durationInSeconds", m_testCaseTimer.getElapsedSeconds() );
+
+        if( !testCaseStats.stdOut.empty() )
+            m_xml.scopedElement( "StdOut" ).writeText( trim( testCaseStats.stdOut ), XmlFormatting::Newline );
+        if( !testCaseStats.stdErr.empty() )
+            m_xml.scopedElement( "StdErr" ).writeText( trim( testCaseStats.stdErr ), XmlFormatting::Newline );
 
         m_xml.endElement();
     }
-}
 
-void XmlReporter::testCaseEnded( TestCaseStats const& testCaseStats ) {
-    StreamingReporterBase::testCaseEnded( testCaseStats );
-    XmlWriter::ScopedElement e = m_xml.scopedElement( "OverallResult" );
-    e.writeAttribute( "success", testCaseStats.totals.assertions.allOk() );
+    void XmlReporter::testGroupEnded( TestGroupStats const& testGroupStats ) {
+        StreamingReporterBase::testGroupEnded( testGroupStats );
+        // TODO: Check testGroupStats.aborting and act accordingly.
+        m_xml.scopedElement( "OverallResults" )
+            .writeAttribute( "successes", testGroupStats.totals.assertions.passed )
+            .writeAttribute( "failures", testGroupStats.totals.assertions.failed )
+            .writeAttribute( "expectedFailures", testGroupStats.totals.assertions.failedButOk );
+        m_xml.scopedElement( "OverallResultsCases")
+            .writeAttribute( "successes", testGroupStats.totals.testCases.passed )
+            .writeAttribute( "failures", testGroupStats.totals.testCases.failed )
+            .writeAttribute( "expectedFailures", testGroupStats.totals.testCases.failedButOk );
+        m_xml.endElement();
+    }
 
-    if ( m_config->showDurations() == ShowDurations::Always )
-        e.writeAttribute( "durationInSeconds", m_testCaseTimer.getElapsedSeconds() );
-
-    if( !testCaseStats.stdOut.empty() )
-        m_xml.scopedElement( "StdOut" ).writeText( trim( testCaseStats.stdOut ), XmlFormatting::Newline );
-    if( !testCaseStats.stdErr.empty() )
-        m_xml.scopedElement( "StdErr" ).writeText( trim( testCaseStats.stdErr ), XmlFormatting::Newline );
-
-    m_xml.endElement();
-}
-
-void XmlReporter::testGroupEnded( TestGroupStats const& testGroupStats ) {
-    StreamingReporterBase::testGroupEnded( testGroupStats );
-    // TODO: Check testGroupStats.aborting and act accordingly.
-    m_xml.scopedElement( "OverallResults" )
-        .writeAttribute( "successes", testGroupStats.totals.assertions.passed )
-        .writeAttribute( "failures", testGroupStats.totals.assertions.failed )
-        .writeAttribute( "expectedFailures", testGroupStats.totals.assertions.failedButOk );
-    m_xml.scopedElement( "OverallResultsCases")
-        .writeAttribute( "successes", testGroupStats.totals.testCases.passed )
-        .writeAttribute( "failures", testGroupStats.totals.testCases.failed )
-        .writeAttribute( "expectedFailures", testGroupStats.totals.testCases.failedButOk );
-    m_xml.endElement();
-}
-
-void XmlReporter::testRunEnded( TestRunStats const& testRunStats ) {
-    StreamingReporterBase::testRunEnded( testRunStats );
-    m_xml.scopedElement( "OverallResults" )
-        .writeAttribute( "successes", testRunStats.totals.assertions.passed )
-        .writeAttribute( "failures", testRunStats.totals.assertions.failed )
-        .writeAttribute( "expectedFailures", testRunStats.totals.assertions.failedButOk );
-    m_xml.scopedElement( "OverallResultsCases")
-        .writeAttribute( "successes", testRunStats.totals.testCases.passed )
-        .writeAttribute( "failures", testRunStats.totals.testCases.failed )
-        .writeAttribute( "expectedFailures", testRunStats.totals.testCases.failedButOk );
-    m_xml.endElement();
-}
+    void XmlReporter::testRunEnded( TestRunStats const& testRunStats ) {
+        StreamingReporterBase::testRunEnded( testRunStats );
+        m_xml.scopedElement( "OverallResults" )
+            .writeAttribute( "successes", testRunStats.totals.assertions.passed )
+            .writeAttribute( "failures", testRunStats.totals.assertions.failed )
+            .writeAttribute( "expectedFailures", testRunStats.totals.assertions.failedButOk );
+        m_xml.scopedElement( "OverallResultsCases")
+            .writeAttribute( "successes", testRunStats.totals.testCases.passed )
+            .writeAttribute( "failures", testRunStats.totals.testCases.failed )
+            .writeAttribute( "expectedFailures", testRunStats.totals.testCases.failedButOk );
+        m_xml.endElement();
+    }
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
-void XmlReporter::benchmarkPreparing(std::string const& name) {
+    void XmlReporter::benchmarkPreparing(std::string const& name) {
         m_xml.startElement("BenchmarkResults")
             .writeAttribute("name", name);
     }
@@ -17330,7 +17497,7 @@ void XmlReporter::benchmarkPreparing(std::string const& name) {
     }
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
-CATCH_REGISTER_REPORTER( "xml", XmlReporter )
+    CATCH_REGISTER_REPORTER( "xml", XmlReporter )
 
 } // end namespace Catch
 
@@ -17340,7 +17507,7 @@ CATCH_REGISTER_REPORTER( "xml", XmlReporter )
 // end catch_reporter_xml.cpp
 
 namespace Catch {
-LeakDetector leakDetector;
+    LeakDetector leakDetector;
 }
 
 #ifdef __clang__
@@ -17488,9 +17655,9 @@ int main (int argc, char * const argv[]) {
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
 #define CATCH_BENCHMARK(...) \
-    INTERNAL_CATCH_BENCHMARK(INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____B_E_N_C_H____), INTERNAL_CATCH_GET_1_ARG(__VA_ARGS__,,), INTERNAL_CATCH_GET_2_ARG(__VA_ARGS__,,))
+    INTERNAL_CATCH_BENCHMARK(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_B_E_N_C_H_), INTERNAL_CATCH_GET_1_ARG(__VA_ARGS__,,), INTERNAL_CATCH_GET_2_ARG(__VA_ARGS__,,))
 #define CATCH_BENCHMARK_ADVANCED(name) \
-    INTERNAL_CATCH_BENCHMARK_ADVANCED(INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____B_E_N_C_H____), name)
+    INTERNAL_CATCH_BENCHMARK_ADVANCED(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_B_E_N_C_H_), name)
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
 // If CATCH_CONFIG_PREFIX_ALL is not defined then the CATCH_ prefix is not required
@@ -17592,9 +17759,9 @@ int main (int argc, char * const argv[]) {
 
 #if defined(CATCH_CONFIG_ENABLE_BENCHMARKING)
 #define BENCHMARK(...) \
-    INTERNAL_CATCH_BENCHMARK(INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____B_E_N_C_H____), INTERNAL_CATCH_GET_1_ARG(__VA_ARGS__,,), INTERNAL_CATCH_GET_2_ARG(__VA_ARGS__,,))
+    INTERNAL_CATCH_BENCHMARK(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_B_E_N_C_H_), INTERNAL_CATCH_GET_1_ARG(__VA_ARGS__,,), INTERNAL_CATCH_GET_2_ARG(__VA_ARGS__,,))
 #define BENCHMARK_ADVANCED(name) \
-    INTERNAL_CATCH_BENCHMARK_ADVANCED(INTERNAL_CATCH_UNIQUE_NAME(____C_A_T_C_H____B_E_N_C_H____), name)
+    INTERNAL_CATCH_BENCHMARK_ADVANCED(INTERNAL_CATCH_UNIQUE_NAME(C_A_T_C_H_B_E_N_C_H_), name)
 #endif // CATCH_CONFIG_ENABLE_BENCHMARKING
 
 using Catch::Detail::Approx;
@@ -17641,8 +17808,8 @@ using Catch::Detail::Approx;
 #define CATCH_WARN( msg )          (void)(0)
 #define CATCH_CAPTURE( msg )       (void)(0)
 
-#define CATCH_TEST_CASE( ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
-#define CATCH_TEST_CASE_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
+#define CATCH_TEST_CASE( ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ))
+#define CATCH_TEST_CASE_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ))
 #define CATCH_METHOD_AS_TEST_CASE( method, ... )
 #define CATCH_REGISTER_TEST_CASE( Function, ... ) (void)(0)
 #define CATCH_SECTION( ... )
@@ -17651,7 +17818,7 @@ using Catch::Detail::Approx;
 #define CATCH_FAIL_CHECK( ... ) (void)(0)
 #define CATCH_SUCCEED( ... ) (void)(0)
 
-#define CATCH_ANON_TEST_CASE() INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
+#define CATCH_ANON_TEST_CASE() INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ))
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define CATCH_TEMPLATE_TEST_CASE( ... ) INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION(__VA_ARGS__)
@@ -17674,8 +17841,8 @@ using Catch::Detail::Approx;
 #endif
 
 // "BDD-style" convenience wrappers
-#define CATCH_SCENARIO( ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
-#define CATCH_SCENARIO_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ), className )
+#define CATCH_SCENARIO( ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ))
+#define CATCH_SCENARIO_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ), className )
 #define CATCH_GIVEN( desc )
 #define CATCH_AND_GIVEN( desc )
 #define CATCH_WHEN( desc )
@@ -17725,8 +17892,8 @@ using Catch::Detail::Approx;
 #define WARN( msg ) (void)(0)
 #define CAPTURE( msg ) (void)(0)
 
-#define TEST_CASE( ... )  INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
-#define TEST_CASE_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
+#define TEST_CASE( ... )  INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ))
+#define TEST_CASE_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ))
 #define METHOD_AS_TEST_CASE( method, ... )
 #define REGISTER_TEST_CASE( Function, ... ) (void)(0)
 #define SECTION( ... )
@@ -17734,7 +17901,7 @@ using Catch::Detail::Approx;
 #define FAIL( ... ) (void)(0)
 #define FAIL_CHECK( ... ) (void)(0)
 #define SUCCEED( ... ) (void)(0)
-#define ANON_TEST_CASE() INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ))
+#define ANON_TEST_CASE() INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ))
 
 #ifndef CATCH_CONFIG_TRADITIONAL_MSVC_PREPROCESSOR
 #define TEMPLATE_TEST_CASE( ... ) INTERNAL_CATCH_TEMPLATE_TEST_CASE_NO_REGISTRATION(__VA_ARGS__)
@@ -17764,8 +17931,8 @@ using Catch::Detail::Approx;
 #define CATCH_TRANSLATE_EXCEPTION( signature ) INTERNAL_CATCH_TRANSLATE_EXCEPTION_NO_REG( INTERNAL_CATCH_UNIQUE_NAME( catch_internal_ExceptionTranslator ), signature )
 
 // "BDD-style" convenience wrappers
-#define SCENARIO( ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ) )
-#define SCENARIO_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ), className )
+#define SCENARIO( ... ) INTERNAL_CATCH_TESTCASE_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ) )
+#define SCENARIO_METHOD( className, ... ) INTERNAL_CATCH_TESTCASE_METHOD_NO_REGISTRATION(INTERNAL_CATCH_UNIQUE_NAME( C_A_T_C_H_T_E_S_T_ ), className )
 
 #define GIVEN( desc )
 #define AND_GIVEN( desc )

--- a/mod/printdb.cc
+++ b/mod/printdb.cc
@@ -1,0 +1,8 @@
+#include "leveldb/db.h"
+
+int main() {
+  leveldb::Options options;
+  leveldb::DB* db;
+  leveldb::Status status = leveldb::DB::Open(options, "/tmp/db1", &db);
+  db->PrintLevelInfo();
+}

--- a/mod/read_cold.cc
+++ b/mod/read_cold.cc
@@ -365,13 +365,17 @@ int main(int argc, char *argv[]) {
             // status = db->Write(write_options, &batch);
             // perform loadi
             for (int i = 0; i < keys.size(); ++i) {
-                    // cout << keys[i] << endl;
-                    status = db->Put(write_options, keys[i], {values.data() + uniform_dist_value(e2), (uint64_t) adgMod::value_size});
-                    assert(status.ok() && "File Put Error");
-                    if(!status.ok()){
-                        cout<<status.ToString()<<endl;
-                    }
-                    // break;
+                if(i%(keys.size()/10)==0)
+                {
+                    cout<<i/(keys.size()/10)<<"/10"<<endl;
+                }
+                // cout << keys[i] << endl;
+                status = db->Put(write_options, keys[i], {values.data() + uniform_dist_value(e2), (uint64_t) adgMod::value_size});
+                assert(status.ok() && "File Put Error");
+                if(!status.ok()){
+                    cout<<status.ToString()<<endl;
+                }
+                // break;
             }
             cout << "Put Complete ready to sync" << endl;
             adgMod::db->vlog->Sync();

--- a/mod/rmi/include/rmi/models.hpp
+++ b/mod/rmi/include/rmi/models.hpp
@@ -94,25 +94,33 @@ class LinearSpline
         return out << m.slope() << " * x + " << m.intercept();
     }
 
-    void write_file_m(std::string filename){
-        std::ofstream file(filename, std::ios::app); // Open the file in append mode
-        if (!file) {
-            std::cerr << "Unable to open file " << filename << " in Linear Spline";
-            return;
-        }
+    // void write_file_m(std::string filename){
+    //     std::ofstream file(filename, std::ios::app); // Open the file in append mode
+    //     if (!file) {
+    //         std::cerr << "Unable to open file " << filename << " in Linear Spline";
+    //         return;
+    //     }
+    //     file << std::setprecision(writeprecision) << slope_ << " " << intercept_ << std::endl; // Write the LinearSpline object to the file
+    //     file.close();
+    //     return;
+    // }
+
+    // void read_file_m(std::string filename){
+    //     std::ifstream file(filename); // Open the file in read mode
+    //     if (!file) {
+    //         std::cerr << "Unable to open file " << filename << " in Linear Spline";
+    //         return;
+    //     }
+    //     file >> slope_ >> intercept_; // Read the slope and intercept from the file
+    //     file.close();
+    // }
+    void write_file_m(std::ofstream&file){
         file << std::setprecision(writeprecision) << slope_ << " " << intercept_ << std::endl; // Write the LinearSpline object to the file
-        file.close();
         return;
     }
-
-    void read_file_m(std::string filename){
-        std::ifstream file(filename); // Open the file in read mode
-        if (!file) {
-            std::cerr << "Unable to open file " << filename << " in Linear Spline";
-            return;
-        }
+    void read_file_m(std::ifstream &file){
         file >> slope_ >> intercept_; // Read the slope and intercept from the file
-        file.close();
+        return;
     }
 };
 
@@ -224,25 +232,32 @@ class LinearRegression
         return out << m.slope() << " * x + " << m.intercept();
     }
 
-    void write_file_m(std::string filename){
-        std::ofstream file(filename, std::ios::app); // Open the file in append mode
-        if (!file) {
-            std::cerr << "Unable to open file " << filename << " in Linear Regression";
-            return;
-        }
+    // void write_file_m(std::string filename){
+    //     std::ofstream file(filename, std::ios::app); // Open the file in append mode
+    //     if (!file) {
+    //         std::cerr << "Unable to open file " << filename << " in Linear Regression";
+    //         return;
+    //     }
+    //     file << std::setprecision(writeprecision) << slope_ << " " << intercept_ << std::endl; // Write the LinearSpline object to the file
+    //     file.close();
+    //     return;
+    // }
+    void write_file_m(std::ofstream &file){
         file << std::setprecision(writeprecision) << slope_ << " " << intercept_ << std::endl; // Write the LinearSpline object to the file
-        file.close();
         return;
     }
 
-    void read_file_m(std::string filename){
-        std::ifstream file(filename); // Open the file in read mode
-        if (!file) {
-            std::cerr << "Unable to open file " << filename << " in Linear Regression";
-            return;
-        }
+    // void read_file_m(std::string filename){
+    //     std::ifstream file(filename); // Open the file in read mode
+    //     if (!file) {
+    //         std::cerr << "Unable to open file " << filename << " in Linear Regression";
+    //         return;
+    //     }
+    //     file >> slope_ >> intercept_; // Read the slope and intercept from the file
+    //     file.close();
+    // }
+    void read_file_m(std::ifstream &file){
         file >> slope_ >> intercept_; // Read the slope and intercept from the file
-        file.close();
     }
 };
 

--- a/mod/rmi/include/rmi/rmi.hpp
+++ b/mod/rmi/include/rmi/rmi.hpp
@@ -180,11 +180,12 @@ class Rmi
 
         //write models
         // std::cout<<"\tWriting l1 model to file:"<<std::endl;
-        l1_.write_file_m(filename);
+        l1_.write_file_m(file);
         // std::cout<<"\tWriting "<< layer2_size_ << " models in layer2 to file"<<std::endl;
         for(int i=0; i<layer2_size_; i++){
-            l2_[i].write_file_m(filename);
+            l2_[i].write_file_m(file);
         }
+        file.close();
         return;
     }
 
@@ -194,12 +195,13 @@ class Rmi
         file >> n_keys_ >> layer2_size_;
 
         //read models
-        l1_.read_file_m(filename);
+        l1_.read_file_m(file);
         // std::cout<<"there are "<< layer2_size_ << " models in layer2"<<std::endl;
         l2_ = new layer2_type[layer2_size_];
         for(int i=0; i<layer2_size_; i++){
-            l2_[i].read_file_m(filename);
+            l2_[i].read_file_m(file);
         }
+        file.close();
         return 0;
     }
 };

--- a/mod/stats.h
+++ b/mod/stats.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <cstring>
 #include "timer.h"
+#include <string>
 
 using std::string;
 using std::to_string;

--- a/mod/test_compaction.cc
+++ b/mod/test_compaction.cc
@@ -1,0 +1,149 @@
+#include <cassert>
+#include <chrono>
+#include <iostream>
+#include "leveldb/db.h"
+#include "leveldb/comparator.h"
+#include "util.h"
+#include "stats.h"
+#include "learned_index.h"
+#include <cstring>
+#include "cxxopts.hpp"
+#include <unistd.h>
+#include <fstream>
+#include "../db/version_set.h"
+#include <cmath>
+#include <random>
+#include <fstream>
+#include <numeric>
+#include <algorithm>
+#include <stdlib.h>
+
+#include "gflags/gflags.h"
+
+DEFINE_string(compaction_style, "leveling", "compaction style");
+DEFINE_int32(num_levels, 5, "number of logical levels");
+DEFINE_int64(buffer_size, 2 * 1024 * 1024, "buffer size"); // default 2MB
+DEFINE_int32(T, 10, "size ratios");
+DEFINE_int32(key_size, 24, "key size");
+DEFINE_int32(value_size, 1000, "value size");
+DEFINE_int32(num_ops, 10000000, "number of operations");
+
+std::string PadString(const std::string& s, size_t n) {
+  std::string ret = s;
+  int pad = n - s.size();
+  ret = std::string(pad, '0') + ret;
+  return ret;
+}
+
+leveldb::Options GetLevelingOptions() {
+  leveldb::Options options;
+  options.create_if_missing = true;
+  options.L0_compaction_trigger = 2;
+  options.write_buffer_size = FLAGS_buffer_size;
+  options.max_bytes_for_level_base = FLAGS_buffer_size * FLAGS_T; // size for level 1, default 20MB
+  options.max_bytes_for_level_multiplier = FLAGS_T;
+  options.max_logical_level = FLAGS_num_levels;
+  options.max_file_size = 10 * (1<<20); // 10MB
+
+  
+  leveldb::config::kL0_CompactionTrigger = 2;
+  leveldb::config::kL0_SlowdownWritesTrigger = 2;
+  leveldb::config::kL0_StopWritesTrigger = 4;
+
+  return options;
+}
+
+leveldb::Options GetTieringOptions() {
+  leveldb::Options options;
+  options.create_if_missing = true;
+  options.L0_compaction_trigger = FLAGS_T;
+  options.write_buffer_size = FLAGS_buffer_size;
+  options.max_bytes_for_level_base = FLAGS_buffer_size * FLAGS_T * FLAGS_T; // size for level 1, default 200MB
+  options.max_bytes_for_level_multiplier = FLAGS_T;
+  options.max_logical_level = FLAGS_num_levels;
+  options.max_file_size = 10 * (1<<20); // 10MB
+  options.compaction_policy = leveldb::kCompactionStyleTier;
+
+  leveldb::config::kL0_CompactionTrigger = FLAGS_T;
+  leveldb::config::kL0_SlowdownWritesTrigger = FLAGS_T + 2;
+  leveldb::config::kL0_StopWritesTrigger = FLAGS_T + 4;
+  
+  return options;
+}
+
+leveldb::Options GetLazyLevelOptions() {
+  leveldb::Options options;
+  options.create_if_missing = true;
+  options.L0_compaction_trigger = FLAGS_T;
+  options.write_buffer_size = FLAGS_buffer_size;
+  options.max_bytes_for_level_base = FLAGS_buffer_size * FLAGS_T * FLAGS_T; // size for level 1, default 200MB
+  options.max_bytes_for_level_multiplier = FLAGS_T;
+  options.max_logical_level = FLAGS_num_levels;
+  options.max_file_size = 10 * (1<<20); // 10MB
+  options.compaction_policy = leveldb::kCompactionStyleLazyLevel;
+
+  leveldb::config::kL0_CompactionTrigger = FLAGS_T;
+  leveldb::config::kL0_SlowdownWritesTrigger = FLAGS_T + 2;
+  leveldb::config::kL0_StopWritesTrigger = FLAGS_T + 4;
+  
+  return options;
+}
+
+void PrepareDB(leveldb::DB* db, int total_ops) {
+  while (-- total_ops) {
+    int rng = std::rand() % INT32_MAX;
+    std::string key = PadString(std::to_string(rng), FLAGS_key_size);
+    std::string value = PadString(std::to_string(rng), FLAGS_value_size);
+    auto s = db->Put(leveldb::WriteOptions(), key, value);
+    if (!s.ok()) {
+      std::cout << "Failed to put key: " << key << ": " << s.ToString() << std::endl;
+      return;
+    }
+    if (total_ops % 100000 == 0) {
+      db->PrintLevelInfo();
+      std::cout << "Left: " << total_ops << std::endl;
+      std::cout << "---------" << std::endl;
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  adgMod::MOD = 0;
+  leveldb::Options options;
+  if (FLAGS_compaction_style == "leveling") {
+    std::cout << "leveling compaction" << std::endl;
+    options = GetLevelingOptions();
+  } else if (FLAGS_compaction_style == "tiering") {
+    std::cout << "tiering compaction" << std::endl;
+    options = GetTieringOptions();
+  } else if (FLAGS_compaction_style == "lazylevel") {
+    std::cout << "lazylevel compaction" << std::endl;
+    options = GetLazyLevelOptions();
+  } else {
+    std::cout << "Invalid compaction style: " << FLAGS_compaction_style << std::endl;
+    return 0;
+  }
+  leveldb::DB* db;
+  leveldb::Status status = leveldb::DB::Open(options, "/tmp/db", &db);
+  if (!status.ok()) {
+    std::cout << "Failed to open db: " << status.ToString() << std::endl;
+    return 0;
+  }
+  // db->PrintLevelInfo();
+  PrepareDB(db, FLAGS_num_ops);
+  db->PrintLevelInfo();
+
+  std::cout << "--------------------" << std::endl;
+
+  std::string stat;
+  db->GetProperty("leveldb.stats", &stat);
+  std::cout << stat << std::endl;
+
+  adgMod::levelled_counters[10].Report();
+
+  std::cout << "==================================" << std::endl;
+
+  delete db;
+  return 0;
+}

--- a/mod/util.cpp
+++ b/mod/util.cpp
@@ -101,6 +101,24 @@ namespace adgMod {
     int iocounter = 0;
     int rangelength = 0;
 
+    // Jiarui
+    int LevelRead_counter=0;
+    double LevelRead_duration=0;
+    int prediction_counter=0;
+    double prediction_duration=0;
+    int bisearch_counter=0;
+    double bisearch_duration=0;
+    size_t prediction_range=0;
+    int RSbits=18;
+    int rmi_layer_size=1024;
+    int lipp_gap=5;
+    int alex_node_size = 1 << 11;
+    int bisearch_depth=0;
+    int compaction_count=0;
+    int memcompaction_count=0;
+    int filelearn_count=0;
+    int newSST_count=0;
+
     uint64_t ExtractInteger(const char* pos, size_t size) {
         char* temp = new char[size + 1];
         memcpy(temp, pos, size);

--- a/mod/util.h
+++ b/mod/util.h
@@ -132,6 +132,23 @@ namespace adgMod {
     extern int iocounter;
     extern int rangelength;
 
+    // Jiarui
+    extern int LevelRead_counter;
+    extern double LevelRead_duration;
+    extern int prediction_counter;
+    extern double prediction_duration;
+    extern int bisearch_counter;
+    extern double bisearch_duration;
+    extern size_t prediction_range;
+    extern int RSbits;
+    extern int rmi_layer_size;
+    extern int lipp_gap;
+    extern int alex_node_size;
+    extern int bisearch_depth;
+    extern int compaction_count;
+    extern int memcompaction_count;
+    extern int newSST_count;
+    extern int filelearn_count;
 
     // some util functions
     uint64_t ExtractInteger(const char* pos, size_t size);

--- a/port/port.h
+++ b/port/port.h
@@ -7,6 +7,11 @@
 
 #include <string.h>
 
+// make ide happy
+// #ifndef LEVELDB_PLATFORM_POSIX
+// #define LEVELDB_PLATFORM_POSIX
+// #endif
+
 // Include the appropriate platform specific file below.  If you are
 // porting to a new platform, see "port_example.h" for documentation
 // of what the new port_<platform>.h file must provide.

--- a/runit.sh
+++ b/runit.sh
@@ -1,0 +1,125 @@
+# Usage:
+#   leveldb read test [OPTION...]
+
+#   -n, --get_number arg         the number of gets (to be multiplied by 1024)
+#                                (default: 1000)
+#   -s, --step arg               the step of the loop of the size of db
+#                                (default: 1)
+#   -i, --iteration arg          the number of iterations of a same size
+#                                (default: 1)
+#   -m, --modification arg       if set, run our modified version, 7 fjle-model
+#                                bourbon, 8 wiskey, 9 ours (default: 0)
+#   -h, --help                   print help message
+#   -d, --directory arg          the directory of db (default: /mnt/ssd/testdb)
+#   -k, --key_size arg           the size of key (default: 16)
+#   -v, --value_size arg         the size of value (default: 8)
+#       --single_timing          print the time of every single get
+#       --file_info              print the file structure info
+#       --test_num_segments arg  test: number of segments per level (default:
+#                                1)
+#       --string_mode            test: use string or int in model
+#       --file_model_error arg   error in file model (default: 8)
+#       --level_model_error arg  error in level model (default: 1)
+#   -f, --input_file arg         the filename of input file (default: "")
+#       --blocksize arg          block size in SSTables (default: 4096)
+#   -r, --read_file arg          the filename of read file (default: "")
+#       --multiple arg           test: use larger keys (default: 1)
+#   -w, --write                  writedb
+#   -c, --uncache                evict cache
+#   -u, --unlimit_fd             unlimit fd
+#   -b, --bpk arg                bits per key (default: 10)
+#   -e, --modelerror arg         bits per key (default: 8)
+#   -x, --dummy                  dummy option
+#   -l, --load_type arg          load type (default: 0)
+#       --filter                 use filter
+#       --mix arg                portion of writes in workload in 1000
+#                                operations (default: 0)
+#       --distribution arg       operation distribution (default: "")
+#       --change_level_load      load level model
+#       --change_file_load       enable level learning
+#   -p, --pause                  pause between operation
+#       --policy arg             learn policy (default: 0)
+#       --YCSB arg               use YCSB trace (default: "")
+#       --insert arg             insert new value (default: 0)
+#       --modelmode arg          mm=0 plr, mm=1 lipp (default: 0)
+#       --alexinterval arg       alex* (default: 1)
+#       --dataset arg            name of dataset (default: 0)
+#       --workload arg           name of workload (default: 0)
+#       --exp arg                name of workload (default: 0)
+#       --range arg              use range query and specify length (default:
+#                                0)
+
+app=./build/read
+data=random_readonly_uniform
+# data=longitude_readonly_uniform
+data=random_ycsba
+modelmode=1
+MOD=7
+file_model_error=4
+bpk=10
+
+cd build
+make -j4
+cd ..
+
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 1000000 -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 0 --dataset 0 --workload 0 --exp 0 -w 
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 1000000 -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 2 --dataset 0 --workload 0 --exp 0 -w 
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 1000000 -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 3 --dataset 0 --workload 0 --exp 0 -w 
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 1000000 -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 5 --dataset 0 --workload 0 --exp 0 -w 
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 1000000 -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 6 --dataset 0 --workload 0 --exp 0 -w 
+
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 3 -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 3 --dataset 0 --workload 0 --exp 0 -w 
+
+# RMI
+# for j in `seq 1 5`; do
+# for i in 50 100 500 1000 5000 10000 50000 100000; do
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 3 --rmisize $i -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 4 --dataset 0 --workload 0 --exp 0 -w 
+# done
+# done
+
+
+# PGM
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 3 -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 3 --dataset 0 --workload 0 --exp 0 -w 
+
+# RS
+# for error in 5000; do
+# for i in 4; do
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e $error --RSbits $i -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 5 --dataset 0 --workload 0 --exp 0 -w 
+# done
+# done
+
+# LIPP
+# for i in 20; do
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 1 --lippgap $i -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 1 --dataset 0 --workload 0 --exp 0 -w 
+# done
+
+# Fitting-tree
+# for i in 1 2 4 8; do
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e $i -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 2 --dataset 0 --workload 0 --exp 0 -w 
+# done
+
+# DILI
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 1 -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 7 --dataset 0 --workload 0 --exp 0 -w 
+
+# ALEX
+# for i in 1000000 10000000 100000000 ; do
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 1 --alexnodesize $i -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 8 --dataset 0 --workload 0 --exp 0 -w 
+# done
+
+# for i in 0 5 6; do
+#     for j in 1 10 100 1000 10000; do
+#         ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e $j -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode $i --dataset 0 --workload 0 --exp 0 -w 
+#     done
+# done
+
+# PLR
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 1 -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 0 --dataset 0 --workload 0 --exp 0 -w |& tee ./log/64Mlongitude.log
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 10 -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 0 --dataset 0 --workload 0 --exp 0 -w |& tee ./log/64Mlongitude.log
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 100 -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 0 --dataset 0 --workload 0 --exp 0 -w |& tee ./log/64Mlongitude.log
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 1000 -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 0 --dataset 0 --workload 0 --exp 0 -w |& tee ./log/64Mlongitude.log
+valgrind --log-file="valgrind_log.txt" --leak-check=yes ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 10 -k 16 -v 64 -d ~/db/ --blocksize 2097152 -m $MOD --modelmode 0 --dataset 0 --workload 0 --exp 0 -w | tee ./log/64Mlongitude.log
+
+
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 1 -k 16 -v 64 -d ~/db/ --blocksize 2097152 --buffersize 4194304 -m $MOD --modelmode 0 --dataset 0 --workload 0 --exp 0 -w |& tee ./log/64Mlongitude.log
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 10 -k 16 -v 64 -d ~/db/ --blocksize 2097152 --buffersize 269177824 -m $MOD --modelmode 0 --dataset 0 --workload 0 --exp 0 -w |& tee ./log/64Mlongitude.log
+# ./build/read -f ~/DataGenerator/output_dat/${data}_datset.dat -r ~/DataGenerator/output_dat/${data}_query.dat -b $bpk -e 100 -k 16 -v 64 -d ~/db/ --blocksize 2097152 --buffersize 280159624 -m $MOD --modelmode 0 --dataset 0 --workload 0 --exp 0 -w |& tee ./log/64Mlongitude.log

--- a/test_compaction.sh
+++ b/test_compaction.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+rm -rf /tmp/db
+# build/test_compaction --compaction_style=leveling --num_levels=5 --num_ops=5000000
+# rm -rf /tmp/db
+# build/test_compaction --compaction_style=tiering --num_levels=4 --num_ops=5000000
+build/test_compaction --compaction_style=lazylevel --num_levels=4 --num_ops=5000000

--- a/util/env_posix.cc
+++ b/util/env_posix.cc
@@ -818,11 +818,11 @@ class PosixEnv : public Env {
 
         // if the file has been created for longer than wait_time (learn_trigger_time),
         // we can do CBA analysis. else, wait until the file has lived wait_time
-        time_diff = front.first + adgMod::learn_trigger_time - time_start;
-        if (time_diff > 0) {
-          wait_for_time = true;
-          break;
-        }
+        // time_diff = front.first + adgMod::learn_trigger_time - time_start;
+        // if (time_diff > 0) {
+        //   wait_for_time = true;
+        //   break;
+        // }
 
         learning_prepare.pop();
         double score = adgMod::learn_cb_model->CalculateCB(level, front.second.second->file_size);
@@ -844,15 +844,6 @@ class PosixEnv : public Env {
         adgMod::filelearn_count++;
         learn_pq.pop();
       }
-
-      // if we decide to wait, sleep here
-      if (wait_for_time) {
-        // prepare_queue_mutex.Unlock();
-        SleepForMicroseconds((int) (time_diff / 1000));
-        // prepare_queue_mutex.Lock();
-        wait_for_time = false;
-      }
-    // }
   }
 
   static void PrepareLearnEntryPoint(PosixEnv* env) {
@@ -868,8 +859,7 @@ class PosixEnv : public Env {
         // background_thread.detach();
         
     // }
-    PrepareLearnEntryPoint(this);   
-    // if (learning_prepare.empty()) preparing_queue_cv.Signal();
+    PrepareLearnEntryPoint(this);
     learning_prepare.emplace(std::make_pair(time_start, std::make_pair(level, meta)));
     adgMod::newSST_count++;
   }


### PR DESCRIPTION
# Policies to implement
1. Tiering
2. LazyLeveling

Treat each level in LevelDB as a sorted run and merge them when T sorted runs are filled at each **logical** level (i.e., level in the paper).

## Minor changes
1. Enable configuring L0_stop_write and L0_slowdown_write in order to limit the number of sorted runs at L0
2. Build a tool for dumping the status of the db (printdb.cc)